### PR TITLE
refactor: return deterministic execution payload directly from engine

### DIFF
--- a/flexirule/ruleflow/api.py
+++ b/flexirule/ruleflow/api.py
@@ -236,54 +236,55 @@ def test_rule(
 			"execution_log": {},
 		}
 
+	save_log_flag = bool(frappe.parse_json(save_log))
+
 	try:
 		from flexirule.ruleflow.core.engine import RuleEngine
 
-		# Run in test_mode to prevent rollback of the rule itself during tests
-		engine = RuleEngine(rule, {"test_mode": True, "save_log": frappe.parse_json(save_log)})
-		engine.execute(doc)
-
-		# Fetch the latest log (created by engine even in test mode)
-		logs = frappe.get_all(
-			"Rule Execution Log",
-			filters={"rule": rule_name, "reference_docname": doc.name},
-			order_by="creation desc",
-			limit=1,
-			fields=["status", "message", "execution_path", "context_snapshot"],
+		# Run in test_mode and return deterministic details directly from engine output.
+		# Avoids races with async "latest log" lookups.
+		engine = RuleEngine(
+			rule,
+			{
+				"test_mode": True,
+				"save_log": save_log_flag,
+				"skip_log_persistence": not save_log_flag,
+			},
 		)
-
-		log_data = logs[0] if logs else {}
-
-		# Parse JSON fields
-		if isinstance(log_data, dict) and log_data.get("execution_path"):
-			try:
-				log_data["execution_path"] = json.loads(log_data["execution_path"])
-			except Exception:
-				pass
-
-		if isinstance(log_data, dict) and log_data.get("context_snapshot"):
-			try:
-				log_data["context_snapshot"] = json.loads(log_data["context_snapshot"])
-			except Exception:
-				pass
+		context_result = engine.execute(doc)
+		engine_payload = engine.get_execution_payload(context_result)
 
 		# Include info about skipped trigger filters for transparency
 		info_msg = _("Rule '{0}' executed successfully").format(rule.rule_name)
 		if rule.compiled_expression:
 			info_msg += _(" (trigger filters were bypassed for manual test)")
 
-		# Capture path trace from engine
-		path_trace = getattr(engine, "path_trace", [])
+		path_trace = engine_payload.get("path_trace", [])
+		context_vars = engine_payload.get("context_vars", {})
+		messages = engine_payload.get("messages", [])
+		errors = engine_payload.get("errors", [])
+
+		execution_log = {
+			"status": "Success",
+			"message": messages[-1]["message"] if messages else _("Executed successfully"),
+			"execution_path": path_trace,
+			"context_snapshot": context_vars,
+			"messages": messages,
+			"errors": errors,
+			"log_saved": save_log_flag,
+		}
 
 	except Exception as e:
 		return {"success": False, "status": _("Failed"), "error": str(e)}
 
 	return {
 		"success": True,
-		"status": _(log_data.get("status", "Success")),
-		"execution_log": log_data,
-		"execution_path": log_data.get("execution_path", path_trace or []),
-		"context_snapshot": log_data.get("context_snapshot", {}),
+		"status": _("Success"),
+		"execution_log": execution_log,
+		"execution_path": path_trace,
+		"context_snapshot": context_vars,
+		"messages": messages,
+		"errors": errors,
 		"message": info_msg,
 	}
 

--- a/flexirule/ruleflow/core/engine.py
+++ b/flexirule/ruleflow/core/engine.py
@@ -251,6 +251,7 @@ class RuleEngine:
 
 		self.execution_log = []
 		self.cache = {}
+		self.last_context = {}
 
 		# Build action maps for fast lookup
 		self.action_map_by_id = {a.action_id: a for a in self.actions if a.action_id}
@@ -353,19 +354,46 @@ class RuleEngine:
 			raise
 
 		finally:
+			active_context = context if "context" in locals() else self.context
+			self.last_context = active_context or {}
+
 			# Persist Log
 			duration = time.time() - start_time
 			self._save_execution_log(
 				self._normalize_execution_status(status),
 				duration,
 				error_detail,
-				context=context if "context" in locals() else None,
+				context=active_context,
 				message=self.execution_log[-1]["message"] if self.execution_log else None,
 			)
 
 			# Update last_error on Rule for get_computed_status()
 			if not self.context.get("dry_run") and not self.context.get("test_mode"):
 				self._update_last_error(error_detail if status == "Failed" else None)
+
+	def _sanitize_for_payload(self, value):
+		"""Return a JSON-safe value for API payloads."""
+		if isinstance(value, str | int | float | bool) or value is None:
+			return value
+		if isinstance(value, list):
+			return [self._sanitize_for_payload(item) for item in value]
+		if isinstance(value, tuple):
+			return [self._sanitize_for_payload(item) for item in value]
+		if isinstance(value, dict):
+			return {str(k): self._sanitize_for_payload(v) for k, v in value.items()}
+		return str(value)
+
+	def get_execution_payload(self, context=None):
+		"""Return deterministic execution details without relying on persisted logs."""
+		active_context = context or self.last_context or {}
+		return {
+			"path_trace": self._sanitize_for_payload(getattr(self, "path_trace", []) or []),
+			"context_vars": self._sanitize_for_payload(active_context.get("vars", {}) or {}),
+			"messages": self._sanitize_for_payload(self.execution_log or []),
+			"errors": self._sanitize_for_payload(
+				[entry for entry in (self.execution_log or []) if entry.get("level") == "ERROR"]
+			),
+		}
 
 	def _validate_execution(self):
 		"""Validate rule is executable"""
@@ -1028,6 +1056,9 @@ class RuleEngine:
 			if self.context.get("dry_run"):
 				# In dry_run mode, we don't persist logs at all
 				pass
+			elif active_context.get("skip_log_persistence"):
+				# Deterministic API tests can opt-out of persistence and rely on engine payload.
+				pass
 			elif status in ("Failed", "Error") and not active_context.get("test_mode"):
 				# Enqueue log creation to run in a separate transaction
 				# This avoids the problematic rollback+commit pattern
@@ -1037,12 +1068,12 @@ class RuleEngine:
 					now=frappe.flags.in_test,  # Run synchronously in tests
 					log_data=log_data,
 				)
-			elif active_context.get("save_log") and not active_context.get("test_mode"):
+			elif active_context.get("save_log"):
 				# Forced persistence - also use enqueue for consistency
 				frappe.enqueue(
 					"flexirule.ruleflow.utils.logging.persist_execution_log",
 					queue="short",
-					now=frappe.flags.in_test,
+					now=frappe.flags.in_test or active_context.get("test_mode"),
 					log_data=log_data,
 				)
 			else:


### PR DESCRIPTION
## Summary
- Add get_execution_payload() method to return deterministic execution details without relying on persisted logs or database lookups
- Add _sanitize_for_payload() to ensure JSON-safe values in API responses
- Add last_context tracking for payload retrieval after execution completes
- Update test_rule API to use new payload method, avoiding race conditions with async log persistence
- Allow skip_log_persistence option for deterministic API tests
- Simplify log saving logic to handle test_mode consistently

## Changes
- flexirule/ruleflow/api.py: Refactored test_rule to return deterministic payload directly from engine
- flexirule/ruleflow/core/engine.py: Added _sanitize_for_payload(), get_execution_payload(), and last_context tracking