### PR TITLE
Normalize process operation DTOs and adapt frontend parsing

### DIFF
--- a/flexirule/public/js/flexirule/utils/utils.js
+++ b/flexirule/public/js/flexirule/utils/utils.js
@@ -204,6 +204,32 @@ flexirule.utils.get_process_adapter = function (process_name) {
 };
 
 /**
+ * Normalize operation records from API/DB/adapter into a stable object shape.
+ *
+ * @param {Array} operations
+ * @returns {Array<{value:string, func_name:string, label:string}>}
+ */
+flexirule.utils.normalize_process_operations = function (operations = []) {
+	return (operations || [])
+		.map((op) => {
+			if (typeof op === "string") {
+				return { value: op, func_name: op, label: op };
+			}
+
+			const value = op?.value || op?.func_name;
+			if (!value) return null;
+
+			return {
+				...op,
+				value,
+				func_name: op?.func_name || value,
+				label: op?.label || value,
+			};
+		})
+		.filter(Boolean);
+};
+
+/**
  * Get operations for a process, ensuring the adapter is loaded first.
  *
  * @param {string} process_name - Name of the process
@@ -215,7 +241,7 @@ flexirule.utils.get_process_operations = async function (process_name, db_operat
 
 	// 1. If we have DB operations, use them (they are authoritative for visible operations)
 	if (db_operations && db_operations.length > 0) {
-		return db_operations;
+		return flexirule.utils.normalize_process_operations(db_operations);
 	}
 
 	// 2. Otherwise load adapter and get from JS
@@ -223,7 +249,9 @@ flexirule.utils.get_process_operations = async function (process_name, db_operat
 	const adapter = flexirule.utils.get_process_adapter(process_name);
 	if (!adapter) return [];
 
-	return adapter.get_visible_operations?.() || adapter.operations || [];
+	return flexirule.utils.normalize_process_operations(
+		adapter.get_visible_operations?.() || adapter.operations || []
+	);
 };
 
 /**

--- a/flexirule/ruleflow/api.py
+++ b/flexirule/ruleflow/api.py
@@ -476,19 +476,44 @@ def get_action_context_schema(rule_name: str, action_id: str):
 @frappe.whitelist()
 def get_process_operations(process_name: str):
 	"""
-	Get enabled operations for a specific process.
+	Get enabled operations for a specific process as normalized DTOs.
+	Returns stable shape for both Rule Form and Rule Builder consumers.
 	"""
 	if not process_name:
 		return []
 
-	return frappe.get_all(
+	rows = frappe.get_all(
 		"Process Operation",
 		filters={
 			"parenttype": "Process",
 			"parent": process_name,
 			"enabled": 1,
 		},
+		fields=[
+			"func_name",
+			"label",
+			"enabled",
+			"visible_in_builder",
+			"writes_to",
+			"is_terminal",
+		],
+		order_by="idx asc",
 	)
+
+	# Stable DTO with compatibility fields
+	return [
+		{
+			"value": r.get("func_name"),
+			"func_name": r.get("func_name"),
+			"label": r.get("label") or r.get("func_name"),
+			"enabled": r.get("enabled", 1),
+			"visible_in_builder": r.get("visible_in_builder", 1),
+			"writes_to": r.get("writes_to"),
+			"is_terminal": r.get("is_terminal", 0),
+		}
+		for r in rows
+		if r.get("func_name")
+	]
 
 
 @frappe.whitelist()

--- a/flexirule/ruleflow/doctype/rule/rule.js
+++ b/flexirule/ruleflow/doctype/rule/rule.js
@@ -385,8 +385,13 @@ function update_operation_options(frm, cdt, cdn) {
 	const apply_ops = (ops) => {
 		const field = grid_row.get_field("operation");
 		if (!field) return;
-		field.df.options = ops.join("\n");
-		field.set_data?.(ops);
+		const normalized = (ops || []).map((op) => {
+			if (typeof op === "string") return op;
+			return op?.value || op?.func_name || op?.label;
+		});
+		const cleaned = normalized.filter(Boolean);
+		field.df.options = cleaned.join("\n");
+		field.set_data?.(cleaned);
 		field.refresh();
 	};
 

--- a/flexirule/ruleflow/tests/test_api.py
+++ b/flexirule/ruleflow/tests/test_api.py
@@ -90,6 +90,19 @@ class TestBoltonAPI(unittest.TestCase):
 
 		self.assertTrue(result.get("success"))
 
+	def test_get_process_operations_returns_normalized_dto(self):
+		"""Process operations API should return normalized records."""
+		from flexirule.ruleflow.api import get_process_operations
+
+		result = get_process_operations("Enrichment")
+
+		self.assertIsInstance(result, list)
+		if result:
+			row = result[0]
+			self.assertIn("value", row)
+			self.assertIn("func_name", row)
+			self.assertIn("label", row)
+
 
 class TestAPIPermissions(unittest.TestCase):
 	"""Test API permission enforcement"""

--- a/flexirule_codebase_review_2026-03-18.md
+++ b/flexirule_codebase_review_2026-03-18.md
@@ -1,0 +1,158 @@
+# FlexiRule Codebase Review (2026-03-18)
+
+## Scope
+Code-only review of FlexiRule backend (Python/Frappe) and frontend (Vue/Frappe Desk JS), with focus on architecture, contracts, security, scaling, and developer/user experience.
+
+## Executive Verdict
+FlexiRule has strong ambition and substantial coverage (compiler, coordinator, adapters, tests), but the architecture currently relies on duplicated contracts, runtime dynamic execution, and mixed API shapes that create avoidable fragility.
+
+The core issue: **the frontend-builder contract, process metadata contract, and backend execution contract are not governed from a single typed source of truth**. This is the root of multiple bugs and maintainability pain.
+
+> **Beta context:** The app is not production-ready yet, so the right strategy is to prioritize correctness and contract stability over backward compatibility and feature breadth during this phase.
+
+## Priority Issues
+
+### P0 — Contract drift & shape mismatch between backend API and consumers
+- `get_process_operations` returns raw `Process Operation` rows (dicts), while form logic in `rule.js` treats response as list of strings (`ops.join("\n")`). This is a direct mismatch and a likely UI bug in classic form editing.
+- Action-type contract exists in both Python and JS as duplicated static maps (`core/contracts.py` and `public/js/.../contracts.js`) with no generation/checksum/version enforcement.
+
+**Impact**
+- Broken or inconsistent operation dropdowns depending on entry surface (Rule Form vs Rule Builder).
+- Silent divergence risk whenever one side adds/modifies action semantics.
+
+### P0 — Security boundary is inconsistent across whitelisted APIs
+- Sensitive APIs call `_require_api_access`, but utility endpoints like `get_doctype_fields`, `get_operator_config`, `get_schema_field_options`, and `get_process_operations` do not.
+- `get_script` is whitelisted and exposes process JS source dynamically; `load_process_adapter` evaluates returned script with `new Function(...)`.
+
+**Impact**
+- Wider-than-necessary metadata/script exposure.
+- Hard-to-reason threat model and larger attack surface in multitenant environments.
+
+### P1 — Runtime code loading/execution pattern is too permissive
+- Process adapters are loaded dynamically and executed in browser with `new Function(response.message.script)()`.
+- Backend process execution dispatches by dotted path from module + process name.
+
+**Impact**
+- Debugging and security hardening are harder.
+- Change safety depends on conventions instead of explicit compile-time contracts.
+
+### P1 — Rule orchestration has good structure but heavy per-request potential at scale
+- Global `doc_events` hook on `*` for many events is broad; there is early exit via rule map, but entry overhead still exists for every doctypes/event pair.
+- Rule map invalidation is coarse (full map clear/rebuild).
+
+**Impact**
+- Overhead in high-write sites and queue-heavy installs.
+- Cache churn across workers when many rule edits happen.
+
+### P1 — Validation and execution semantics are spread across too many layers
+- Rule validity is split between doctype validation, graph validator, contracts, process metadata, runtime handler checks, and builder-side checks.
+- Some compiler fallbacks silently emit `''` for invalid refs/scopes, which can mask authoring mistakes instead of failing fast.
+
+**Impact**
+- Users can save logically wrong rules that only fail at runtime.
+- Harder troubleshooting due to deferred failures.
+
+### P2 — Developer experience is backend-test heavy but frontend-contract light
+- Strong Python test surface exists.
+- No equivalent contract snapshot tests ensuring Python contracts/process metadata remain in sync with frontend expectations.
+
+**Impact**
+- Regressions surface in UI behavior late.
+
+## Frontend ↔ Backend Gaps (Concrete)
+
+1) **Operation options shape mismatch (Form UI)**
+- Backend API returns operation objects.
+- `rule.js` treats them like strings and does `ops.join("\n")`.
+
+2) **Parallel contract definitions (action types)**
+- Python and JS both define action type requirements and flags.
+- No CI guard proving they are equal.
+
+3) **Multiple field metadata strategies**
+- Builder store computes field metadata via `frappe.get_meta` directly.
+- Other parts use API-driven `get_doctype_fields` utilities.
+- Field naming/labeling conventions differ by path (`doc.field`, child prefixes, system fields).
+
+4) **Operation source ambiguity**
+- Some paths rely on DB `Process Operation` rows.
+- Others fallback to adapter JS operations.
+- Eligibility filtering can diverge based on which source is used first.
+
+## Recommended Architecture Changes
+
+### 1) Introduce a single canonical “Rule Contract Spec” artifact
+Create one machine-readable schema (JSON/TS/Pydantic) for:
+- action types,
+- required fields,
+- branching capabilities,
+- mutation/return constraints,
+- per-action config schema,
+- API payload schemas.
+
+Generate both Python and JS bindings from it; reject mismatched generated files in CI.
+
+### 2) Normalize all builder-facing APIs to versioned DTOs
+- Add `/api/v1/ruleflow/...` typed response DTOs.
+- Example: `get_process_operations` should **always** return `[{value,label,meta...}]` and never raw DB row shape.
+- Add response version markers to prevent hidden breaking changes.
+
+### 3) Lock down API exposure by capability tiers
+- Public metadata endpoints: minimal fields, read-only, explicit permission checks.
+- Builder/editor endpoints: require `Rule Builder` or `System Manager`.
+- Debug/test endpoints: stricter role + site config flag.
+
+### 4) Replace dynamic adapter execution with signed/static asset loading where possible
+- Prefer static bundled adapters (or server-rendered manifests) over arbitrary `new Function` evaluation.
+- If dynamic script is mandatory, enforce strict signature/hash allowlist and CSP-safe loading path.
+
+### 5) Add compile-time fail-fast validation
+- Invalid scope/ref in condition compiler should hard-fail with actionable error, not silently coerce to empty string expression.
+
+## Consistency Enforcement Strategy
+
+1. **Schema-first**
+   - Author contracts as JSON Schema (or Pydantic models exported to JSON Schema).
+2. **Codegen**
+   - Generate Python validators + TS types + runtime validators (zod/ajv).
+3. **CI gates**
+   - Contract parity test (backend vs frontend generated hashes).
+   - API snapshot tests for DTO shape.
+4. **Runtime guardrails**
+   - Validate request/response payloads at API boundary.
+   - Reject unknown fields in strict mode.
+
+## Performance & Scaling Suggestions
+
+- Cache rule map per doctype+event shard (not single monolith key).
+- Incremental cache invalidation when one rule changes.
+- Add bounded execution metrics tags (doctype/event/rule) and p95/p99 logging.
+- Guard `test_action_query`/manual test endpoints with rate-limit + size limits for JSON payloads.
+- Add lazy loading and virtualized lists in builder for very large process/rule graphs.
+
+## Refactoring Roadmap
+
+### Phase 1 (Stabilize contracts, 1–2 weeks)
+- Fix `get_process_operations` contract mismatch.
+- Add typed DTO normalizers in backend APIs.
+- Add one CI test asserting frontend/backend action contract parity.
+- Keep migration lightweight and intentionally opinionated (breaking early in beta is cheaper than accumulating silent drift).
+
+### Phase 2 (Security hardening, 1–2 weeks)
+- Apply `_require_api_access` (or explicit permission checks) consistently.
+- Restrict script loading path and remove raw `new Function` where feasible.
+- Add allowlist-based endpoint policy doc + tests.
+- In beta, allow temporary developer overrides only behind explicit site config flags (default OFF).
+
+### Phase 3 (Architecture cleanup, 2–4 weeks)
+- Introduce canonical contract spec + generated bindings.
+- Consolidate field metadata retrieval into one service path.
+- Refactor builder and classic form to use the same operation DTO parser.
+
+### Phase 4 (Scale & observability, ongoing)
+- Incremental cache invalidation.
+- Rule execution telemetry dashboards.
+- Load-test suite for heavy-doc-event environments.
+
+## Opinionated Bottom Line
+FlexiRule is close to being a strong framework-level rule engine, but it needs **contract governance and API discipline** more than new features. Until the contract duplication and dynamic execution model are tightened, every feature addition will increase hidden coupling and regression risk.

--- a/flexirule_implementation_plan_2026-03-18.md
+++ b/flexirule_implementation_plan_2026-03-18.md
@@ -1,0 +1,248 @@
+# FlexiRule Implementation Plan (Post-Architecture Review)
+
+Date: 2026-03-18
+Scope: Convert architecture findings into executable engineering work.
+
+## Beta delivery posture
+
+Because FlexiRule is still in beta (not production-ready), this plan favors:
+- fast convergence on one contract/API behavior,
+- explicit breaking changes where they reduce long-term risk,
+- strict CI guards early,
+- reduced emphasis on long-tail backward compatibility.
+
+## Outcomes (What “done” means)
+
+1. Frontend + backend use one contract source (or generated artifacts) for rule action semantics.
+2. Builder-facing APIs return stable, versioned DTOs.
+3. Whitelisted endpoints follow explicit access policy tiers.
+4. Dynamic process adapter execution risk is reduced with controlled loading.
+5. CI enforces contract/API consistency and blocks drift.
+
+## Beta-ready exit gate (before wider rollout)
+
+1. No known frontend/backend operation-shape mismatches.
+2. Contract parity check is mandatory in CI and passing.
+3. All sensitive whitelisted endpoints have explicit permission policy tests.
+4. Dynamic adapter loading path is constrained (or guarded with strict fallback + visibility).
+5. Critical builder flows pass smoke tests (Rule Form + Rule Builder parity).
+
+---
+
+## Phase 0 — Baseline & Guardrails (2–3 days)
+
+### Work
+- Add architecture decision record (ADR) for:
+  - contract source-of-truth,
+  - API DTO versioning,
+  - endpoint access tiers,
+  - adapter loading hardening.
+- Create tracking board with epics:
+  - Contract unification,
+  - API normalization,
+  - Security hardening,
+  - Runtime/scale improvements,
+  - CI quality gates.
+
+### Deliverables
+- `docs/adr/ADR-00x-rule-contract-governance.md`
+- implementation tracker with owners and target dates.
+
+### Exit criteria
+- Team agrees on canonical schema strategy and migration order.
+
+---
+
+## Phase 1 — Fix Critical Contract Breaks First (1 week)
+
+### 1.1 Normalize `get_process_operations`
+- Change backend response to explicit DTO shape:
+  - `[{ value: func_name, label, enabled, visible_in_builder, meta: {...} }]`
+- Add backward compatibility (temporary):
+  - if caller expects old shape, adapt in frontend parser.
+- Update:
+  - `ruleflow/doctype/rule/rule.js`
+  - rule builder store/composables to consume the same parser utility.
+
+### 1.2 Introduce one frontend operation parser
+- Add `normalizeOperationOptions(raw)` helper.
+- Use in both:
+  - classic Rule form,
+  - Vue Rule Builder.
+
+### 1.3 Add regression tests for this mismatch
+- Python API test for DTO fields.
+- JS unit test for parser behavior (object list + legacy list fallback).
+
+### Deliverables
+- API DTO for operations.
+- Shared frontend parser.
+- Tests proving no surface-specific mismatch.
+
+### Exit criteria
+- Operation dropdown works identically on Rule form and Rule Builder.
+- Any intentional breaking API shape change is documented in `CHANGELOG` under a beta-breaking section.
+
+---
+
+## Phase 2 — Contract Unification (1–2 weeks)
+
+### 2.1 Create canonical contract artifact
+- Define `rule_contract.schema.json` (or equivalent typed model).
+- Include:
+  - action types,
+  - required fields,
+  - branching capabilities,
+  - terminal behavior,
+  - mutation constraints,
+  - per-action config schema hooks.
+
+### 2.2 Generate backend/frontend artifacts
+- Python: generated module for validation constants.
+- JS: generated contract module for builder UI.
+- Keep generated files committed and deterministic.
+
+### 2.3 CI parity gate
+- Add check that generated outputs are up-to-date.
+- Fail CI when manual edits drift from canonical source.
+
+### Deliverables
+- Canonical schema + generator scripts.
+- Generated Python/JS contracts.
+- CI enforcement job.
+
+### Exit criteria
+- Remove hand-maintained duplicate contract maps.
+
+---
+
+## Phase 3 — API Boundary Hardening (1 week)
+
+### 3.1 Endpoint access policy matrix
+- Classify whitelisted endpoints by tier:
+  - Tier A (public metadata, minimal scope),
+  - Tier B (builder/editor),
+  - Tier C (test/debug/administrative).
+
+### 3.2 Enforce permission checks consistently
+- Apply role/capability checks to utility endpoints where needed.
+- Ensure all potentially sensitive metadata/script endpoints are gated.
+
+### 3.3 Response minimization
+- Remove unnecessary fields from utility API payloads.
+- Add explicit `api_version` in response objects for critical endpoints.
+
+### Deliverables
+- `docs/security/api-access-matrix.md`
+- endpoint permission tests.
+
+### Exit criteria
+- No whitelisted endpoint with sensitive behavior lacks explicit policy.
+
+---
+
+## Phase 4 — Dynamic Adapter Risk Reduction (1 week)
+
+### 4.1 Restrict adapter loading
+- Prefer static asset path or signed manifest over arbitrary script execution.
+- If dynamic path remains, validate checksum/signature before evaluation.
+
+### 4.2 Controlled fallback behavior
+- If adapter load fails verification, disable operation configuration with actionable UI error.
+
+### 4.3 Observability
+- Log adapter load source, hash, and failure reason (without leaking payload).
+
+### Deliverables
+- Adapter loading policy + implementation.
+- telemetry events for adapter loading.
+
+### Exit criteria
+- No uncontrolled dynamic script eval path in production mode.
+
+---
+
+## Phase 5 — Runtime Correctness & Scale (1–2 weeks)
+
+### 5.1 Compiler strict mode
+- Change invalid scope/reference fallback from silent empty expression to validation error.
+- Add migration script/report for existing affected rules.
+
+### 5.2 Rule map invalidation improvements
+- Move from full global invalidation to targeted doctype/event key invalidation where feasible.
+
+### 5.3 Execution observability
+- Add p95/p99 execution telemetry by doctype/event/rule.
+- Add skip/fail reason counters.
+
+### Deliverables
+- strict compiler validation mode.
+- improved cache invalidation strategy.
+- dashboard-ready metrics.
+
+### Exit criteria
+- measurable drop in ambiguous runtime failures and improved rule execution visibility.
+
+---
+
+## Testing & Quality Gates
+
+## Backend
+- API contract tests for each normalized endpoint.
+- Permission tests for all whitelisted endpoints.
+- Rule compile/validate tests for strict mode behavior.
+
+## Frontend
+- Unit tests for DTO parsers and contract consumers.
+- E2E smoke tests:
+  - create/edit process action in Rule form,
+  - same action in Rule Builder,
+  - save/validate/execute path.
+
+## CI policy
+- Lint + static checks must pass.
+- Contract parity/generation check must pass.
+- API snapshot diff requires explicit approval.
+
+---
+
+## Rollout Strategy
+
+1. Ship Phase 1 behind compatibility adapter (no breaking UI changes).
+2. Introduce Phase 2 generation in “warn-only” CI mode for one sprint.
+3. Flip to strict CI enforcement once all call sites migrate.
+4. Roll out endpoint hardening with feature flags per endpoint group.
+
+### Beta acceleration option (recommended)
+
+If internal consumers can absorb minor breaking changes, skip compatibility adapter and move directly to normalized DTOs + strict parser checks in one sprint. This reduces dual-path maintenance during beta.
+
+---
+
+## Risks & Mitigations
+
+- **Risk:** Contract migration breaks existing customizations.
+  - **Mitigation:** Provide compatibility parser + deprecation window.
+- **Risk:** Permission tightening surprises existing roles.
+  - **Mitigation:** publish access matrix + migration notes.
+- **Risk:** Adapter hardening blocks legacy custom process scripts.
+  - **Mitigation:** temporary allowlist + signed migration path.
+
+---
+
+## Suggested Owner Split
+
+- **Backend lead:** DTOs, permissions, compiler strict mode, cache invalidation.
+- **Frontend lead:** unified parser, generated contracts integration, UI fallback handling.
+- **QA lead:** cross-surface rule authoring regression suite.
+- **DevOps:** CI gates, contract-generation checks, telemetry wiring.
+
+---
+
+## First Sprint Backlog (Practical)
+
+1. Normalize `get_process_operations` DTO.
+2. Add shared JS parser and migrate Rule form + Builder to it.
+3. Add API and UI regression tests for operations dropdown behavior.
+4. Add ADR for contract source-of-truth decision.
+5. Add initial CI check that backend/frontend operation shapes are validated.


### PR DESCRIPTION
### Motivation
- Fix a contract mismatch where the backend `get_process_operations` returned raw DB rows while the Rule form frontend expected a list of strings, causing inconsistent operation dropdown behavior. 
- Provide a single, stable operation shape for both Rule Form and Rule Builder consumers to reduce fragile parsing logic across surfaces. 
- Improve discoverability and ordering of operations by selecting and returning only the fields consumers require.

### Description
- Add `flexirule.utils.normalize_process_operations` in `public/js/flexirule/utils/utils.js` to normalize operation entries (strings or objects) into `{value, func_name, label}` records. 
- Change backend API `get_process_operations` in `flexirule/ruleflow/api.py` to return a stable DTO list with explicit fields (`value`, `func_name`, `label`, `enabled`, `visible_in_builder`, `writes_to`, `is_terminal`) and ordered by `idx asc`. 
- Update Rule form client code in `flexirule/ruleflow/doctype/rule/rule.js` to accept object-shaped operations and derive dropdown options from `value/func_name/label`, preserving caching and `field.set_data`. 
- Add a unit test `test_get_process_operations_returns_normalized_dto` to `flexirule/ruleflow/tests/test_api.py` and include codebase review and implementation plan documents (`flexirule_codebase_review_2026-03-18.md`, `flexirule_implementation_plan_2026-03-18.md`).

### Testing
- Added unit test `test_get_process_operations_returns_normalized_dto` which imports `get_process_operations` and asserts the response is a list and each row includes `value`, `func_name`, and `label`. 
- No automated test run was included in this rollout; the new test was added to the test suite but not executed as part of this change submission.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b9ff4fbd50832bb42bc4e890421604)