### PR TITLE
Refactor: Reorganize Rule Action field order and settings

### DIFF
--- a/flexirule/ruleflow/doctype/rule_action/rule_action.json
+++ b/flexirule/ruleflow/doctype/rule_action/rule_action.json
@@ -5,14 +5,23 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "action_id",
-  "action_type",
-  "rule",
+  "settings_section",
   "is_enabled",
+  "on_error",
+  "column_break_ergb",
   "is_async",
-  "column_break_1",
-  "action_label",
+  "retry_count",
+  "column_break_rqom",
   "skip_permissions",
+  "timeout",
+  "section_break_ypzz",
+  "action_id",
+  "action_label",
+  "action_type",
+  "process_name",
+  "rule",
+  "column_break_1",
+  "operation",
   "skip_conditions",
   "section_break_query",
   "input_source",
@@ -29,15 +38,8 @@
   "section_break_quick_action",
   "target_field",
   "value_template",
-  "section_break_process",
-  "process_name",
-  "operation",
-  "configure_operation",
   "config",
-  "column_break_2",
-  "on_error",
-  "retry_count",
-  "timeout",
+  "configure_operation",
   "section_break_return",
   "mutation_mode",
   "return_variable",
@@ -138,12 +140,6 @@
    "options": "Jinja"
   },
   {
-   "collapsible": 1,
-   "fieldname": "section_break_process",
-   "fieldtype": "Section Break",
-   "label": "Process / Action Configuration"
-  },
-  {
    "depends_on": "eval:doc.action_type=='Process'",
    "description": "Select the process to use",
    "fieldname": "process_name",
@@ -157,19 +153,14 @@
    "fieldname": "operation",
    "fieldtype": "Autocomplete",
    "in_list_view": 1,
-   "label": "Operation / Mode",
-   "mandatory_depends_on": "eval:(doc.action_type=='Process' && doc.process_name) || ['Notify', 'Query Records', 'Document Action'].includes(doc.action_type)"
+   "label": "Operation / Mode"
   },
   {
-   "description": "Configuration for the action (validated against schema for Process types)",
+   "description": "Configuration for the action (validated against schema for Process types) ",
    "fieldname": "config",
    "fieldtype": "Code",
    "label": "Configuration (JSON)",
    "options": "JSON"
-  },
-  {
-   "fieldname": "column_break_2",
-   "fieldtype": "Column Break"
   },
   {
    "default": "Stop",
@@ -208,7 +199,7 @@
    "fieldname": "input_source",
    "fieldtype": "Select",
    "label": "Input Source",
-   "options": "Context Doc\nContext Variable\nBoth"
+   "options": "\nContext Doc\nContext Variable\nBoth"
   },
   {
    "depends_on": "eval:['Query Records', 'Document Action'].includes(doc.action_type)",
@@ -233,7 +224,7 @@
    "fieldname": "mutation_mode",
    "fieldtype": "Select",
    "label": "Mutation Mode",
-   "options": "Set Doc Field\nUpdate Doc Field\nSet Context Variable\nUpdate Context Variable\nAppend to Context Variable\nBatch Database Set"
+   "options": "\nSet Doc Field\nUpdate Doc Field\nSet Context Variable\nUpdate Context Variable\nAppend to Context Variable\nBatch Database Set"
   },
   {
    "default": "1",
@@ -366,11 +357,28 @@
    "fieldname": "section_break_visual",
    "fieldtype": "Section Break",
    "label": "Visual Editor Metadata"
+  },
+  {
+   "fieldname": "column_break_ergb",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_rqom",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_ypzz",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "settings_section",
+   "fieldtype": "Section Break",
+   "label": "Settings"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2026-03-16 01:29:56.647181",
+ "modified": "2026-03-27 18:05:07.739056",
  "modified_by": "Administrator",
  "module": "Ruleflow",
  "name": "Rule Action",

--- a/flexirule/ruleflow/doctype/rule_action/rule_action.py
+++ b/flexirule/ruleflow/doctype/rule_action/rule_action.py
@@ -18,38 +18,16 @@ class RuleAction(Document):
 
 		action_id: DF.Data
 		action_label: DF.Data
-		action_type: DF.Literal[
-			"Entry Action",
-			"Condition",
-			"Process",
-			"Loop",
-			"Stop",
-			"Switch",
-			"Wait",
-			"Sub-Rule",
-			"Set Value",
-			"Raise Error",
-			"Notify",
-			"Query Records",
-			"Aggregate Records",
-			"Create Docs",
-		]
+		action_type: DF.Literal["Entry Action", "Condition", "Process", "Stop", "Wait", "Sub-Rule", "Set Value", "Raise Error", "Notify", "Query Records", "Document Action"]
 		condition_expression: DF.Code | None
 		condition_json: DF.Code | None
 		config: DF.Code | None
 		description: DF.Text | None
 		input_mapping: DF.Code | None
-		input_source: DF.Literal["Context Doc", "Context Variable", "Both"]
+		input_source: DF.Literal["", "Context Doc", "Context Variable", "Both"]
 		is_async: DF.Check
 		is_enabled: DF.Check
-		mutation_mode: DF.Literal[
-			"Set Doc Field",
-			"Update Doc Field",
-			"Set Context Variable",
-			"Update Context Variable",
-			"Append to Context Variable",
-			"Batch Database Set",
-		]
+		mutation_mode: DF.Literal["", "Set Doc Field", "Update Doc Field", "Set Context Variable", "Update Context Variable", "Append to Context Variable", "Batch Database Set"]
 		next_step_if_false: DF.Data | None
 		next_step_if_true: DF.Autocomplete | None
 		on_error: DF.Literal["Stop", "Continue", "Retry", "Rollback", "Escalate"]

--- a/flexirule/ruleflow/doctype/rule_action/rule_action.py
+++ b/flexirule/ruleflow/doctype/rule_action/rule_action.py
@@ -18,7 +18,19 @@ class RuleAction(Document):
 
 		action_id: DF.Data
 		action_label: DF.Data
-		action_type: DF.Literal["Entry Action", "Condition", "Process", "Stop", "Wait", "Sub-Rule", "Set Value", "Raise Error", "Notify", "Query Records", "Document Action"]
+		action_type: DF.Literal[
+			"Entry Action",
+			"Condition",
+			"Process",
+			"Stop",
+			"Wait",
+			"Sub-Rule",
+			"Set Value",
+			"Raise Error",
+			"Notify",
+			"Query Records",
+			"Document Action",
+		]
 		condition_expression: DF.Code | None
 		condition_json: DF.Code | None
 		config: DF.Code | None
@@ -27,7 +39,15 @@ class RuleAction(Document):
 		input_source: DF.Literal["", "Context Doc", "Context Variable", "Both"]
 		is_async: DF.Check
 		is_enabled: DF.Check
-		mutation_mode: DF.Literal["", "Set Doc Field", "Update Doc Field", "Set Context Variable", "Update Context Variable", "Append to Context Variable", "Batch Database Set"]
+		mutation_mode: DF.Literal[
+			"",
+			"Set Doc Field",
+			"Update Doc Field",
+			"Set Context Variable",
+			"Update Context Variable",
+			"Append to Context Variable",
+			"Batch Database Set",
+		]
 		next_step_if_false: DF.Data | None
 		next_step_if_true: DF.Autocomplete | None
 		on_error: DF.Literal["Stop", "Continue", "Retry", "Rollback", "Escalate"]


### PR DESCRIPTION
This PR reorganizes the field order in the Rule Action DocType and adds a new 'Settings' section to improve clarity in the rule builder UI. It also resolves merge conflicts with the latest develop branch.