### PR TITLE
FlexiRule RC Refactor — Implementation Plan (v2)

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/components/Sidebar.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/Sidebar.vue
@@ -123,16 +123,42 @@ function update_action_field(fieldname, value) {
 
 	// Handle action_type change - update node type
 	if (fieldname === "action_type" && selectedNode.value.data.action_type !== value) {
-		let type = value.toLowerCase();
-		if (value === "Query Records") type = "query";
-		if (value === "Aggregate Records") type = "aggregate";
-		if (value === "Create Docs") type = "createdoc";
-		selectedNode.value.type = type;
+		selectedNode.value.type = map_action_type(value);
 	}
 
 	selectedNode.value.data[fieldname] = value;
 	store.touch_node(selectedNode.value.id);
 	store.mark_dirty();
+}
+
+function map_action_type(actionType) {
+	if (!actionType) return selectedNode.value?.type || "process";
+	switch (actionType) {
+		case "Entry Action":
+			return "start";
+		case "Condition":
+			return "condition";
+		case "Loop":
+			return "loop";
+		case "Wait":
+			return "wait";
+		case "Sub-Rule":
+			return "sub-rule";
+		case "Raise Error":
+			return "raise-error";
+		case "Set Value":
+			return "set-value";
+		case "Notify":
+			return "notify";
+		case "Query Records":
+			return "query";
+		case "Aggregate Records":
+			return "aggregate";
+		case "Create Docs":
+			return "createdoc";
+		default:
+			return "process";
+	}
 }
 
 function update_edge(field, newTarget) {

--- a/flexirule/public/js/flexirule/rule_builder/components/Sidebar.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/Sidebar.vue
@@ -93,6 +93,7 @@ const isConfigurable = computed(() => {
 function update_start_field(fieldname, value) {
 	if (!selectedNode.value?.data) return;
 	selectedNode.value.data[fieldname] = value;
+	store.touch_node(selectedNode.value.id);
 	store.mark_dirty();
 }
 
@@ -130,6 +131,7 @@ function update_action_field(fieldname, value) {
 	}
 
 	selectedNode.value.data[fieldname] = value;
+	store.touch_node(selectedNode.value.id);
 	store.mark_dirty();
 }
 

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/ActionSelectorNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/ActionSelectorNode.vue
@@ -65,6 +65,8 @@ function onCreate() {
 		action_label: label,
 	};
 
+	store.selected_id = props.id;
+	store.touch_node(props.id);
 	store.mark_dirty();
 }
 

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/QueryRecordsConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/QueryRecordsConfig.vue
@@ -67,12 +67,13 @@
 					<h6>{{ __("Filters") }}</h6>
 					<div class="table-rows">
 						<div v-for="(row, idx) in filterRows" :key="idx" class="row-item">
-							<input
-								class="form-control input-xs"
-								v-model="row.field"
-								:placeholder="__('Field')"
-								:disabled="readOnly"
-								@change="syncConfig"
+							<FieldPickerControl
+								:df="{ label: '' }"
+								:fields="doctypeFields"
+								:documentType="referenceDoctype"
+								:modelValue="row.field"
+								:read_only="readOnly"
+								@update:modelValue="(val) => (row.field = val)"
 							/>
 							<select
 								class="form-control input-xs"
@@ -119,12 +120,13 @@
 					<h6>{{ __("Fields") }}</h6>
 					<div class="table-rows">
 						<div v-for="(row, idx) in fieldRows" :key="idx" class="row-item">
-							<input
-								class="form-control input-xs"
-								v-model="row.field"
-								:placeholder="__('Field name')"
-								:disabled="readOnly"
-								@change="syncConfig"
+							<FieldPickerControl
+								:df="{ label: '' }"
+								:fields="doctypeFields"
+								:documentType="referenceDoctype"
+								:modelValue="row.field"
+								:read_only="readOnly"
+								@update:modelValue="(val) => (row.field = val)"
 							/>
 							<button
 								v-if="!readOnly"
@@ -151,9 +153,12 @@
 						:modelValue="config.order_by"
 						@update:modelValue="(val) => updateConfigKey('order_by', val)"
 					/>
-					<ControlFactory
-						:df="withReadOnly(groupByField)"
+					<FieldPickerControl
+						:df="groupByField"
+						:fields="doctypeFields"
+						:documentType="referenceDoctype"
 						:modelValue="config.group_by"
+						:read_only="readOnly"
 						@update:modelValue="(val) => updateConfigKey('group_by', val)"
 					/>
 				</div>
@@ -177,12 +182,13 @@
 					<h6>{{ __("Filters") }}</h6>
 					<div class="table-rows">
 						<div v-for="(row, idx) in filterRows" :key="idx" class="row-item">
-							<input
-								class="form-control input-xs"
-								v-model="row.field"
-								:placeholder="__('Field')"
-								:disabled="readOnly"
-								@change="syncConfig"
+							<FieldPickerControl
+								:df="{ label: '' }"
+								:fields="doctypeFields"
+								:documentType="referenceDoctype"
+								:modelValue="row.field"
+								:read_only="readOnly"
+								@update:modelValue="(val) => (row.field = val)"
 							/>
 							<select
 								class="form-control input-xs"
@@ -331,11 +337,13 @@ const testStatus = ref("");
 const filterRows = ref([]);
 const fieldRows = ref([]);
 const argRows = ref([]);
+const doctypeFields = ref([]);
 
 const reportFilters = ref([]);
 const reportFilterValues = reactive({});
 
 const mode = computed(() => props.node?.data?.operation || "");
+const referenceDoctype = computed(() => props.node?.data?.reference_doctype || "");
 
 const operators = ["=", "!=", ">", ">=", "<", "<=", "in", "not in"];
 const valueTypes = ["Value", "Number", "Boolean", "Expression"];
@@ -444,6 +452,18 @@ function updateActionField(fieldname, value) {
 	if (!props.node?.data) return;
 	props.node.data[fieldname] = value;
 	store.mark_dirty();
+}
+
+async function loadDoctypeFields(doctype) {
+	if (!doctype) {
+		doctypeFields.value = [];
+		return;
+	}
+	try {
+		doctypeFields.value = await flexirule.utils.get_doctype_fields(doctype);
+	} catch (e) {
+		doctypeFields.value = [];
+	}
 }
 
 async function onSelectReport(val) {
@@ -698,6 +718,12 @@ watch(
 );
 
 watch(
+	() => referenceDoctype.value,
+	(val) => loadDoctypeFields(val),
+	{ immediate: true }
+);
+
+watch(
 	() => [filterRows.value, fieldRows.value, argRows.value, reportFilterValues, config],
 	() => {
 		syncConfig();
@@ -795,6 +821,10 @@ defineExpose({ validate });
 	grid-template-columns: 1.3fr 0.7fr 1fr 0.8fr auto;
 	gap: 6px;
 	align-items: center;
+}
+
+.row-item .field-picker-control {
+	margin-bottom: 0;
 }
 
 .row-item.report {

--- a/flexirule/public/js/flexirule/rule_builder/composables/useRuleConfig.js
+++ b/flexirule/public/js/flexirule/rule_builder/composables/useRuleConfig.js
@@ -94,6 +94,7 @@ export function useRuleConfig(props, emit) {
 		if (props.node && draftNode.value) {
 			props.node.data = JSON.parse(JSON.stringify(draftNode.value.data));
 			props.node.label = draftNode.value.label || draftNode.value.data?.action_label;
+			store.touch_node(props.node.id);
 			store.mark_dirty();
 		}
 

--- a/flexirule/public/js/flexirule/rule_builder/store.js
+++ b/flexirule/public/js/flexirule/rule_builder/store.js
@@ -959,6 +959,17 @@ export const useStore = defineStore("rule-builder-store", () => {
 		mark_dirty();
 	}
 
+	function touch_node(nodeId) {
+		if (!nodeId) return;
+		const idx = nodes.value.findIndex((n) => n.id === nodeId);
+		if (idx === -1) return;
+		const node = nodes.value[idx];
+		nodes.value.splice(idx, 1, {
+			...node,
+			data: { ...(node.data || {}) },
+		});
+	}
+
 	function getTopologicalSort(nodes, edges) {
 		const adj = {};
 		const processed = new Set();
@@ -1080,6 +1091,7 @@ export const useStore = defineStore("rule-builder-store", () => {
 		clear_dirty,
 		delete_node,
 		delete_edge,
+		touch_node,
 		getEffectivelyDisabledIds,
 		fetch_available_rules,
 		fetch_processes,

--- a/flexirule/ruleflow/api.py
+++ b/flexirule/ruleflow/api.py
@@ -13,6 +13,19 @@ from frappe import _
 
 from flexirule.ruleflow.core.compiler import ConditionCompiler
 
+
+def _require_api_access():
+	"""Check if user has permission to use sensitive API endpoints"""
+	if frappe.session.user == "Administrator":
+		return
+
+	roles = frappe.get_roles(frappe.session.user)
+	if "System Manager" not in roles and "Rule Builder" not in roles:
+		frappe.throw(
+			_("Not permitted. Requires 'System Manager' or 'Rule Builder' role."), frappe.PermissionError
+		)
+
+
 # Layout fieldtypes to exclude by default
 LAYOUT_FIELDTYPES = [
 	"Tab Break",
@@ -186,6 +199,7 @@ def test_rule(
 	Test a rule against a document.
 	Supports either an existing document (by docname) or a transient document (by document_json).
 	"""
+	_require_api_access()
 
 	rule = frappe.get_doc("Rule", rule_name)
 
@@ -271,6 +285,8 @@ def execute_rule(rule_name, context=None, dry_run=True):
 	"""
 	Pure execution API for a rule.
 	"""
+	_require_api_access()
+
 	from flexirule.ruleflow.core.coordinator import RuleCoordinator
 
 	if isinstance(context, str):
@@ -299,6 +315,7 @@ def execute_rule(rule_name, context=None, dry_run=True):
 @frappe.whitelist()
 def clear_cache(doctype=None):
 	"""Clear rule cache"""
+	_require_api_access()
 	try:
 		from flexirule.ruleflow.core.coordinator import RuleCoordinator
 
@@ -351,6 +368,7 @@ def get_schema_field_options(schema_field, parent_doctype, current_values=None):
 @frappe.whitelist()
 def get_rule_versions(rule_name, limit=20):
 	"""Get version history for a rule"""
+	_require_api_access()
 	from flexirule.ruleflow.doctype.rule.rule_version_hooks import (
 		get_rule_versions as _get_versions,
 	)
@@ -361,6 +379,7 @@ def get_rule_versions(rule_name, limit=20):
 @frappe.whitelist()
 def restore_rule_version(rule_name, version_name):
 	"""Restore a rule to a previous version"""
+	_require_api_access()
 	from flexirule.ruleflow.doctype.rule.rule_version_hooks import (
 		restore_rule_version as _restore,
 	)
@@ -371,6 +390,7 @@ def restore_rule_version(rule_name, version_name):
 @frappe.whitelist()
 def export_rule(rule_name):
 	"""Export a rule to JSON"""
+	_require_api_access()
 	from flexirule.ruleflow.utils.import_export import export_rule as _export
 
 	return _export(rule_name)
@@ -379,6 +399,7 @@ def export_rule(rule_name):
 @frappe.whitelist()
 def import_rule(import_data, overwrite=False):
 	"""Import a rule from JSON"""
+	_require_api_access()
 	from flexirule.ruleflow.utils.import_export import import_rule as _import
 
 	overwrite = frappe.parse_json(overwrite) if isinstance(overwrite, str) else overwrite
@@ -475,6 +496,7 @@ def clone_rule(rule_name, new_name=None):
 	Clone a rule to create a new version or copy.
 	Resets status to Draft (inactive) and clears execution stats.
 	"""
+	_require_api_access()
 	try:
 		doc = frappe.get_doc("Rule", rule_name)
 
@@ -515,6 +537,7 @@ def amend_rule(rule_name: str) -> str:
 	Returns:
 	    Name of the new amended rule.
 	"""
+	_require_api_access()
 	from flexirule.ruleflow.core.rule_service import amend_rule as _amend_rule
 
 	return _amend_rule(rule_name)
@@ -528,6 +551,7 @@ def test_action_query(
 	Execute a single action in isolation for testing.
 	Returns detected return fields for auto-populating returns_keys.
 	"""
+	_require_api_access()
 	rule = frappe.get_doc("Rule", rule_name)
 
 	# Find the action

--- a/flexirule/ruleflow/api.py
+++ b/flexirule/ruleflow/api.py
@@ -73,7 +73,7 @@ SYSTEM_FIELDS = [
 
 
 @frappe.whitelist()
-def get_doctype_fields(doctype, filters=None):
+def get_doctype_fields(doctype: str, filters: str | dict | None = None):
 	"""
 	Get fields for DocField autocomplete - grouped by parent/child tables
 
@@ -281,7 +281,7 @@ def test_rule(
 
 
 @frappe.whitelist()
-def execute_rule(rule_name, context=None, dry_run=True):
+def execute_rule(rule_name: str, context: str | dict | None = None, dry_run: bool | str = True):
 	"""
 	Pure execution API for a rule.
 	"""
@@ -313,7 +313,7 @@ def execute_rule(rule_name, context=None, dry_run=True):
 
 
 @frappe.whitelist()
-def clear_cache(doctype=None):
+def clear_cache(doctype: str | None = None):
 	"""Clear rule cache"""
 	_require_api_access()
 	try:
@@ -338,7 +338,9 @@ def get_operator_config():
 
 
 @frappe.whitelist()
-def get_schema_field_options(schema_field, parent_doctype, current_values=None):
+def get_schema_field_options(
+	schema_field: str | dict, parent_doctype: str, current_values: str | dict | None = None
+):
 	"""
 	Get options for a schema field dynamically
 	Used for dependent DocField sources
@@ -366,7 +368,7 @@ def get_schema_field_options(schema_field, parent_doctype, current_values=None):
 
 
 @frappe.whitelist()
-def get_rule_versions(rule_name, limit=20):
+def get_rule_versions(rule_name: str, limit: int | str = 20):
 	"""Get version history for a rule"""
 	_require_api_access()
 	from flexirule.ruleflow.doctype.rule.rule_version_hooks import (
@@ -377,7 +379,7 @@ def get_rule_versions(rule_name, limit=20):
 
 
 @frappe.whitelist()
-def restore_rule_version(rule_name, version_name):
+def restore_rule_version(rule_name: str, version_name: str):
 	"""Restore a rule to a previous version"""
 	_require_api_access()
 	from flexirule.ruleflow.doctype.rule.rule_version_hooks import (
@@ -388,7 +390,7 @@ def restore_rule_version(rule_name, version_name):
 
 
 @frappe.whitelist()
-def export_rule(rule_name):
+def export_rule(rule_name: str):
 	"""Export a rule to JSON"""
 	_require_api_access()
 	from flexirule.ruleflow.utils.import_export import export_rule as _export
@@ -397,7 +399,7 @@ def export_rule(rule_name):
 
 
 @frappe.whitelist()
-def import_rule(import_data, overwrite=False):
+def import_rule(import_data: str | dict, overwrite: bool | str = False):
 	"""Import a rule from JSON"""
 	_require_api_access()
 	from flexirule.ruleflow.utils.import_export import import_rule as _import
@@ -407,7 +409,7 @@ def import_rule(import_data, overwrite=False):
 
 
 @frappe.whitelist()
-def get_action_context_schema(rule_name, action_id):
+def get_action_context_schema(rule_name: str, action_id: str):
 	"""
 	Get available context variables for a specific action in rule flow.
 	Used by UI to enable context-aware field selection.
@@ -473,7 +475,7 @@ def get_action_context_schema(rule_name, action_id):
 
 
 @frappe.whitelist()
-def get_process_operations(process_name):
+def get_process_operations(process_name: str):
 	"""
 	Get enabled operations for a specific process.
 	"""
@@ -491,7 +493,7 @@ def get_process_operations(process_name):
 
 
 @frappe.whitelist()
-def clone_rule(rule_name, new_name=None):
+def clone_rule(rule_name: str, new_name: str | None = None):
 	"""
 	Clone a rule to create a new version or copy.
 	Resets status to Draft (inactive) and clears execution stats.

--- a/flexirule/ruleflow/core/compiler.py
+++ b/flexirule/ruleflow/core/compiler.py
@@ -298,6 +298,16 @@ class ConditionCompiler:
 			import ast
 
 			ast.parse(expression, mode="eval")
+
+			from flexirule.ruleflow.core.permissions import validate_safe_eval
+
+			frappe.flags.in_validate_safe_eval = True
+			try:
+				if not validate_safe_eval(expression):
+					return False, "Expression contains forbidden pattern"
+			finally:
+				frappe.flags.in_validate_safe_eval = False
+
 		except SyntaxError as e:
 			return False, f"Invalid Python syntax: {e}"
 

--- a/flexirule/ruleflow/core/coordinator.py
+++ b/flexirule/ruleflow/core/coordinator.py
@@ -59,7 +59,7 @@ class RuleCoordinator:
 			engine = RuleEngine(rule, execution_context=context)
 			# Ensure engine knows about dry_run (it can use it for logging/behavior)
 			engine.context["dry_run"] = dry_run
-			return engine.execute(doc)
+			return engine.execute(doc, event_name=rule.trigger_event)
 
 		if dry_run:
 			savepoint_name = "flexirule_dry_run"
@@ -97,15 +97,15 @@ class RuleCoordinator:
 					frappe.log_error("FlexiRule: Cache write failed.")
 					return rule_map or {}
 
-			return rule_map
+			return rule_map or {}
 
 		# Use the SAME local cache key as hooks.py for unified access
 		# Note: hooks.py calls it via frappe.local_cache("flexirule_map", "unified", generator)
 		# So we should match that or adapt RuleCoordinator to retrieve the "unified" key if it exists.
 		if hasattr(frappe.local, "flexirule_map") and "unified" in frappe.local.flexirule_map:
-			return frappe.local.flexirule_map["unified"]
+			return frappe.local.flexirule_map["unified"] or {}
 
-		return frappe.local_cache("flexirule_map", "unified", generator)
+		return frappe.local_cache("flexirule_map", "unified", generator) or {}
 
 	@staticmethod
 	def _build_rule_map() -> dict:
@@ -177,7 +177,7 @@ class RuleCoordinator:
 		# Execute eligible rules
 		for rule_doc in valid_rules:
 			try:
-				RuleCoordinator.execute_single_rule(doc, rule_doc, old_doc=old_doc)
+				RuleCoordinator.execute_single_rule(doc, rule_doc, old_doc=old_doc, event_name=event_name)
 			except Exception as e:
 				# Log error to Rule Execution Log (async to avoid transaction conflicts)
 				error_msg = str(e)
@@ -322,7 +322,7 @@ class RuleCoordinator:
 		return rules
 
 	@staticmethod
-	def execute_single_rule(doc, rule_doc, old_doc=None):
+	def execute_single_rule(doc, rule_doc, old_doc=None, event_name=None):
 		"""
 		Execute a single rule against a document
 
@@ -330,6 +330,7 @@ class RuleCoordinator:
 		        doc: Frappe document
 		        rule_doc: Rule document
 		        old_doc: Document state before save (optional)
+		        event_name: Trigger event name (optional)
 		"""
 		# Check if rule should run asynchronously
 		if rule_doc.execution_mode == "Asynchronous":
@@ -347,10 +348,6 @@ class RuleCoordinator:
 
 		from flexirule.ruleflow.core.engine import RuleEngine
 
-		# Increment execution count (Cached in Redis, not DB write)
-		frappe.cache().hincrby(f"rule_stats:{rule_doc.name}", "count", 1)
-		frappe.cache().hset(f"rule_stats:{rule_doc.name}", "last_executed", frappe.utils.now())
-
 		# Execute using new Engine
 		# Pass old_doc in context
 		execution_context = {"old_doc": old_doc}
@@ -358,7 +355,7 @@ class RuleCoordinator:
 			execution_context["test_mode"] = True
 
 		engine = RuleEngine(rule_doc, execution_context=execution_context)
-		engine.execute(doc)
+		engine.execute(doc, event_name=event_name)
 
 	@staticmethod
 	def run_rule_background(rule_name, doc_doctype, doc_name):

--- a/flexirule/ruleflow/core/engine.py
+++ b/flexirule/ruleflow/core/engine.py
@@ -245,12 +245,13 @@ class RuleEngine:
 		except (json.JSONDecodeError, TypeError):
 			return {}
 
-	def execute(self, doc, **kwargs):
+	def execute(self, doc, event_name=None, **kwargs):
 		"""
 		Execute rule with comprehensive error handling
 
 		Args:
 		        doc: Frappe document to process
+		        event_name: Trigger event name (e.g. 'Before Save')
 		        **kwargs: Additional context variables
 
 		Returns:
@@ -261,6 +262,7 @@ class RuleEngine:
 		status = "Success"
 		error_detail = None
 		self.path_trace = []
+		self.context["event_name"] = event_name or self.rule.trigger_event
 
 		try:
 			# Pre-execution validation
@@ -336,13 +338,16 @@ class RuleEngine:
 
 		finally:
 			# Persist Log
-			duration = time.time() - start_time
+			duration = (time.time() - start_time) * 1000  # Convert to ms
 			self._save_execution_log(
 				status,
 				duration,
 				error_detail,
 				context=context if "context" in locals() else None,
 			)
+
+			if not self.context.get("dry_run"):
+				self._update_rule_stats(success=(status == "Success"), duration=duration, error=error_detail)
 
 	def _validate_execution(self):
 		"""Validate rule is executable"""
@@ -726,6 +731,32 @@ class RuleEngine:
 					_("Operation {0} requires a document but context.doc is not set").format(operation)
 				)
 
+		# 2. Runtime Contract: writes_to Document check in restricted events
+		if op_def and op_def.writes_to == "Document":
+			event_name = context.get("event_name")
+			after_events = [
+				"After Insert",
+				"After Save",
+				"On Submit",
+				"Before Cancel",
+				"On Cancel",
+				"On Trash",
+				"On Update After Submit",
+				"On Change",
+			]
+			if event_name in after_events:
+				self._log(
+					"WARNING",
+					_(
+						"Operation {0} writes to Document in an 'After' event ({1}). "
+						"This may cause inconsistent state or recursive triggers."
+					).format(operation, event_name),
+				)
+
+		# 3. Runtime Contract: has_side_effect in transactional context
+		if op_def and op_def.has_side_effect:
+			self._log("INFO", _("Executing operation {0} with side effects").format(operation))
+
 		for attempt in range(retry_count + 1):
 			try:
 				if attempt > 0:
@@ -847,24 +878,47 @@ class RuleEngine:
 		if self.rule.debug_mode or self.context.get("test_mode"):
 			frappe.logger().info(f"[{self.rule.name}] [{level}] {message}")
 
-	def _update_rule_stats(self, success=True, error=None):
+	def _update_rule_stats(self, success=True, duration=0, error=None):
 		"""Update rule execution statistics (non-blocking, no commit)"""
 		if self.context.get("dry_run"):
 			return
 
 		try:
+			# Get current stats to calculate new success rate and avg time
+			current_count = self.rule.execution_count or 0
+			current_avg = self.rule.avg_execution_time or 0
+			current_success_rate = self.rule.success_rate or 0
+
+			new_count = current_count + 1
+			new_avg = (current_avg * current_count + duration) / new_count
+
+			# Calculate new success rate
+			success_count = (current_success_rate / 100.0) * current_count
+			if success:
+				success_count += 1
+			new_success_rate = (success_count / new_count) * 100.0
+
 			# Update in DB without triggering validations
-			# Note: No explicit commit - let the calling transaction handle it
 			frappe.db.set_value(
 				"Rule",
 				self.rule.name,
 				{
-					"execution_count": (self.rule.execution_count or 0) + 1,
+					"execution_count": new_count,
+					"avg_execution_time": new_avg,
+					"success_rate": new_success_rate,
 					"last_executed": frappe.utils.now(),
 					"last_error": error if not success else None,
 				},
 				update_modified=False,
 			)
+
+			# Also update local object for immediate feedback in engine if needed
+			self.rule.execution_count = new_count
+			self.rule.avg_execution_time = new_avg
+			self.rule.success_rate = new_success_rate
+			self.rule.last_executed = frappe.utils.now()
+			self.rule.last_error = error if not success else None
+
 		except Exception as e:
 			# Don't fail execution if stats update fails
 			frappe.logger().error(f"Failed to update rule stats: {e!s}")

--- a/flexirule/ruleflow/core/permissions.py
+++ b/flexirule/ruleflow/core/permissions.py
@@ -159,6 +159,8 @@ def validate_safe_eval(expression):
 	expr_lower = expression.lower()
 	for pattern in dangerous:
 		if pattern in expr_lower:
+			if getattr(frappe.flags, "in_validate_safe_eval", False):
+				return False
 			frappe.throw(
 				_("Expression contains forbidden pattern: {0}").format(pattern),
 				frappe.ValidationError,

--- a/flexirule/ruleflow/doctype/process_operation/process_operation.json
+++ b/flexirule/ruleflow/doctype/process_operation/process_operation.json
@@ -133,6 +133,13 @@
 			"label": "Transactional"
 		},
 		{
+			"default": "0",
+			"description": "Mark if operation has destructive or external side effects",
+			"fieldname": "has_side_effect",
+			"fieldtype": "Check",
+			"label": "Has Side Effects"
+		},
+		{
 			"collapsible": 1,
 			"fieldname": "section_break_targeting",
 			"fieldtype": "Section Break",

--- a/flexirule/ruleflow/doctype/rule/rule.json
+++ b/flexirule/ruleflow/doctype/rule/rule.json
@@ -214,7 +214,23 @@
    "fieldname": "execution_count",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "Execution Count",
+   "label": "Total Executions",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "success_rate",
+   "fieldtype": "Percent",
+   "label": "Success Rate",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "avg_execution_time",
+   "fieldtype": "Float",
+   "label": "Avg. Execution Time (ms)",
    "no_copy": 1,
    "read_only": 1
   },

--- a/flexirule/ruleflow/doctype/rule/rule.py
+++ b/flexirule/ruleflow/doctype/rule/rule.py
@@ -134,7 +134,7 @@ class Rule(Document):
 		if not self.is_active:
 			return
 
-		# 1. Enforce Reachability (No orphans)
+		# 1. Enforce Reachability (No orphans) and No cycles
 		from flexirule.ruleflow.utils.graph_validator import validate_graph_integrity
 
 		validate_graph_integrity(self)

--- a/flexirule/ruleflow/process/normalization/normalization.py
+++ b/flexirule/ruleflow/process/normalization/normalization.py
@@ -270,7 +270,7 @@ def normalize_multiple_fields(context, config):
 
 # Whitelisted API for testing/preview
 @frappe.whitelist()
-def preview_normalization(text, transformations):
+def preview_normalization(text: str, transformations: str | list):
 	"""
 	Preview normalization result without saving
 	"""

--- a/flexirule/ruleflow/process/normalization/pipeline.py
+++ b/flexirule/ruleflow/process/normalization/pipeline.py
@@ -133,7 +133,7 @@ class NormalizationPipeline:
 
 # Whitelisted API for testing
 @frappe.whitelist()
-def test_normalization(text, transformations):
+def test_normalization(text: str, transformations: str | list):
 	"""
 	Test normalization transformations
 

--- a/flexirule/ruleflow/tests/test_engine_complex_flows.py
+++ b/flexirule/ruleflow/tests/test_engine_complex_flows.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2025, Bolton and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from flexirule.ruleflow.core.coordinator import RuleCoordinator
+from flexirule.ruleflow.core.exceptions import CycleDetectedError
+
+
+class TestComplexFlows(FrappeTestCase):
+	def setUp(self):
+		self.cleanup()
+		self.create_test_data()
+
+	def tearDown(self):
+		self.cleanup()
+
+	def cleanup(self):
+		frappe.db.delete("Rule", {"rule_name": ["like", "Test %"]})
+		frappe.db.delete("Rule Action", {"parent": ["like", "Test %"]})
+		frappe.db.delete("Rule Execution Log", {"rule": ["like", "Test %"]})
+		frappe.db.commit()
+
+	def create_test_data(self):
+		# Create a dummy doctype or use User
+		self.doctype = "User"
+		self.docname = "test_user_flow@example.com"
+		if not frappe.db.exists("User", self.docname):
+			user = frappe.get_doc(
+				{"doctype": "User", "email": self.docname, "first_name": "Test User", "send_welcome_email": 0}
+			).insert(ignore_permissions=True)
+		else:
+			user = frappe.get_doc("User", self.docname)
+		self.doc = user
+
+	def test_nested_sub_rule_branching(self):
+		"""
+		Test Case: Rule A calls Rule B, which has a Condition that branches.
+		"""
+		# Rule B: Child Rule
+		rule_b = frappe.get_doc(
+			{
+				"doctype": "Rule",
+				"rule_name": "Test Child Rule",
+				"document_type": self.doctype,
+				"trigger_event": "Manual",
+				"priority": 0,
+				"is_active": 1,
+				"is_sub_rule": 1,
+				"actions": [
+					{
+						"action_id": "root",
+						"action_type": "Entry Action",
+						"action_label": "Start",
+						"next_step_if_true": "cond_1",
+					},
+					{
+						"action_id": "cond_1",
+						"action_type": "Condition",
+						"action_label": "Check First Name",
+						"condition_json": json.dumps(
+							{"left": {"ref": "doc.first_name"}, "op": "==", "right": {"value": "Test User"}}
+						),
+						"next_step_if_true": "set_true",
+						"next_step_if_false": "set_false",
+					},
+					{
+						"action_id": "set_true",
+						"action_type": "Set Value",
+						"action_label": "Set Middle Name",
+						"target_field": "middle_name",
+						"value_template": "SubRuleSuccess",
+					},
+					{
+						"action_id": "set_false",
+						"action_type": "Set Value",
+						"action_label": "Set Middle Name Fail",
+						"target_field": "middle_name",
+						"value_template": "SubRuleFail",
+					},
+				],
+			}
+		).insert()
+
+		# Rule A: Parent Rule
+		rule_a = frappe.get_doc(
+			{
+				"doctype": "Rule",
+				"rule_name": "Test Parent Rule",
+				"document_type": self.doctype,
+				"trigger_event": "Manual",
+				"priority": 0,
+				"is_active": 1,
+				"actions": [
+					{
+						"action_id": "root",
+						"action_type": "Entry Action",
+						"action_label": "Start",
+						"next_step_if_true": "call_sub",
+					},
+					{
+						"action_id": "call_sub",
+						"action_type": "Sub-Rule",
+						"action_label": "Execute Child",
+						"rule": rule_b.name,
+					},
+				],
+			}
+		).insert()
+
+		# Execute Parent
+		RuleCoordinator.execute_rule(rule_a.name, {"doc": self.doc})
+
+		# Verify result (doc is mutated in sub-rule)
+		self.assertEqual(self.doc.middle_name, "SubRuleSuccess")
+
+	def test_recursive_cycle_prevention(self):
+		"""
+		Test Case: Rule A calls Rule B, Rule B calls Rule A.
+		Should throw ValidationError during cycle detection in Rule.validate().
+		"""
+		# Create Rules without sub-rule actions first to satisfy link validation during insert
+		rule_a = frappe.get_doc(
+			{
+				"doctype": "Rule",
+				"rule_name": "Test Cycle A",
+				"document_type": self.doctype,
+				"trigger_event": "Manual",
+				"priority": 0,
+				"is_active": 1,
+				"is_sub_rule": 1,
+				"actions": [{"action_id": "root", "action_type": "Entry Action", "action_label": "Start"}],
+			}
+		).insert()
+
+		rule_b = frappe.get_doc(
+			{
+				"doctype": "Rule",
+				"rule_name": "Test Cycle B",
+				"document_type": self.doctype,
+				"trigger_event": "Manual",
+				"priority": 0,
+				"is_active": 1,
+				"is_sub_rule": 1,
+				"actions": [{"action_id": "root", "action_type": "Entry Action", "action_label": "Start"}],
+			}
+		).insert()
+
+		# Now add the sub-rule actions that point to each other via DB to bypass link validation if needed,
+		# but here we use append and save with ignore_links if possible, or just re-insert.
+		# Actually, Frappe 15+ link validation is strict.
+		frappe.db.sql(
+			"insert into `tabRule Action` (name, parent, parenttype, parentfield, action_id, action_type, rule) values (%s, %s, %s, %s, %s, %s, %s)",
+			(frappe.generate_hash(), rule_a.name, "Rule", "actions", "call_b", "Sub-Rule", rule_b.name),
+		)
+
+		rule_b.append("actions", {"action_id": "call_a", "action_type": "Sub-Rule", "rule": rule_a.name})
+
+		# This save should trigger Rule.validate() -> validate_graph_integrity -> frappe.throw
+		with self.assertRaises(frappe.exceptions.ValidationError) as cm:
+			rule_b.save()
+
+		self.assertIn("Cycle detected", str(cm.exception))
+
+	def test_analytics_and_audit(self):
+		"""
+		Verify analytics fields are updated and path trace is saved.
+		"""
+		rule = frappe.get_doc(
+			{
+				"doctype": "Rule",
+				"rule_name": "Test Analytics",
+				"document_type": self.doctype,
+				"trigger_event": "Manual",
+				"priority": 0,
+				"is_active": 1,
+				"actions": [{"action_id": "root", "action_type": "Entry Action", "action_label": "Start"}],
+			}
+		).insert()
+
+		# Check Execution Log
+		logs = frappe.get_all("Rule Execution Log", filters={"rule": rule.name}, fields=["name", "status"])
+		self.assertEqual(len(logs), 1, f"Expected 1 log, got {len(logs)}: {logs}")
+
+		rule.reload()
+		self.assertEqual(rule.execution_count, 1)
+		self.assertEqual(rule.success_rate, 100.0)
+		self.assertGreater(rule.avg_execution_time, 0)
+
+		# Check Execution Log
+		logs = frappe.get_all("Rule Execution Log", filters={"rule": rule.name}, fields=["execution_path"])
+		self.assertTrue(len(logs) > 0)
+		path = json.loads(logs[0].execution_path)
+		self.assertEqual(path[0]["action"], "Start")
+
+
+import json

--- a/flexirule/ruleflow/tests/test_engine_complex_flows.py
+++ b/flexirule/ruleflow/tests/test_engine_complex_flows.py
@@ -179,6 +179,9 @@ class TestComplexFlows(FrappeTestCase):
 			}
 		).insert()
 
+		# Execute
+		RuleCoordinator.execute_rule(rule.name, {"doc": self.doc})
+
 		# Check Execution Log
 		logs = frappe.get_all("Rule Execution Log", filters={"rule": rule.name}, fields=["name", "status"])
 		self.assertEqual(len(logs), 1, f"Expected 1 log, got {len(logs)}: {logs}")

--- a/flexirule/ruleflow/utils/field_resolver.py
+++ b/flexirule/ruleflow/utils/field_resolver.py
@@ -250,7 +250,7 @@ class FieldResolver:
 
 # Whitelisted API for UI
 @frappe.whitelist()
-def get_doctype_fields(doctype, include_child_tables=False):
+def get_doctype_fields(doctype: str, include_child_tables: bool = False):
 	"""
 	Get all fields for a DocType (API endpoint)
 

--- a/flexirule/ruleflow/utils/graph_validator.py
+++ b/flexirule/ruleflow/utils/graph_validator.py
@@ -28,7 +28,9 @@ def validate_graph_integrity(rule_doc):
 			neighbors = []
 			if current_action.get("next_step_if_true"):
 				neighbors.append(current_action.get("next_step_if_true"))
-			if current_action.get("action_type") == "Condition" and current_action.get("next_step_if_false"):
+			if current_action.get("action_type") in ["Condition", "Switch", "Loop"] and current_action.get(
+				"next_step_if_false"
+			):
 				neighbors.append(current_action.get("next_step_if_false"))
 
 			for neighbor in neighbors:


### PR DESCRIPTION
FlexiRule RC Refactor — Implementation Plan (v2)

This plan refactors and extends FlexiRule before the first Release Candidate. The app is beta (no production data), so breaking changes are permitted without migrations.

NOTE

Execution: All phases will be implemented sequentially. Test site: insight.test.

Proposed Changes
Phase 1: Rule DocType Schema Changes
[MODIFY]

rule.json
New fields:

Field	Type	Details

version
Int	Default 1, read-only, no_copy=1
parent_rule	Link → Rule	Custom field replacing amended_from (which is a Frappe system field requiring docstatus=2). Read-only, no_copy=1
visual_data	Code (JSON)	Already referenced by store.js but missing from schema. Hidden.
permissions	Table → Rule Permission	Child table for role-based permissions
Modify

priority
: Change from Int (default 100) to Select, options 0\n1\n2\n...\n20, default 10. Higher = executes first.

[MODIFY]

rule.py

validate_priority_manual()
 — if trigger_event == "Manual", enforce priority == "0".

validate_version_constraints()
 — single draft amendment, can't deactivate original while amendment is draft.

before_save()
 — set version = 1 on new rules.
[NEW]

rule_service.py

amend_rule(rule_name)
 — frappe.copy_doc(), increments version, sets parent_rule, clears stats.

get_latest_rule_version(rule_key)
 — queries highest version for a rule lineage.

validate_single_draft_copy(rule_key)
 — ensures no other draft amendment exists.
[NEW] Rule Permission child DocType
Directory: flexirule/ruleflow/doctype/rule_permission/

Fields: role (Link → Role), can_execute (Check), can_edit (Check), can_view (Check), can_disable (Check).

[MODIFY]

engine.py
Add permission check in

_validate_execution()
: if rule.permissions exists, verify current user has can_execute for at least one matching role.

Phase 2: Rule Action DocType Extensions
[MODIFY]

rule_action.json
Field Reuse Analysis — maximizing reuse of existing fields:

Requested Field	Reuse Strategy	Rationale
mode	Reuse

operation
For Process actions,

operation
 selects the function. For Query/Aggregate/Create actions,

operation
 holds the mode (e.g., "Query List", "Create New"). Same semantic: "what does this action do?"
ignore_permissions	Reuse skip_permissions	Already exists. Just widen

depends_on
 to include new action types.
returns_keys	Reuse resolved_output_schema	Already Code(JSON) for output schema. Repurpose as the return key schema.
New fields (5 only):

Field	Type	Options	Depends On
input_source	Select	Context Doc\nContext Variable\nBoth	['Query Records','Aggregate Records','Create Docs']
reference_doctype	Link → DocType	—	['Query Records','Create Docs','Aggregate Records']
reference_docname	Dynamic Link	reference_doctype	eval:doc.reference_doctype
mutation_mode	Select	Set Doc Field\nUpdate Doc Field\nSet Context Variable\nUpdate Context Variable\nAppend to Context Variable\nBatch Database Set	['Create Docs','Query Records','Aggregate Records']

return_type
Select	Boolean\nDict\nList\nList of Dict\nDoc as Dict	All action types
Modified existing fields:


action_type
 Select: append \nQuery Records\nAggregate Records\nCreate Docs

operation
 — widen

depends_on
 to include new types, used as "mode" for those types
skip_permissions — widen

depends_on
 to all action types, rename label to "Ignore Permissions"
resolved_output_schema — widen

depends_on
 to all action types, relabel to "Return Keys Schema"
[MODIFY]

contracts.py
Add contracts for 3 new action types with allowed_mutations enforcement.

[MODIFY]

contracts.js
Mirror Python contracts with icons: Query (fa-search), Aggregate (fa-calculator), Create (fa-plus-circle).

Phase 3: New Action Handlers
[NEW]

query_records.py
Modes (via

operation
 field): Query List, Query Doc, Exist Record, Query Report, Query API. Uses reference_doctype for target. Config from

config
 JSON. Auto-populates resolved_output_schema.

[NEW]

create_doc.py
Modes (via

operation
): Create New, Update Existing. Field mapping from

config
 JSON. Optional async via is_async. Permissions via skip_permissions.

[NEW]

aggregate_records.py
Operations: sum, avg, count, min, max, group_by. Uses reference_doctype, PythonExpression filters, mutation_mode for output.

[MODIFY]

action_handlers/

init
.py
Register 3 new handlers in

_ensure_initialized()
.

Phase 4: Engine & Context Improvements
[MODIFY]

engine.py
Validate allowed_mutations from contract against mutation_mode.
Validate

return_type
 after handler execution.
Enhanced path trace: {step, input, output, duration} per action.
[NEW]

context_manager.py

ContextManager
: variable storage, return type validation, variable availability tracking.

[MODIFY]

api.py

test_action_query(rule_name, action_id, context_doc)
 — isolated action test, returns detected fields.

amend_rule(rule_name)
 — calls rule_service.amend_rule().
Enhanced

test_rule()
 with per-step trace.
Phase 5: Vue Frontend Updates
[MODIFY]

store.js
Add node type mappings and serialize new fields (reference_doctype, mutation_mode, etc.).

[MODIFY]

contracts.js
Ensure icons, colors, and descriptions for new actions are consistent.

Phase 7: Frontend UI Implementation (New Actions)
Implement dedicated configuration interfaces for complex operations.

[MODIFY]

ActionFieldProperties.vue
Add Query Records, Aggregate Records, and Create Docs to CONFIG_MODAL_TYPES.

[MODIFY]

ConfigurationPanel.vue
Register the new configuration components.

[NEW]

QueryRecordsConfig.vue
Controls for Mode selection (operation).
DocType selection.
Filter builder / JSON config.
Return variables / mapping.
[NEW]

AggregateRecordsConfig.vue
Selection for aggregate function.
Field selection based on DocType.
Filter builder integration.
[NEW]

CreateDocsConfig.vue
Target DocType selection.
Field mapping interface (reusing MappingWrapper if possible).
Mutation mode selection.
