### PR TITLE
docs: RC refactor branch comparison and target architecture recommendation

### DIFF
--- a/RC_REFACTOR_BRANCH_ARCHITECTURE_REVIEW.md
+++ b/RC_REFACTOR_BRANCH_ARCHITECTURE_REVIEW.md
@@ -1,0 +1,211 @@
+# RC Refactor Branch Architecture Review (Frappe + Vue 3 Rule Engine)
+
+Date: 2026-04-03
+Branches evaluated:
+- `origin/rc_refactor_version_1` (`ca7f03d`)
+- `origin/rc_refactor_version_2` (`614f595`)
+- `origin/rc_refactor_v_3` (`e20c4fc`) *(mapped to requested `rc_refactor_v3`)*
+- `origin/rc_refactor_v4` (`3f8de2f`)
+
+## 1) Comparison Matrix
+
+| Dimension | rc_refactor_version_1 | rc_refactor_version_2 | rc_refactor_v3 | rc_refactor_v4 |
+|---|---|---|---|---|
+| Code structure & modularity | Baseline; broader API surface | Simplified contracts/store; reduced legacy aliases | Minor backend cleanup + added RC validation artifacts | Strongest backend modularity (notably sub-rule context isolation), plus architecture docs |
+| Frappe best practices | Mostly standard DocType layout; mixed trigger nomenclature | Improves trigger consistency (`Callable Event`) and removes aliasing | Same as v2, plus test-oriented hardening | Best on trigger consistency + sub-rule constraints; still inherits Semgrep issues from base |
+| Vue 3 architecture quality | Composition API + Pinia in place, but extra translation/adaptation logic in store | Cleaner store model and fewer legacy compatibility transforms | Essentially v2 frontend-wise | Same frontend baseline as v3; backend behavior changes require careful API contract checks |
+| Rule engine flexibility/extensibility | Good base, but mutable sub-rule merge behavior is riskier | Deterministic payload direction improved | Adds RC validation tests but limited engine evolution | Best: copy-on-write sub-rule var overlay + explicit namespaced outputs |
+| Dead code / unused modules | Similar baseline | Slightly reduced | Slightly more due test artifacts | Similar baseline; still several unused imports/vars |
+| Code duplication | Moderate | Reduced in store/contracts via cleanup | Similar to v2 | Slightly improved in core handler logic; no major dedupe campaign |
+| Testability | Good baseline | Regression risk (removes production-readiness test assets) | Improves with `test_rc_validation.py` and feature docs | Adds `test_real_rules.py` but drops RC feature matrix tests/docs from v3 |
+| Maintainability | Medium | Better than v1 due simplification | Better backend behavior checks, but fragmented artifacts | Highest if paired with missing v3 validation assets |
+| Migration complexity | Low (baseline) | Medium (trigger and payload normalization changes) | Medium | Medium-high due sub-rule semantic change (no implicit merge-back) |
+| Technical risk | Medium | Medium-low | Medium | Medium-low for long-term architecture, medium for short-term regression if consumers expect old API behavior |
+| Readability / DX | Acceptable | Improved by removing alias clutter | Similar to v2 | Best overall due added docs (`docs/*.md`) + clearer sub-rule internals |
+
+## 2) Deep Code Analysis by Branch
+
+### A. `rc_refactor_version_1`
+- **Key strengths**
+  - Stable baseline behavior and complete test fixture set (includes production-readiness fixtures/tests).
+- **Anti-patterns / coupling**
+  - Store contained compatibility aliases (`target_*`, `result_handling`, trigger normalization conversions) that increase cognitive load and widen UI-domain coupling.
+  - Sub-rule execution relied on broader mutable context merge semantics; harder to reason about side effects.
+- **DocType/schema observations**
+  - DocType naming appears consistent structurally, but trigger semantics still carried legacy vocabulary handling.
+- **Risk**
+  - Medium: more compatibility logic implies higher chance of hidden edge-case regressions.
+
+### B. `rc_refactor_version_2`
+- **Key strengths**
+  - Significant simplification: removes alias fields and trigger normalization round-tripping in UI/store and contracts.
+  - Moves toward deterministic execution payload handling in engine/API flow.
+- **Anti-patterns / coupling**
+  - Removed some backend-assisted context schema enrichment (`available_variables`) from API path and shifted more inference client-side, which can reduce backend/frontend contract richness.
+- **Dead code / tests**
+  - Removed `test_production_readiness.py` and fixture JSON; this weakens confidence for real-world scenario validation.
+- **Risk**
+  - Medium-low technically, but validation coverage regresses.
+
+### C. `rc_refactor_v3`
+- **Key strengths**
+  - Adds `test_rc_validation.py`, `RC_FEATURE_MATRIX.md`, and production rule notes to close design/test gaps.
+  - Continues v2 cleanup trajectory.
+- **Anti-patterns / coupling**
+  - Architectural deltas are limited; still depends on prior simplification decisions without full contract re-hardening.
+- **Dead code / noise**
+  - Slight increase in TODO/FIXME density versus v2/v4.
+- **Risk**
+  - Medium: better validation intent, but not a complete architectural endpoint.
+
+### D. `rc_refactor_v4`
+- **Key strengths**
+  - Introduces robust **sub-rule context isolation** via copy-on-write `SubRuleVarsOverlay` and explicit namespaced outputs (strong architectural move).
+  - Improves long-term maintainability with documentation set (`ARCHITECTURE`, `EXECUTION_MODEL`, `PROCESS_SYSTEM`, etc.).
+  - Keeps refactor scope focused on rule-engine contracts and behavior.
+- **Anti-patterns / concerns**
+  - Replaces/changes some API return behavior in ways that may surprise current Vue consumers if expectations were tied to earlier payload shape.
+  - Removes v3 RC matrix/validation artifacts; loses some explicitly curated regression checks.
+- **Risk**
+  - Best long-term architecture of the four, but should not ship without reintegrating stronger validation suite.
+
+## 3) Rule Engine Evaluation (Cross-Branch)
+
+| Criterion | Best branch | Why |
+|---|---|---|
+| Extensibility (new action/rule types) | `rc_refactor_v4` | Cleaner sub-rule boundary and clearer contracts make extension safer. |
+| Maintainability | `rc_refactor_v4` | Better encapsulation + architecture docs reduce tribal knowledge risk. |
+| Logic vs UI separation | `rc_refactor_version_2` / `rc_refactor_v4` tie | v2 reduced UI alias churn; v4 strengthens backend boundaries. |
+| Data-driven vs hardcoded | `rc_refactor_v4` | More explicit rule execution semantics and handler behavior. |
+| Execution efficiency | `rc_refactor_v4` | Copy-on-write overlay avoids excessive deep-copy while preventing accidental parent mutation. |
+
+## 4) Final Recommendation
+
+## ⚠️ Recommend a HYBRID approach
+
+Use **`rc_refactor_v4` as the base**, then selectively reintroduce high-value assets from earlier branches:
+
+1. From **`rc_refactor_v3`**:
+   - Re-add `flexirule/ruleflow/tests/test_rc_validation.py`
+   - Re-add `flexirule/ruleflow/tests/RC_FEATURE_MATRIX.md`
+   - Re-add `flexirule/ruleflow/tests/production_rules.md`
+   - **Why:** preserves explicit RC regression intent and real-rule verification matrix.
+
+2. From **`rc_refactor_version_2`**:
+   - Reconcile deterministic execution payload pathway in `flexirule/ruleflow/api.py` + `flexirule/ruleflow/core/engine.py` where it improves API predictability.
+   - **Why:** v2 direction favored deterministic responses and reduced ambiguity.
+
+3. Keep from **`rc_refactor_v4`**:
+   - `flexirule/ruleflow/core/action_handlers/sub_rule.py` sub-rule overlay + namespaced output semantics.
+   - `docs/*.md` architecture and rule-authoring docs.
+   - **Why:** strongest long-term maintainability and extension safety.
+
+## 5) Refactoring Strategy (Phased)
+
+### Phase 0 — Stabilization Baseline (1 sprint)
+- Branch from `rc_refactor_v4`.
+- Cherry-pick/recreate v3 validation artifacts.
+- Define API contract snapshots for critical methods (`test_rule`, `get_action_context_schema`, execution result payload).
+
+### Phase 1 — Dead Code & Duplicate Removal (1 sprint)
+- Run `vulture`/`ruff` guided cleanup for obvious unused imports/variables.
+- Remove compatibility aliases still lingering in frontend payload transforms.
+- Add CI guard: fail on reintroduced duplicate compatibility fields.
+
+### Phase 2 — DocType Standardization (1–2 sprints)
+- Enforce naming conventions:
+  - DocType names: Title Case
+  - fieldnames: snake_case
+  - child-table link fields standardized (`parent`, `parenttype`, `parentfield` usage patterns)
+- Normalize field types for rule/action semantics (e.g., unify `Data` vs semantic typed fields where applicable).
+- Add schema assertions for required relationships (`Rule` -> `Rule Action`, process references, sub-rule references).
+
+### Phase 3 — API Normalization (1 sprint)
+- Publish a strict versioned API schema for frontend consumption:
+  - request payload DTOs
+  - response DTOs
+  - error envelope standardization
+- Remove fallback/legacy keys from API once Vue adapter is migrated.
+
+### Phase 4 — Vue 3 Architecture Hardening (1–2 sprints)
+- Split rule builder into layers:
+  - view components
+  - composables (interaction logic)
+  - domain services/adapters (API + mapping)
+- Keep Pinia store thin: orchestration only, no heavy normalization logic.
+- Centralize serializer/deserializer mapping in one adapter module.
+
+### Phase 5 — Rule Engine Decoupling (2 sprints)
+- Introduce explicit engine interfaces:
+  - `RuleRepository`
+  - `ActionExecutor`
+  - `ContextStore`
+  - `TraceLogger`
+- Keep Frappe IO at infrastructure layer; domain engine pure-Python where possible.
+- Add plugin registration for new action handlers via registry contracts.
+
+### Phase 6 — Regression Gates (continuous)
+- CI lanes:
+  - lint + semgrep
+  - unit (engine/contracts)
+  - integration (doctype + API)
+  - real-rules snapshot tests
+- Add performance budget checks for large rule graphs.
+
+## 6) Future-Proof Target Architecture
+
+### Suggested Folder Structure
+
+```text
+flexirule/
+  ruleflow/
+    domain/
+      engine/
+      rules/
+      actions/
+      contracts/
+    application/
+      services/
+      use_cases/
+    infrastructure/
+      frappe_repos/
+      frappe_api/
+      persistence/
+      logging/
+    interfaces/
+      api/
+      schedulers/
+      workers/
+  public/js/flexirule/
+    rule_builder/
+      ui/
+        components/
+        pages/
+      domain/
+        models/
+        policies/
+      data/
+        api/
+        mappers/
+      state/
+        stores/
+      composables/
+```
+
+### Layered Architecture
+- **UI layer (Vue):** rendering + user interaction only.
+- **Domain layer (rule engine):** rule graph evaluation, action contracts, context transitions.
+- **Data/integration layer:** Frappe DocType access, whitelisted API methods, serialization.
+
+### Rule Engine Abstraction Model
+- `IRuleCompiler`: graph validation + normalized execution plan.
+- `IRuleExecutor`: deterministic execution with explicit context in/out.
+- `IActionHandler`: plugin interface for action types.
+- `IContextNamespacePolicy`: governs variable scoping (global, action-local, sub-rule namespace).
+- `ITraceSink`: emits execution trace for logs/UI.
+
+This model minimizes future RC refactors by making action-type growth plugin-driven and contract-verified rather than store-driven ad hoc branching.
+
+## 7) Additional Findings from Lint/SAST Setup
+- Pre-commit/lint stack runs successfully on current tree.
+- Semgrep (Frappe rules + `r/python.lang.correctness`) returns blocking findings inherited from current codebase (manual commits, realtime publish scope, file traversal hotspots, translation issues). These should be treated as mandatory remediation backlog before release hardening.


### PR DESCRIPTION
### Motivation
- Provide a single, engineer-facing artifact that compares the four RC refactor branches, closes knowledge gaps, and gives a clear migration/refactor recommendation and roadmap for the rule-engine (Frappe + Vue 3) app.
- Surface immediate lint/SAST findings and testing gaps so the chosen refactor direction can be hardened before release.

### Description
- Add `RC_REFACTOR_BRANCH_ARCHITECTURE_REVIEW.md` containing a comparison matrix, per-branch findings (dead code, anti-patterns, DocType/API observations), a decisive recommendation (HYBRID: use `rc_refactor_v4` as base, restore validation artifacts from `rc_refactor_v3`, reconcile deterministic payloads from `rc_refactor_version_2`), a phased refactor roadmap, and a target architecture blueprint (folder layout + abstractions).
- Commit message: `docs: add RC refactor branch architecture comparison and roadmap`; new file created at repository root.
- Captured and documented the lint/SAST posture and tooling outputs used to evaluate branches so remediation tasks are explicit in the roadmap.

### Testing
- Ran `pre-commit run --all-files`; outcome: passed (pre-commit/linters succeeded on current tree).
- Ran `semgrep ci --config /tmp/frappe-semgrep-rules/rules --config r/python.lang.correctness`; outcome: executed but produced blocking findings (security/translation/manual-commit/realtime rules) which are recorded as a remediation backlog and cause the semgrep check to fail.
- Ran `vulture` scans for unused code to surface dead-code candidates; outcome: produced a small set of unused imports/variables for follow-up cleanup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d03c02a0f8832f814df61e39c1269f)