### PR TITLE
refactor: extract validation logic to validation_service.py

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/ActionSettings.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/ActionSettings.vue
@@ -42,6 +42,24 @@
 						@update:modelValue="(val) => update_action_field('skip_permissions', val)"
 					/>
 				</div>
+				<div class="grid-item span-2" v-if="node.data?.skip_permissions">
+					<ControlFactory
+						:df="
+							with_read_only({
+								fieldname: 'permission_audit_reason',
+								fieldtype: 'Small Text',
+								label: __('Permission Audit Reason'),
+								description: __(
+									'Required when bypassing permissions. Stored in action config.'
+								),
+							})
+						"
+						:modelValue="configValue('permission_audit_reason')"
+						@update:modelValue="
+							(val) => update_config_field('permission_audit_reason', val)
+						"
+					/>
+				</div>
 				<div class="grid-item">
 					<ControlFactory
 						:df="
@@ -165,6 +183,23 @@ function with_read_only(field) {
 
 function update_action_field(fieldname, value) {
 	emit("update:field", { fieldname, value });
+}
+
+function update_config_field(fieldname, value) {
+	emit("update:field", { fieldname, value, scope: "config" });
+}
+
+function configValue(fieldname) {
+	const config = props.node?.data?.config;
+	if (!config) return null;
+	if (typeof config === "object") {
+		return config[fieldname];
+	}
+	try {
+		return JSON.parse(config)?.[fieldname];
+	} catch (e) {
+		return null;
+	}
 }
 </script>
 

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/InputPanel.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/InputPanel.vue
@@ -414,7 +414,7 @@ function updateField(fieldname, value) {
 					props.node.data.return_variable = null;
 					props.node.data.return_type = null;
 					props.node.data.resolved_output_schema = null;
-					props.node.data.output_mapping = null;
+					clearConfigKey("output_mapping");
 				}
 			}
 
@@ -438,6 +438,22 @@ function updateField(fieldname, value) {
 		props.node.data[fieldname] = value;
 		store.mark_dirty();
 	}
+}
+
+function clearConfigKey(key) {
+	if (!props.node?.data) return;
+	let currentConfig = {};
+	if (props.node.data.config && typeof props.node.data.config === "object") {
+		currentConfig = { ...props.node.data.config };
+	} else if (typeof props.node.data.config === "string") {
+		try {
+			currentConfig = JSON.parse(props.node.data.config) || {};
+		} catch (e) {
+			currentConfig = {};
+		}
+	}
+	delete currentConfig[key];
+	props.node.data.config = currentConfig;
 }
 
 watch(

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/OutputPanel.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/OutputPanel.vue
@@ -201,11 +201,14 @@ function serializeSchema(val) {
 
 // -- Mapping Logic --
 watch(
-	() => props.node.data?.output_mapping,
+	() => props.node.data?.config,
 	(val) => {
-		if (val) {
+		const config = parseConfig(val);
+		const mappingValue = config.output_mapping;
+		if (mappingValue) {
 			try {
-				const obj = typeof val === "string" ? JSON.parse(val) : val;
+				const obj =
+					typeof mappingValue === "string" ? JSON.parse(mappingValue) : mappingValue;
 				outputMappings.value = Object.entries(obj).map(([source, target]) => ({
 					source,
 					target,
@@ -234,7 +237,7 @@ function saveOutputMappings() {
 	outputMappings.value.forEach((m) => {
 		if (m.source && m.target) obj[m.source] = m.target;
 	});
-	updateField("output_mapping", obj);
+	updateConfigKey("output_mapping", Object.keys(obj).length ? obj : null);
 }
 
 function updateField(fieldname, value) {
@@ -242,6 +245,37 @@ function updateField(fieldname, value) {
 		props.node.data[fieldname] = value;
 		store.mark_dirty();
 	}
+}
+
+function parseConfig(configValue) {
+	if (!configValue) return {};
+	if (typeof configValue === "object") return configValue;
+	try {
+		return JSON.parse(configValue);
+	} catch (e) {
+		return {};
+	}
+}
+
+function updateConfigKey(key, value) {
+	if (!props.node?.data) return;
+	const nextConfig = {
+		...parseConfig(props.node.data.config),
+	};
+
+	if (
+		value === null ||
+		value === undefined ||
+		value === "" ||
+		(typeof value === "object" && !Array.isArray(value) && !Object.keys(value).length)
+	) {
+		delete nextConfig[key];
+	} else {
+		nextConfig[key] = value;
+	}
+
+	props.node.data.config = nextConfig;
+	store.mark_dirty();
 }
 
 async function refreshVariables() {

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/RuleConfigModal.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/RuleConfigModal.vue
@@ -276,8 +276,36 @@ const title = computed(() => {
 	return baseTitle + suffix;
 });
 
-function on_update_action_field({ fieldname, value }) {
+function on_update_action_field({ fieldname, value, scope }) {
 	if (!draftNode.value?.data) return;
+	if (fieldname && scope === "config") {
+		let baseConfig = {};
+		if (draftNode.value.data.config && typeof draftNode.value.data.config === "object") {
+			baseConfig = draftNode.value.data.config;
+		} else if (typeof draftNode.value.data.config === "string") {
+			try {
+				baseConfig = JSON.parse(draftNode.value.data.config) || {};
+			} catch (e) {
+				baseConfig = {};
+			}
+		}
+		const nextConfig = {
+			...baseConfig,
+		};
+		if (
+			value === null ||
+			value === undefined ||
+			value === "" ||
+			(typeof value === "object" && !Array.isArray(value) && !Object.keys(value).length)
+		) {
+			delete nextConfig[fieldname];
+		} else {
+			nextConfig[fieldname] = value;
+		}
+		draftNode.value.data.config = nextConfig;
+		store.mark_dirty();
+		return;
+	}
 	draftNode.value.data[fieldname] = value;
 	store.mark_dirty();
 }

--- a/flexirule/public/js/flexirule/rule_builder/store.js
+++ b/flexirule/public/js/flexirule/rule_builder/store.js
@@ -392,10 +392,15 @@ export const useStore = defineStore("rule-builder-store", () => {
 			}
 
 			const nodeLabel = isRoot ? "Start" : action.action_label || `Action ${index + 1}`;
-			// Safe JSON parse helper
-			const safeParse = (val) => flexirule.utils.safe_json_parse(val);
+			// Parse JSON-like payloads while preserving already-parsed objects.
+			const safeParse = (val, defaultVal = null) => {
+				if (val && typeof val === "object") {
+					return val;
+				}
+				return flexirule.utils.safe_json_parse(val, defaultVal);
+			};
 
-			const configData = safeParse(action.config);
+			const configData = safeParse(action.config, {}) || {};
 
 			const nodeData = {
 				action_id: nodeId,
@@ -753,6 +758,31 @@ export const useStore = defineStore("rule-builder-store", () => {
 			clean.static_values = cleaned_static;
 		}
 
+		if (
+			clean.input_mapping &&
+			typeof clean.input_mapping === "object" &&
+			!Array.isArray(clean.input_mapping) &&
+			!Object.keys(clean.input_mapping).length
+		) {
+			delete clean.input_mapping;
+		}
+
+		if (
+			clean.output_mapping &&
+			typeof clean.output_mapping === "object" &&
+			!Array.isArray(clean.output_mapping) &&
+			!Object.keys(clean.output_mapping).length
+		) {
+			delete clean.output_mapping;
+		}
+
+		if (
+			typeof clean.permission_audit_reason === "string" &&
+			!clean.permission_audit_reason.trim()
+		) {
+			delete clean.permission_audit_reason;
+		}
+
 		return clean;
 	}
 
@@ -824,102 +854,7 @@ export const useStore = defineStore("rule-builder-store", () => {
 				return;
 			}
 
-			// 2. Contract Validation: Variable Dependencies and Flow Constraints
-			// Build operation metadata from loaded processes
-			const op_metadata =
-				flexirule.validation?.build_operation_metadata?.(processes.value) || {};
-
-			// Prepare actions in topological order for validation
-			const sortedNodesForValidation = getTopologicalSort(nodes.value, edges.value);
-			const actionsForValidation = sortedNodesForValidation.map((node) => ({
-				action_id: node.data?.action_id || node.id,
-				action_type:
-					node.type === "start" ? "Entry Action" : node.data?.action_type || "Process",
-				action_label: node.data?.action_label || node.label || node.id,
-				process_name: node.data?.process_name,
-				operation: node.data?.operation,
-				is_enabled: node.data?.is_enabled !== undefined ? node.data.is_enabled : 1,
-				return_variable: node.data?.return_variable,
-				return_type: node.data?.return_type,
-				resolved_output_schema: node.data?.resolved_output_schema,
-				mutation_mode: node.data?.mutation_mode,
-				condition_json: node.data?.condition_json,
-				condition_expression: node.data?.condition_expression,
-				rule: node.data?.rule,
-				config: node.data?.config,
-				input_variables: node.data?.input_variables,
-				name: node.data?.name,
-			}));
-
-			// Validate variable dependencies
-			if (flexirule.validation?.validate_variable_dependencies) {
-				const varResult = flexirule.validation.validate_variable_dependencies(
-					actionsForValidation,
-					op_metadata
-				);
-				if (!varResult.valid) {
-					const message = varResult.errors.map((e) => `<li>${e}</li>`).join("");
-					frappe.msgprint({
-						title: __("Variable Dependency Error"),
-						message: `<ul class="text-left">${message}</ul>`,
-						indicator: "red",
-					});
-					return;
-				}
-				// Show warnings if any
-				if (varResult.warnings.length > 0) {
-					console.warn("Variable validation warnings:", varResult.warnings);
-				}
-			}
-
-			// Validate flow constraints (is_terminal, writes_to)
-			if (flexirule.validation?.validate_flow_constraints) {
-				const edgesForValidation = edges.value.map((e) => ({
-					source: e.source,
-					target: e.target,
-				}));
-				const flowResult = flexirule.validation.validate_flow_constraints(
-					actionsForValidation,
-					op_metadata,
-					edgesForValidation
-				);
-				if (!flowResult.valid) {
-					const message = flowResult.errors.map((e) => `<li>${e}</li>`).join("");
-					frappe.msgprint({
-						title: __("Flow Constraint Error"),
-						message: `<ul class="text-left">${message}</ul>`,
-						indicator: "red",
-					});
-					return;
-				}
-				// Show warnings for side-effects
-				if (flowResult.warnings.length > 0) {
-					// For now just skip logging, could show as toast or info dialog
-				}
-			}
-
-			// Validate action type-specific constraints (Sub-Rule, Condition, Loop, Switch, return_variable)
-			if (flexirule.validation?.validate_action_types) {
-				const typeResult = flexirule.validation.validate_action_types(
-					actionsForValidation,
-					op_metadata,
-					rule_name.value
-				);
-				if (!typeResult.valid) {
-					const message = typeResult.errors.map((e) => `<li>${e}</li>`).join("");
-					frappe.msgprint({
-						title: __("Action Configuration Error"),
-						message: `<ul class="text-left">${message}</ul>`,
-						indicator: "red",
-					});
-					return;
-				}
-				if (typeResult.warnings.length > 0) {
-					console.warn("Action type warnings:", typeResult.warnings);
-				}
-			}
-
-			// 3. Prepare doc for save
+			// 2. Prepare doc for save
 			const fresh = await frappe.call({
 				method: "frappe.client.get",
 				args: { doctype: "Rule", name: rule_name.value },
@@ -1037,8 +972,10 @@ export const useStore = defineStore("rule-builder-store", () => {
 				};
 			});
 
-			// 4. Backend precheck (shared validator service)
+			// 3. Backend precheck (authoritative shared validator service)
 			const validationPayload = {
+				name: doc.name,
+				is_active: doc.is_active,
 				trigger_type: doc.trigger_type,
 				document_type: doc.document_type,
 				trigger_event: doc.trigger_event,

--- a/flexirule/ruleflow/core/validation_service.py
+++ b/flexirule/ruleflow/core/validation_service.py
@@ -10,8 +10,10 @@ backend form save and frontend builder prechecks.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 
+import frappe
 from frappe import _
 
 from flexirule.ruleflow.core.action_handlers import HandlerRegistry
@@ -22,68 +24,40 @@ from flexirule.ruleflow.core.contracts import (
 	is_release_disabled_action,
 	normalize_action_type,
 )
+from flexirule.ruleflow.utils.graph_validator import validate_graph_integrity
 
 
 def validate_rule_definition(rule_doc) -> dict:
 	"""Validate rule payload/doc and return structured errors/warnings."""
+	rule = _coerce_rule_doc(rule_doc)
 	errors: list[str] = []
 	warnings: list[str] = []
 
-	trigger_type = _safe_get(rule_doc, "trigger_type")
-	trigger_contract = get_trigger_type_contract(trigger_type)
+	_normalize_hidden_trigger_fields(rule)
+	_validate_trigger_requirements(rule, errors)
 
-	for fieldname in trigger_contract.get("required_fields", []):
-		if _is_empty(_safe_get(rule_doc, fieldname)):
-			errors.append(_("Missing required trigger field: {0}").format(fieldname))
+	actions = list(_safe_get(rule, "actions", []) or [])
+	operation_metadata = _build_operation_metadata(actions)
 
-	for action in _safe_get(rule_doc, "actions", []) or []:
+	for action in actions:
 		action_label = _safe_get(action, "action_label") or _safe_get(action, "action_id") or _("(unnamed)")
 		action_type_raw = _safe_get(action, "action_type")
 		action_type = normalize_action_type(action_type_raw)
+
+		_validate_action_json(action, action_label, errors)
 
 		if _is_empty(action_type):
 			errors.append(_("Action '{0}' has no action_type").format(action_label))
 			continue
 
+		if action_type == "Stop" and _is_empty(_safe_get(action, "operation")):
+			_safe_set(action, "operation", "Success")
+
 		if is_release_disabled_action(action_type):
 			errors.append(_("Action '{0}' uses disabled type '{1}'").format(action_label, action_type))
 
-		contract = get_contract(action_type)
-
-		for fieldname in get_required_fields(action_type):
-			if _is_empty(_safe_get(action, fieldname)):
-				errors.append(
-					_("Action '{0}' ({1}) requires field '{2}'").format(action_label, action_type, fieldname)
-				)
-
-		operation = _safe_get(action, "operation")
-		if operation:
-			for fieldname in contract.get("mandatory_fields", {}).get(operation, []):
-				if _is_empty(_safe_get(action, fieldname)):
-					errors.append(
-						_("Action '{0}' ({1}) mode '{2}' requires field '{3}'").format(
-							action_label, action_type, operation, fieldname
-						)
-					)
-
-		if contract.get("terminal") and (
-			_safe_get(action, "next_step_if_true") or _safe_get(action, "next_step_if_false")
-		):
-			errors.append(
-				_("Action '{0}' ({1}) is terminal and should not have next steps").format(
-					action_label, action_type
-				)
-			)
-
-		if not contract.get("has_next_false") and _safe_get(action, "next_step_if_false"):
-			errors.append(
-				_("Action '{0}' ({1}) does not support 'next step if false'").format(
-					action_label, action_type
-				)
-			)
-
-		if action_type == "Query Records" and operation == "Query API":
-			errors.append(_("Action '{0}' uses removed mode Query API").format(action_label))
+		_validate_action_contracts(action, action_type, action_label, errors)
+		_validate_action_specifics(rule, action, action_type, action_label, warnings, errors)
 
 		handler = HandlerRegistry.get(action_type)
 		if handler:
@@ -93,7 +67,374 @@ def validate_rule_definition(rule_doc) -> dict:
 					_("Action '{0}' ({1}) validation failed: {2}").format(action_label, action_type, err)
 				)
 
+	dependency_result = _validate_variable_dependencies(actions, operation_metadata)
+	errors.extend(dependency_result["errors"])
+	warnings.extend(dependency_result["warnings"])
+
+	flow_result = _validate_flow_constraints(actions, operation_metadata)
+	errors.extend(flow_result["errors"])
+	warnings.extend(flow_result["warnings"])
+
+	if hasattr(rule, "validate_no_sub_rule_cycles"):
+		_capture_validation(errors, rule.validate_no_sub_rule_cycles)
+
+	if _is_truthy(_safe_get(rule, "is_active")):
+		_capture_validation(errors, validate_graph_integrity, rule)
+
+		entry_nodes = [
+			action
+			for action in actions
+			if _safe_get(action, "action_type") == "Entry Action" or _safe_get(action, "action_id") == "root"
+		]
+		if len(entry_nodes) != 1:
+			errors.append(_("Active Rule must have exactly one Entry Action (Start) node."))
+
+		if hasattr(rule, "validate_trigger_alignment"):
+			_capture_validation(errors, rule.validate_trigger_alignment)
+
 	return {"valid": len(errors) == 0, "errors": errors, "warnings": warnings}
+
+
+def _coerce_rule_doc(rule_doc):
+	if hasattr(rule_doc, "doctype"):
+		return rule_doc
+
+	payload = dict(rule_doc or {})
+	payload.setdefault("doctype", "Rule")
+	return frappe.get_doc(payload)
+
+
+def _validate_trigger_requirements(rule_doc, errors: list[str]) -> None:
+	trigger_type = _safe_get(rule_doc, "trigger_type")
+	trigger_contract = get_trigger_type_contract(trigger_type)
+
+	for fieldname in trigger_contract.get("required_fields", []):
+		if _is_empty(_safe_get(rule_doc, fieldname)):
+			errors.append(_("Missing required trigger field: {0}").format(fieldname))
+
+
+def _normalize_hidden_trigger_fields(rule_doc) -> None:
+	trigger_type = _safe_get(rule_doc, "trigger_type")
+	trigger_contract = get_trigger_type_contract(trigger_type)
+
+	for fieldname in trigger_contract.get("hidden_fields", []):
+		if not _is_empty(_safe_get(rule_doc, fieldname)):
+			_safe_set(rule_doc, fieldname, None)
+
+
+def _validate_action_json(action, action_label: str, errors: list[str]) -> None:
+	config = _safe_get(action, "config")
+	config_data = _validate_json_value(config, _("Action {0}: Configuration").format(action_label), errors)
+
+	if not isinstance(config_data, Mapping):
+		return
+
+	input_mapping = config_data.get("input_mapping")
+	if isinstance(input_mapping, str):
+		_validate_json_value(input_mapping, _("Action {0}: Input Mapping").format(action_label), errors)
+
+	output_mapping = config_data.get("output_mapping")
+	if isinstance(output_mapping, str):
+		_validate_json_value(output_mapping, _("Action {0}: Output Mapping").format(action_label), errors)
+
+
+def _validate_action_contracts(action, action_type: str, action_label: str, errors: list[str]) -> None:
+	contract = get_contract(action_type)
+	operation = _safe_get(action, "operation")
+
+	for fieldname in get_required_fields(action_type):
+		if _is_empty(_safe_get(action, fieldname)):
+			errors.append(
+				_("Action '{0}' ({1}) requires field '{2}'").format(action_label, action_type, fieldname)
+			)
+
+	if operation:
+		for fieldname in contract.get("mandatory_fields", {}).get(operation, []):
+			if _is_empty(_safe_get(action, fieldname)):
+				errors.append(
+					_("Action '{0}' ({1}) mode '{2}' requires field '{3}'").format(
+						action_label, action_type, operation, fieldname
+					)
+				)
+
+	mutation_mode = _safe_get(action, "mutation_mode")
+	if mutation_mode:
+		allowed_mutations = contract.get("allowed_mutations")
+		if allowed_mutations and mutation_mode not in allowed_mutations:
+			errors.append(
+				_("Action '{0}' ({1}) does not allow mutation mode '{2}'").format(
+					action_label, action_type, mutation_mode
+				)
+			)
+
+		if allowed_mutations and _is_empty(_safe_get(action, "return_variable")):
+			errors.append(
+				_("Action '{0}' ({1}) requires Return Variable Name when Mutation Mode is set").format(
+					action_label, action_type
+				)
+			)
+
+	if (_safe_get(action, "return_type") or _safe_get(action, "resolved_output_schema")) and _is_empty(
+		_safe_get(action, "return_variable")
+	):
+		errors.append(
+			_("Action '{0}' ({1}) requires Return Variable Name for Return Schema").format(
+				action_label, action_type
+			)
+		)
+
+	config_data = _parse_json_value(_safe_get(action, "config"), {})
+	if config_data.get("output_mapping") and _is_truthy(_safe_get(action, "is_async")):
+		errors.append(
+			_("Action '{0}' ({1}) cannot use Output Mapping with Async enabled").format(
+				action_label, action_type
+			)
+		)
+
+	if contract.get("terminal") and (
+		_safe_get(action, "next_step_if_true") or _safe_get(action, "next_step_if_false")
+	):
+		errors.append(
+			_("Action '{0}' ({1}) is terminal and should not have next steps").format(
+				action_label, action_type
+			)
+		)
+
+	if not contract.get("has_next_false") and _safe_get(action, "next_step_if_false"):
+		errors.append(
+			_("Action '{0}' ({1}) does not support 'next step if false'").format(action_label, action_type)
+		)
+
+
+def _validate_action_specifics(
+	rule_doc,
+	action,
+	action_type: str,
+	action_label: str,
+	warnings: list[str],
+	errors: list[str],
+) -> None:
+	operation = _safe_get(action, "operation")
+	config = _parse_json_value(_safe_get(action, "config"), {})
+
+	if action_type == "Process" and _safe_get(action, "process_name"):
+		_capture_validation(errors, rule_doc._validate_action_config, action)
+
+	if action_type == "Query Records" and operation == "Query API":
+		errors.append(_("Action '{0}' uses removed mode Query API").format(action_label))
+
+	if action_type == "Sub-Rule":
+		_capture_validation(errors, rule_doc.validate_sub_rule_target, action)
+
+	elif action_type == "Condition":
+		if _is_empty(_safe_get(action, "condition_json")) and _is_empty(
+			_safe_get(action, "condition_expression")
+		):
+			errors.append(_("Action '{0}' is a Condition but no condition is defined.").format(action_label))
+
+	elif action_type == "Loop":
+		if not config.get("iterator_var") and not config.get("collection"):
+			warnings.append(
+				_("Action '{0}' is a Loop but iterator configuration may be incomplete.").format(action_label)
+			)
+
+	elif action_type == "Switch":
+		if not config.get("cases"):
+			warnings.append(_("Action '{0}' is a Switch but no cases are defined.").format(action_label))
+
+	elif action_type == "Set Value":
+		_capture_validation(errors, rule_doc._validate_set_value_editable, action)
+
+
+def _build_operation_metadata(actions) -> dict:
+	metadata = {}
+	process_names = {
+		_safe_get(action, "process_name")
+		for action in actions
+		if normalize_action_type(_safe_get(action, "action_type")) == "Process"
+		and _safe_get(action, "process_name")
+	}
+
+	for process_name in process_names:
+		try:
+			process = frappe.get_cached_doc("Process", process_name)
+		except Exception:
+			continue
+
+		for operation in process.get("operations") or []:
+			key = f"{process.name}:{_safe_get(operation, 'func_name')}"
+			metadata[key] = {
+				"reads_vars": _safe_get(operation, "reads_vars"),
+				"writes_vars": _safe_get(operation, "writes_vars"),
+				"is_terminal": _safe_get(operation, "is_terminal"),
+				"writes_to": _safe_get(operation, "writes_to"),
+				"can_stop_save": _safe_get(operation, "can_stop_save"),
+				"output_schema": _safe_get(operation, "output_schema"),
+			}
+
+	return metadata
+
+
+def _validate_variable_dependencies(actions, operation_metadata=None) -> dict:
+	errors: list[str] = []
+	warnings: list[str] = []
+	available_vars = {"doc", "old_doc", "frappe"}
+	operation_metadata = operation_metadata or {}
+
+	for action in actions:
+		if _safe_get(action, "action_type") == "Entry Action" or _safe_get(action, "action_id") == "root":
+			continue
+
+		if _safe_get(action, "is_enabled") == 0:
+			continue
+
+		op_key = f"{_safe_get(action, 'process_name')}:{_safe_get(action, 'operation')}"
+		op_meta = operation_metadata.get(op_key, {})
+		action_label = _safe_get(action, "action_label") or _safe_get(action, "action_id") or _("(unnamed)")
+
+		reads_vars = _load_json_list(op_meta.get("reads_vars"), warnings, action_label, "reads_vars")
+		for var_def in reads_vars:
+			var_name = var_def if isinstance(var_def, str) else _safe_get(var_def, "fieldname")
+			is_required = 1 if isinstance(var_def, str) else _safe_get(var_def, "reqd", 1)
+
+			if is_required and var_name and var_name not in available_vars:
+				errors.append(
+					_(
+						"Action '{0}' requires variable '{1}' which is not produced by any prior action"
+					).format(action_label, var_name)
+				)
+
+		writes_vars = _load_json_list(op_meta.get("writes_vars"), warnings, action_label, "writes_vars")
+		for var_def in writes_vars:
+			var_name = var_def if isinstance(var_def, str) else _safe_get(var_def, "fieldname")
+			if var_name:
+				available_vars.add(var_name)
+
+		if _safe_get(action, "return_variable"):
+			available_vars.add(_safe_get(action, "return_variable"))
+
+	return {"valid": len(errors) == 0, "errors": errors, "warnings": warnings}
+
+
+def _validate_flow_constraints(actions, operation_metadata=None) -> dict:
+	errors: list[str] = []
+	warnings: list[str] = []
+	operation_metadata = operation_metadata or {}
+	outgoing: dict[str, list[str]] = {}
+
+	for action in actions:
+		source = _safe_get(action, "action_id") or _safe_get(action, "name")
+		if not source:
+			continue
+
+		if _safe_get(action, "next_step_if_true"):
+			outgoing.setdefault(source, []).append(_safe_get(action, "next_step_if_true"))
+		if _safe_get(action, "next_step_if_false"):
+			outgoing.setdefault(source, []).append(_safe_get(action, "next_step_if_false"))
+
+	start_action = next(
+		(
+			action
+			for action in actions
+			if _safe_get(action, "action_type") == "Entry Action" or _safe_get(action, "action_id") == "root"
+		),
+		None,
+	)
+	if start_action:
+		reachable = set()
+		queue = [_safe_get(start_action, "action_id") or _safe_get(start_action, "name")]
+
+		while queue:
+			current = queue.pop(0)
+			if not current or current in reachable:
+				continue
+			reachable.add(current)
+			queue.extend(outgoing.get(current, []))
+
+		for action in actions:
+			action_id = _safe_get(action, "action_id") or _safe_get(action, "name")
+			label = _safe_get(action, "action_label") or action_id or _("(unnamed)")
+			if action_id and action_id not in reachable:
+				errors.append(_("Action '{0}' is unreachable from the start node.").format(label))
+
+	for action in actions:
+		if _safe_get(action, "action_type") == "Entry Action" or _safe_get(action, "action_id") == "root":
+			continue
+
+		action_type = normalize_action_type(_safe_get(action, "action_type"))
+		action_id = _safe_get(action, "action_id") or _safe_get(action, "name")
+		action_label = _safe_get(action, "action_label") or action_id or _("(unnamed)")
+		downstream = outgoing.get(action_id, [])
+		op_key = f"{_safe_get(action, 'process_name')}:{_safe_get(action, 'operation')}"
+		op_meta = operation_metadata.get(op_key, {})
+
+		if get_contract(action_type).get("terminal") and downstream:
+			errors.append(_("{0} is terminal and should not have downstream actions").format(action_label))
+
+		if get_contract(action_type).get("has_next_false") and _is_empty(
+			_safe_get(action, "next_step_if_false")
+		):
+			errors.append(_("Action '{0}' is missing its required false path.").format(action_label))
+
+		if _is_truthy(op_meta.get("is_terminal")) and downstream:
+			errors.append(
+				_(
+					"Action '{0}' is marked as terminal but has downstream actions. Remove connections to: {1}"
+				).format(action_label, ", ".join(downstream))
+			)
+
+		if op_meta.get("writes_to") == "Database":
+			warnings.append(
+				_(
+					"Action '{0}' writes directly to the database. This is a side-effect that cannot be rolled back."
+				).format(action_label)
+			)
+		elif op_meta.get("writes_to") == "Document":
+			warnings.append(
+				_("Action '{0}' modifies the document. Ensure this is intentional.").format(action_label)
+			)
+
+	return {"valid": len(errors) == 0, "errors": errors, "warnings": warnings}
+
+
+def _load_json_list(value, warnings: list[str], action_label: str, fieldname: str) -> list:
+	if not value:
+		return []
+	try:
+		parsed = json.loads(value) if isinstance(value, str) else value
+		return parsed if isinstance(parsed, list) else []
+	except Exception:
+		warnings.append(f"{action_label}: Failed to parse {fieldname}")
+		return []
+
+
+def _validate_json_value(value, label: str, errors: list[str]):
+	if not value or not isinstance(value, str):
+		return value if value is not None else {}
+
+	try:
+		return json.loads(value)
+	except json.JSONDecodeError as exc:
+		errors.append(_("Invalid JSON in {0}: {1}").format(label, str(exc)))
+		return {}
+
+
+def _parse_json_value(value, default):
+	if value is None or value == "":
+		return default
+	if isinstance(value, Mapping):
+		return dict(value)
+	try:
+		return json.loads(value) if isinstance(value, str) else value
+	except Exception:
+		return default
+
+
+def _capture_validation(errors: list[str], fn, *args, **kwargs) -> None:
+	try:
+		fn(*args, **kwargs)
+	except Exception as exc:
+		errors.append(str(exc))
 
 
 def _safe_get(obj, key, default=None):
@@ -106,5 +447,21 @@ def _safe_get(obj, key, default=None):
 	return getattr(obj, key, default)
 
 
+def _safe_set(obj, key, value) -> None:
+	if obj is None:
+		return
+	if hasattr(obj, "__setitem__"):
+		obj[key] = value
+		return
+	if hasattr(obj, "set"):
+		obj.set(key, value)
+		return
+	setattr(obj, key, value)
+
+
 def _is_empty(value) -> bool:
 	return value in (None, "", [])
+
+
+def _is_truthy(value) -> bool:
+	return value in (1, True, "1")

--- a/flexirule/ruleflow/doctype/rule/rule.py
+++ b/flexirule/ruleflow/doctype/rule/rule.py
@@ -8,7 +8,6 @@ from frappe import _
 from frappe.model.document import Document
 
 from flexirule.ruleflow.utils.graph_validator import validate_graph_integrity
-from flexirule.ruleflow.utils.schema_validator import validate_config
 
 
 class Rule(Document):
@@ -95,17 +94,13 @@ class Rule(Document):
 		self.ensure_start_node()
 		self.reorder_actions()
 		self.compile_conditions()
+		self.normalize_trigger_type_fields()
 		self.validate_with_service()
-		self.validate_actions()
 		self.validate_no_sub_rule_cycles()
 		self.validate_variable_availability()
 		self.validate_active_rule_lock()
 		self.validate_priority_callable()
 		self.validate_version_constraints()
-		self.validate_trigger_type_requirements()
-
-		# New strict validations
-		self.validate_strict_requirements()
 
 		self.status = self.get_computed_status()
 
@@ -137,19 +132,11 @@ class Rule(Document):
 		if self.trigger_type == "Callable Event" and str(self.priority) != "0":
 			frappe.throw(_("Callable Event rules must have priority set to 0."))
 
-	def validate_trigger_type_requirements(self):
-		"""Enforce field presence based on trigger_type."""
+	def normalize_trigger_type_fields(self):
+		"""Clear fields hidden by the selected trigger type."""
 		from flexirule.ruleflow.core.contracts import get_trigger_type_contract
 
 		contract = get_trigger_type_contract(self.trigger_type)
-		meta = frappe.get_meta(self.doctype)
-
-		for fieldname in contract.get("required_fields", []):
-			if not self.get(fieldname):
-				frappe.throw(
-					_("{0} is required for {1} rules.").format(meta.get_label(fieldname), self.trigger_type)
-				)
-
 		for fieldname in contract.get("hidden_fields", []):
 			if self.get(fieldname):
 				self.set(fieldname, None)
@@ -166,26 +153,6 @@ class Rule(Document):
 		from flexirule.ruleflow.core.rule_service import validate_single_draft_copy
 
 		validate_single_draft_copy(self)
-
-	def validate_strict_requirements(self):
-		"""
-		Perform strict checks when rule is active.
-		"""
-		if not self.is_active:
-			return
-
-		# 1. Enforce Reachability (No orphans) and No cycles
-		from flexirule.ruleflow.utils.graph_validator import validate_graph_integrity
-
-		validate_graph_integrity(self)
-
-		# 2. Enforce exactly one Entry Action
-		entry_nodes = [a for a in self.actions if a.action_type == "Entry Action"]
-		if len(entry_nodes) != 1:
-			frappe.throw(_("Active Rule must have exactly one Entry Action (Start) node."))
-
-		# 3. Enforce Trigger Alignment (Doc-editing actions vs Trigger Event)
-		self.validate_trigger_alignment()
 
 	def validate_trigger_alignment(self, rule_doc=None, visited_rules=None, is_after_event_context=None):
 		"""
@@ -377,55 +344,6 @@ class Rule(Document):
 						_("Error compiling Action {0} Condition: {1}").format(action.action_label, str(e))
 					)
 
-	def validate_actions(self):
-		if not self.actions:
-			return
-
-		from flexirule.ruleflow.core.action_handlers import HandlerRegistry
-		from flexirule.ruleflow.core.contracts import normalize_action_type
-
-		for action in self.actions:
-			# 1. Validate JSON fields syntax
-			self._validate_json_field(
-				action.config,
-				_("Action {0}: Configuration").format(action.action_label),
-			)
-			# Validate mappings inside config blob
-			config_data = frappe.parse_json(action.config or "{}") if action.config else {}
-			if config_data.get("input_mapping"):
-				self._validate_json_field(
-					config_data.get("input_mapping")
-					if isinstance(config_data.get("input_mapping"), str)
-					else None,
-					_("Action {0}: Input Mapping").format(action.action_label),
-				)
-			if config_data.get("output_mapping"):
-				self._validate_json_field(
-					config_data.get("output_mapping")
-					if isinstance(config_data.get("output_mapping"), str)
-					else None,
-					_("Action {0}: Output Mapping").format(action.action_label),
-				)
-
-			# 2. Check Process config against Schema
-			if action.action_type == "Process" and action.process_name:
-				self._validate_action_config(action)
-
-			# 3. Validate action type-specific constraints
-			self._validate_all_action_types(action)
-
-			# 4. Handler-level validation (action-specific)
-			handler = HandlerRegistry.get(normalize_action_type(action.action_type))
-			if handler:
-				errors = handler.validate(action, {"doc": None, "vars": {}})
-				if errors:
-					message = "; ".join([str(e) for e in errors])
-					frappe.throw(
-						_("Action '{0}' ({1}) validation failed: {2}").format(
-							action.action_label, action.action_type, message
-						)
-					)
-
 	def get_computed_status(self):
 		if not self.is_active:
 			# New rule or rule that has never been executed
@@ -443,16 +361,6 @@ class Rule(Document):
 			return "Error"
 
 		return "Active"
-
-	def _validate_json_field(self, json_str, label):
-		if not json_str:
-			return
-		import json
-
-		try:
-			json.loads(json_str)
-		except json.JSONDecodeError as e:
-			frappe.throw(_("Invalid JSON in {0}: {1}").format(label, str(e)))
 
 	def _validate_action_config(self, action):
 		if not frappe.db.exists("Process", action.process_name):
@@ -509,128 +417,6 @@ class Rule(Document):
 				).format(action.action_label, action.operation)
 			)
 
-	def _validate_all_action_types(self, action):
-		"""
-		Validate constraints specific to each action type.
-		Uses ACTION_TYPE_CONTRACT for unified backend/frontend validation.
-		"""
-		from flexirule.ruleflow.core.contracts import (
-			get_contract,
-			get_required_fields,
-			normalize_action_type,
-		)
-
-		action_type = normalize_action_type(action.action_type)
-		contract = get_contract(action_type)
-
-		# Backward Compatibility: Default operation to 'Success' for Stop actions if missing
-		if action_type == "Stop" and not getattr(action, "operation", None):
-			action.operation = "Success"
-
-		# 1. Contract: Required fields check
-		for field in get_required_fields(action_type):
-			if not getattr(action, field, None):
-				frappe.throw(
-					_("Action '{0}' ({1}) requires field '{2}'").format(
-						action.action_label, action_type, field
-					)
-				)
-
-		# 1a. Contract: Operation-specific mandatory fields
-		if action.operation:
-			mandatory_fields = contract.get("mandatory_fields", {}).get(action.operation, [])
-			for field in mandatory_fields:
-				if not getattr(action, field, None):
-					frappe.throw(
-						_("Action '{0}' ({1}) mode '{2}' requires field '{3}'").format(
-							action.action_label, action_type, action.operation, field
-						)
-					)
-
-		# 1b. Contract: Allowed mutation modes (only for action types that declare it)
-		if getattr(action, "mutation_mode", None):
-			allowed_mutations = contract.get("allowed_mutations")
-			if allowed_mutations:
-				if action.mutation_mode not in allowed_mutations:
-					frappe.throw(
-						_("Action '{0}' ({1}) does not allow mutation mode '{2}'").format(
-							action.action_label, action_type, action.mutation_mode
-						)
-					)
-
-				if not action.return_variable:
-					frappe.throw(
-						_(
-							"Action '{0}' ({1}) requires Return Variable Name when Mutation Mode is set"
-						).format(action.action_label, action_type)
-					)
-
-		# 1c. Return Schema requires Return Variable
-		if (action.return_type or action.resolved_output_schema) and not action.return_variable:
-			frappe.throw(
-				_("Action '{0}' ({1}) requires Return Variable Name for Return Schema").format(
-					action.action_label, action_type
-				)
-			)
-
-		# 1d. Output Mapping cannot be used with async actions
-		action_cfg = frappe.parse_json(action.config or "{}") if action.config else {}
-		if action_cfg.get("output_mapping") and action.is_async:
-			frappe.throw(
-				_("Action '{0}' ({1}) cannot use Output Mapping with Async enabled").format(
-					action.action_label, action_type
-				)
-			)
-
-		# 2. Contract: Terminal action should not have next_step
-		if contract.get("terminal"):
-			if action.next_step_if_true or action.next_step_if_false:
-				frappe.throw(
-					_("Action '{0}' ({1}) is terminal and should not have next steps").format(
-						action.action_label, action_type
-					)
-				)
-
-		# 3. Contract: Check has_next_false for non-branching actions
-		if not contract.get("has_next_false") and action.next_step_if_false:
-			frappe.throw(
-				_("Action '{0}' ({1}) does not support 'next step if false'").format(
-					action.action_label, action_type
-				)
-			)
-
-		# Type-specific validations
-		if action_type == "Sub-Rule":
-			self.validate_sub_rule_target(action)
-
-		elif action_type == "Condition":
-			if not action.condition_json and not action.condition_expression:
-				frappe.throw(
-					_("Action '{0}' is a Condition but no condition is defined.").format(action.action_label)
-				)
-
-		elif action_type == "Loop":
-			config = self._parse_json_field(action.config)
-			if not config.get("iterator_var") and not config.get("collection"):
-				frappe.msgprint(
-					_("Action '{0}' is a Loop but iterator configuration may be incomplete.").format(
-						action.action_label
-					),
-					alert=True,
-				)
-
-		elif action_type == "Switch":
-			config = self._parse_json_field(action.config)
-			if not config.get("cases"):
-				frappe.msgprint(
-					_("Action '{0}' is a Switch but no cases are defined.").format(action.action_label),
-					alert=True,
-				)
-
-		elif action_type == "Set Value":
-			# Check if target field is editable given trigger event
-			self._validate_set_value_editable(action)
-
 	def _validate_set_value_editable(self, action):
 		"""Check if Set Value target field is valid and editable for current trigger event"""
 		target_field = getattr(action, "target_field", None)
@@ -659,15 +445,6 @@ class Rule(Document):
 						"Action '{0}': Cannot set field '{1}' after submit. Field does not have 'Allow on Submit' enabled."
 					).format(action.action_label, target_field)
 				)
-
-	def _parse_json_field(self, json_str):
-		"""Parse JSON field safely, return empty dict on failure."""
-		if not json_str:
-			return {}
-		try:
-			return json.loads(json_str) if isinstance(json_str, str) else json_str
-		except Exception:
-			return {}
 
 	def validate_sub_rule_target(self, action):
 		"""Validate that a Sub-Rule action targets a compatible callable rule."""
@@ -751,7 +528,7 @@ class Rule(Document):
 				# Cycle detected - build cycle path from where it starts
 				cycle_start = path.index(current_rule)
 				cycle_path = [*path[cycle_start:], current_rule]
-				return " → ".join(cycle_path)
+				return " → ".join([str(part) for part in cycle_path if part])
 
 			if current_rule in globally_visited:
 				return None  # Already fully explored, no cycle from here
@@ -770,7 +547,8 @@ class Rule(Document):
 
 		# Start DFS from this rule
 		globally_visited: set[str] = set()
-		initial_path = [self.name]
+		current_rule_name = self.name or self.rule_name or _("(unsaved rule)")
+		initial_path = [current_rule_name]
 
 		for sub_rule in sub_rules:
 			if sub_rule:

--- a/flexirule/ruleflow/doctype/rule/test_rule.py
+++ b/flexirule/ruleflow/doctype/rule/test_rule.py
@@ -4,6 +4,8 @@
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
+from flexirule.ruleflow.api import validate_rule_document
+
 
 class TestRule(FrappeTestCase):
 	def setUp(self):
@@ -91,3 +93,61 @@ class TestRule(FrappeTestCase):
 			}
 		)
 		valid_rule.validate()
+
+	def test_service_matches_form_validation_for_missing_condition(self):
+		"""API precheck and form validation should reject the same invalid rule definition."""
+		payload = {
+			"doctype": "Rule",
+			"rule_name": "Rule Missing Condition",
+			"document_type": "User",
+			"trigger_type": "DocType Event",
+			"trigger_event": "Before Save",
+			"actions": [
+				{
+					"action_label": "Missing Condition",
+					"action_type": "Condition",
+					"action_id": "condition_1",
+				}
+			],
+		}
+
+		api_result = validate_rule_document(payload)
+		self.assertFalse(api_result["valid"])
+		self.assertTrue(
+			any("is a Condition but no condition is defined" in error for error in api_result["errors"])
+		)
+
+		rule = frappe.get_doc(payload)
+		with self.assertRaisesRegex(frappe.ValidationError, "is a Condition but no condition is defined"):
+			rule.validate()
+
+	def test_service_matches_form_validation_for_async_output_mapping(self):
+		"""Async output mapping should fail consistently through API and form validation."""
+		payload = {
+			"doctype": "Rule",
+			"rule_name": "Rule Async Output Mapping",
+			"document_type": "User",
+			"trigger_type": "DocType Event",
+			"trigger_event": "Before Save",
+			"actions": [
+				{
+					"action_label": "Async Query",
+					"action_type": "Query Records",
+					"action_id": "query_1",
+					"reference_doctype": "User",
+					"operation": "Query List",
+					"is_async": 1,
+					"config": '{"output_mapping":{"rows":"vars.rows"}}',
+				}
+			],
+		}
+
+		api_result = validate_rule_document(payload)
+		self.assertFalse(api_result["valid"])
+		self.assertTrue(
+			any("cannot use Output Mapping with Async enabled" in error for error in api_result["errors"])
+		)
+
+		rule = frappe.get_doc(payload)
+		with self.assertRaisesRegex(frappe.ValidationError, "cannot use Output Mapping with Async enabled"):
+			rule.validate()

--- a/flexirule/ruleflow/utils/graph_validator.py
+++ b/flexirule/ruleflow/utils/graph_validator.py
@@ -108,7 +108,7 @@ def validate_graph_integrity(rule_doc):
 	# Check for non-reachable nodes
 	orphans = [qid for qid in actions if qid not in reachable]
 	if orphans:
-		orphan_labels = [actions[o].action_label for o in orphans]
+		orphan_labels = [actions[o].action_label or actions[o].action_id or str(o) for o in orphans]
 		message = _("Unreachable (Orphan) Actions found: {0}").format(", ".join(orphan_labels))
 		if missing_references:
 			message = "{0}. {1}".format(message, missing_references[0])


### PR DESCRIPTION
## Summary
- Move validation methods from `rule.py` to dedicated `ValidationService` class
- Centralize validation logic with clearer separation of concerns
- Add test coverage for validation methods in `test_rule.py`
- Simplify `rule.py` by delegating validation to service

## Changes
- **New file**: `ruleflow/core/validation_service.py` (467 lines) - contains all validation logic
- **New file**: `ruleflow/doctype/rule/test_rule.py` - tests for validation service
- **Modified**: `rule.py` - simplified from 893 to ~660 lines by removing validation methods
- **Modified**: Vue components - UI refinements for action config panels
- **Modified**: `store.js` - refactored state management

## Benefits
- Cleaner separation of concerns
- Easier to test validation logic in isolation
- More maintainable rule.py document class
- Reusable ValidationService for other components