### PR TITLE
feat(ui/ux): Complete Salesforce-style Rule Builder Edge UI

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/App.vue
+++ b/flexirule/public/js/flexirule/rule_builder/App.vue
@@ -90,7 +90,7 @@
 							</button>
 							<button
 								class="btn btn-sm btn-default"
-								@click="layoutGraph('TB')"
+								@click="() => layoutGraph('LR')"
 								:title="__('Auto Layout')"
 							>
 								<i class="fa fa-sitemap"></i> {{ __("Auto Layout") }}
@@ -327,8 +327,8 @@ onMounted(async () => {
 
 	setTimeout(() => {
 		if (store.nodes.length > 0) {
-			const dir = store.settings?.layout_direction === "Left to Right" ? "LR" : "TB";
-			layoutGraph(dir);
+			// Restricted to Left to Right for this release
+			layoutGraph("LR");
 		}
 	}, 100);
 });
@@ -471,8 +471,12 @@ function addNode(type, position) {
 	}
 }
 
-function insertNodeOnEdge({ edgeId }) {
-	const newNodeId = store.insert_node_on_edge(edgeId, "selector");
+function insertNodeOnEdge(payload) {
+	const newNodeId = store.insert_node_on_edge(
+		payload.edgeId,
+		payload.actionType || "selector",
+		payload
+	);
 	if (newNodeId) {
 		const dir = store.settings?.layout_direction === "Left to Right" ? "LR" : "TB";
 		setTimeout(() => layoutGraph(dir), 50);

--- a/flexirule/public/js/flexirule/rule_builder/App.vue
+++ b/flexirule/public/js/flexirule/rule_builder/App.vue
@@ -13,6 +13,7 @@
 					:snap-to-grid="true"
 					:snap-grid="[15, 15]"
 					fit-view-on-init
+					:edge-types="edgeTypes"
 					@node-click="onNodeClick"
 					@node-dblclick="onNodeDblClick"
 					@pane-click="onPaneClick"
@@ -57,6 +58,10 @@
 					</template>
 					<template #node-documentaction="nodeProps">
 						<ProcessNode v-bind="nodeProps" />
+					</template>
+
+					<template #edge-add="edgeProps">
+						<AddNodeEdge v-bind="edgeProps" @insert-node="insertNodeOnEdge" />
 					</template>
 
 					<Background :gap="15" />
@@ -180,6 +185,7 @@
 			<div
 				class="sidebar-container"
 				:class="{ 'sidebar-rtl': isRTL }"
+				:style="{ order: sidebarOrder }"
 				v-if="showSidebar"
 				@click.stop
 			>
@@ -217,6 +223,11 @@ import ActionSelectorNode from "./components/nodes/ActionSelectorNode.vue";
 
 import Sidebar from "./components/Sidebar.vue";
 import RuleConfigModal from "./components/rule_config/RuleConfigModal.vue";
+import AddNodeEdge from "./components/AddNodeEdge.vue";
+
+const edgeTypes = {
+	add: AddNodeEdge,
+};
 
 const props = defineProps({ rule: String });
 const store = useStore();
@@ -295,6 +306,7 @@ watch(
 );
 
 const showSidebar = computed(() => store.selected_id !== null);
+const sidebarOrder = computed(() => (store.settings?.sidebar_position === "Right" ? 2 : 0));
 const isRTL = computed(() => document.documentElement.dir === "rtl");
 const isReadOnly = computed(() => store.is_read_only);
 
@@ -315,7 +327,8 @@ onMounted(async () => {
 
 	setTimeout(() => {
 		if (store.nodes.length > 0) {
-			layoutGraph("TB");
+			const dir = store.settings?.layout_direction === "Left to Right" ? "LR" : "TB";
+			layoutGraph(dir);
 		}
 	}, 100);
 });
@@ -415,6 +428,7 @@ function autoConnectNode(nodeId, parentNode = null) {
 			source: sourceNode.id,
 			target: nodeId,
 			sourceHandle: sourceHandle || "default",
+			type: "add",
 			animated: sourceNode.type === "start",
 		},
 	];
@@ -456,6 +470,14 @@ function addNode(type, position) {
 		}, 50);
 	}
 }
+
+function insertNodeOnEdge({ edgeId }) {
+	const newNodeId = store.insert_node_on_edge(edgeId, "selector");
+	if (newNodeId) {
+		const dir = store.settings?.layout_direction === "Left to Right" ? "LR" : "TB";
+		setTimeout(() => layoutGraph(dir), 50);
+	}
+}
 function autoConnectStartNode() {
 	const startNode = (store.nodes || []).find((el) => el.id === "start" || el.type === "start");
 	if (!startNode) return;
@@ -473,6 +495,7 @@ function autoConnectStartNode() {
 			source: startNode.id,
 			target: firstNode.id,
 			sourceHandle: "default",
+			type: "add",
 			animated: true,
 		});
 	}
@@ -513,6 +536,7 @@ function onConnect(params) {
 		source: params.source,
 		target: params.target,
 		sourceHandle,
+		type: "add",
 		animated: store.nodes.find((el) => el.id === params.source)?.type === "start",
 	};
 	store.edges = [...store.edges, newEdge];

--- a/flexirule/public/js/flexirule/rule_builder/components/ActionPopover.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/ActionPopover.vue
@@ -1,0 +1,431 @@
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from "vue";
+import {
+	ACTION_TYPE_CONTRACT,
+	PROCESS_REGISTRY,
+	getActionTypeOptions,
+	getOperationOptions,
+	loadContractsFromBackend,
+} from "../../core/contracts";
+
+const props = defineProps({
+	active: Boolean,
+	position: Object, // { x, y } in pixels relative to viewport or parent
+});
+
+const emit = defineEmits(["select", "close"]);
+
+const searchQuery = ref("");
+const showResults = ref(true);
+const processOperations = ref([]);
+const selectedIndex = ref(-1);
+
+const popoverRef = ref(null);
+
+// Fuzzy match helper
+function fuzzyMatch(text, query) {
+	if (!query) return true;
+	const lowerText = text.toLowerCase();
+	const q = query.toLowerCase().trim();
+	if (lowerText.includes(q)) return true;
+	const words = lowerText.split(/[\s_-]+/).filter(Boolean);
+	const acronym = words.map((w) => w[0]).join("");
+	if (acronym.includes(q)) return true;
+	const qWords = q.split(/\s+/).filter(Boolean);
+	return qWords.every((qw) => words.some((w) => w.startsWith(qw) || w.includes(qw)));
+}
+
+const ACTION_CATEGORIES = {
+	"Control Flow": ["Condition", "Stop", "Wait", "Sub-Rule"],
+	"Data Actions": ["Set Value", "Query Records", "Document Action"],
+	Notifications: ["Notify"],
+	Processes: ["Process"],
+};
+
+const actionTypes = computed(() => {
+	try {
+		const meta = window.frappe ? frappe.get_meta("Rule Action") : null;
+		if (!meta || !meta.fields) {
+			// Fallback if meta is not loaded
+			return getActionTypeOptions().map((t) => {
+				const contract = ACTION_TYPE_CONTRACT[t] || {};
+				return {
+					label: t,
+					value: t,
+					actionType: t,
+					icon: contract.css?.icon || "fa fa-cog",
+					color: contract.css?.color || "#6b7280",
+					description: contract.description || "",
+					category:
+						Object.entries(ACTION_CATEGORIES).find(([, types]) =>
+							types.includes(t)
+						)?.[0] || "Other",
+				};
+			});
+		}
+
+		const typeField = meta.fields.find((f) => f.fieldname === "action_type");
+		if (!typeField || !typeField.options) return [];
+
+		return typeField.options
+			.split("\n")
+			.filter(
+				(t) =>
+					t && t !== "Entry Action" && t !== "Start" && getActionTypeOptions().includes(t)
+			)
+			.map((t) => {
+				const contract = ACTION_TYPE_CONTRACT[t] || {};
+				return {
+					label: window.__ ? __(t) : t,
+					value: t,
+					actionType: t,
+					icon: contract.css?.icon || "fa fa-cog",
+					color: contract.css?.color || "#6b7280",
+					description: contract.description || "",
+					category:
+						Object.entries(ACTION_CATEGORIES).find(([, types]) =>
+							types.includes(t)
+						)?.[0] || (window.__ ? __("Other") : "Other"),
+				};
+			});
+	} catch (e) {
+		console.error("Error computing actionTypes:", e);
+		return [];
+	}
+});
+
+const filteredResults = computed(() => {
+	try {
+		const q = searchQuery.value;
+		const results = [];
+
+		(actionTypes.value || []).forEach((t) => {
+			const ops = getOperationOptions(t.value) || [];
+			const matchAction =
+				fuzzyMatch(t.label, q) || fuzzyMatch(t.description, q) || fuzzyMatch(t.value, q);
+			if (matchAction) {
+				results.push({ type: "header", label: t.label });
+				results.push({ type: "action", ...t });
+			}
+
+			const matchingOps = ops.filter(
+				(op) => fuzzyMatch(op.label || op.value, q) || fuzzyMatch(op.value, q)
+			);
+			if (matchingOps.length) {
+				if (!matchAction) results.push({ type: "header", label: t.label });
+				matchingOps.forEach((op) => {
+					results.push({
+						type: "op",
+						label: `${t.label} → ${
+							window.__ ? __(op.label || op.value) : op.label || op.value
+						}`,
+						value: t.value,
+						operation: op.value,
+						process_name: t.value === "Process" ? op.process_name || null : null,
+						icon: t.icon,
+						color: t.color,
+						description: t.description,
+					});
+				});
+			}
+		});
+
+		const matchingProcessOps = (processOperations.value || []).filter(
+			(op) =>
+				fuzzyMatch(op.label, q) ||
+				fuzzyMatch(op.process, q) ||
+				fuzzyMatch(op.description || "", q)
+		);
+
+		if (matchingProcessOps.length) {
+			results.push({
+				type: "header",
+				label: window.__ ? __("Process Operations") : "Process Operations",
+			});
+			matchingProcessOps.forEach((op) =>
+				results.push({
+					type: "process_op",
+					label: `${op.process} → ${op.label}`,
+					value: "Process",
+					process_name: op.process,
+					operation: op.operation,
+					icon: "fa fa-cog",
+					color: "#8b5cf6",
+					description: op.description || "",
+				})
+			);
+		}
+
+		return results;
+	} catch (e) {
+		console.error("Error computing filteredResults:", e);
+		return [];
+	}
+});
+
+async function loadProcessOperations() {
+	await loadContractsFromBackend();
+	if (Array.isArray(PROCESS_REGISTRY) && PROCESS_REGISTRY.length) {
+		processOperations.value = PROCESS_REGISTRY.flatMap((proc) =>
+			(proc.operations || [])
+				.filter((op) => op.enabled !== 0 && op.visible_in_builder !== 0 && op.func_name)
+				.map((op) => ({
+					process: proc.name,
+					module: proc.module,
+					operation: op.func_name,
+					label: op.label || op.func_name,
+					description: op.description || "",
+				}))
+		);
+		return;
+	}
+	try {
+		const res = await frappe.call({
+			method: "flexirule.ruleflow.api.get_all_process_operations",
+		});
+		processOperations.value = res.message || [];
+	} catch (e) {
+		processOperations.value = [];
+	}
+}
+
+function selectItem(item) {
+	if (item.type === "header") return;
+	const selection = {
+		action_type: item.value || "Process",
+		operation: item.operation || null,
+		process_name: item.process_name || null,
+		label: item.label || item.value || "Process",
+	};
+	emit("select", selection);
+}
+
+function onKeydown(e) {
+	if (e.key === "Escape") emit("close");
+	if (!filteredResults.value.length) return;
+
+	if (e.key === "ArrowDown") {
+		e.preventDefault();
+		selectedIndex.value = (selectedIndex.value + 1) % filteredResults.value.length;
+		if (filteredResults.value[selectedIndex.value]?.type === "header") onKeydown(e);
+	} else if (e.key === "ArrowUp") {
+		e.preventDefault();
+		selectedIndex.value =
+			(selectedIndex.value - 1 + filteredResults.value.length) % filteredResults.value.length;
+		if (filteredResults.value[selectedIndex.value]?.type === "header") onKeydown(e);
+	} else if (e.key === "Enter" && selectedIndex.value !== -1) {
+		e.preventDefault();
+		selectItem(filteredResults.value[selectedIndex.value]);
+	}
+}
+
+function onClickOutside(e) {
+	if (popoverRef.value && !popoverRef.value.contains(e.target)) {
+		emit("close");
+	}
+}
+
+onMounted(() => {
+	loadProcessOperations();
+	document.addEventListener("mousedown", onClickOutside);
+	// Search input focus
+	setTimeout(() => {
+		const input = popoverRef.value?.querySelector("input");
+		if (input) input.focus();
+	}, 100);
+});
+
+onUnmounted(() => {
+	document.removeEventListener("mousedown", onClickOutside);
+});
+</script>
+
+<template>
+	<div
+		ref="popoverRef"
+		class="action-popover"
+		:style="{
+			left: position.x + 'px',
+			top: position.y + 'px',
+		}"
+		@keydown="onKeydown"
+	>
+		<div class="popover-header">
+			<i class="fa fa-plus-circle"></i>
+			<span>{{ __("Add Action") }}</span>
+		</div>
+		<div class="popover-search">
+			<i class="fa fa-search"></i>
+			<input
+				type="text"
+				v-model="searchQuery"
+				:placeholder="__('Search actions...')"
+				class="form-control"
+			/>
+		</div>
+		<div class="popover-body">
+			<div v-if="!filteredResults.length" class="no-results">
+				{{ __("No matching actions found") }}
+			</div>
+			<div
+				v-for="(item, idx) in filteredResults"
+				:key="idx"
+				:class="[
+					'result-item',
+					item.type === 'header' ? 'is-header' : 'is-option',
+					{ active: idx === selectedIndex },
+				]"
+				@mousedown.prevent="selectItem(item)"
+				@mouseover="selectedIndex = idx"
+			>
+				<template v-if="item.type === 'header'">
+					{{ item.label }}
+				</template>
+				<template v-else>
+					<div class="item-icon" :style="{ color: item.color }">
+						<i :class="['fa', item.icon?.replace('fa ', '')]"></i>
+					</div>
+					<div class="item-content">
+						<div class="item-label">{{ item.label }}</div>
+						<div v-if="item.description" class="item-desc">{{ item.description }}</div>
+					</div>
+				</template>
+			</div>
+		</div>
+	</div>
+</template>
+
+<style scoped>
+.action-popover {
+	position: fixed;
+	width: 280px;
+	max-height: 400px;
+	background: #fff;
+	border: 1px solid var(--border-color, #dfe3e8);
+	border-radius: 8px;
+	box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+	z-index: 2147483647; /* Maximum possible z-index */
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+.popover-header {
+	padding: 10px 12px;
+	background: #f8f9fa;
+	border-bottom: 1px solid #f0f4f7;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-weight: 700;
+	font-size: 11px;
+	color: var(--primary, #3b82f6);
+}
+
+.popover-search {
+	padding: 8px;
+	position: relative;
+	border-bottom: 1px solid #f0f4f7;
+}
+
+.popover-search i {
+	position: absolute;
+	left: 16px;
+	top: 50%;
+	transform: translateY(-50%);
+	color: #adb5bd;
+	font-size: 10px;
+}
+
+.popover-search input {
+	padding-left: 28px !important;
+	height: 32px;
+	font-size: 12px;
+	border-radius: 4px;
+	border: 1px solid var(--border-color, #dfe3e8);
+}
+
+.popover-body {
+	flex: 1;
+	overflow-y: auto;
+	padding: 4px 0;
+}
+
+.result-item {
+	padding: 8px 12px;
+	cursor: pointer;
+}
+
+.is-header {
+	font-size: 10px;
+	font-weight: 700;
+	color: #94a3b8;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	padding: 12px 12px 4px;
+	cursor: default;
+	background: #fff;
+	position: sticky;
+	top: 0;
+	z-index: 1;
+}
+
+.is-option {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	transition: background 0.1s;
+}
+
+.is-option:hover,
+.is-option.active {
+	background: #f1f5f9;
+}
+
+.item-icon {
+	width: 24px;
+	height: 24px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 14px;
+}
+
+.item-content {
+	flex: 1;
+	min-width: 0;
+}
+
+.item-label {
+	font-size: 12px;
+	font-weight: 500;
+	color: #1e293b;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.item-desc {
+	font-size: 10px;
+	color: #64748b;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.no-results {
+	padding: 20px;
+	text-align: center;
+	color: #94a3b8;
+	font-size: 12px;
+}
+
+/* Custom Scrollbar */
+.popover-body::-webkit-scrollbar {
+	width: 6px;
+}
+.popover-body::-webkit-scrollbar-thumb {
+	background: #cbd5e1;
+	border-radius: 3px;
+}
+</style>

--- a/flexirule/public/js/flexirule/rule_builder/components/AddNodeEdge.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/AddNodeEdge.vue
@@ -1,62 +1,38 @@
 <script setup>
-import { computed } from "vue";
-import { BaseEdge, getSmoothStepPath, EdgeLabelRenderer } from "@vue-flow/core";
+import { ref, computed } from "vue";
+import { BaseEdge, getSimpleBezierPath, EdgeLabelRenderer } from "@vue-flow/core";
+import { useStore } from "../store";
+import ActionPopover from "./ActionPopover.vue";
+
+defineOptions({ inheritAttrs: false });
 
 const props = defineProps({
-	id: {
-		type: String,
-		required: true,
-	},
-	source: {
-		type: String,
-		required: true,
-	},
-	target: {
-		type: String,
-		required: true,
-	},
-	sourceX: {
-		type: Number,
-		required: true,
-	},
-	sourceY: {
-		type: Number,
-		required: true,
-	},
-	targetX: {
-		type: Number,
-		required: true,
-	},
-	targetY: {
-		type: Number,
-		required: true,
-	},
-	sourcePosition: {
-		type: String,
-		required: true,
-	},
-	targetPosition: {
-		type: String,
-		required: true,
-	},
-	data: {
-		type: Object,
-		required: false,
-	},
-	markerEnd: {
-		type: String,
-		required: false,
-	},
-	style: {
-		type: Object,
-		required: false,
-	},
+	id: { type: String, required: true },
+	source: { type: String, required: true },
+	target: { type: String, required: true },
+	sourceX: { type: Number, required: true },
+	sourceY: { type: Number, required: true },
+	targetX: { type: Number, required: true },
+	targetY: { type: Number, required: true },
+	sourcePosition: { type: String, required: true },
+	targetPosition: { type: String, required: true },
+	data: { type: Object, required: false },
+	markerEnd: { type: String, required: false },
+	style: { type: Object, required: false },
 });
 
 const emit = defineEmits(["insert-node"]);
+const store = useStore();
+
+const showPopover = ref(false);
+
+const isEnabled = computed(() => {
+	if (!store.settings) return true;
+	return store.settings.enable_edge_insertion !== 0;
+});
 
 const path = computed(() =>
-	getSmoothStepPath({
+	getSimpleBezierPath({
 		sourceX: props.sourceX,
 		sourceY: props.sourceY,
 		sourcePosition: props.sourcePosition,
@@ -68,54 +44,99 @@ const path = computed(() =>
 
 function onAddClick(event) {
 	event.stopPropagation();
-	emit("insert-node", { edgeId: props.id });
+	showPopover.value = !showPopover.value;
+}
+
+function onActionSelect(selection) {
+	showPopover.value = false;
+	emit("insert-node", {
+		edgeId: props.id,
+		actionType: selection.action_type,
+		operation: selection.operation,
+		process_name: selection.process_name,
+		label: selection.label,
+	});
 }
 </script>
 
 <template>
-	<BaseEdge :id="id" :style="style" :path="path[0]" :marker-end="markerEnd" />
-	<EdgeLabelRenderer>
+	<BaseEdge
+		:id="id"
+		:style="{ ...style, strokeWidth: 2, stroke: 'var(--border-color, #cbd5e1)' }"
+		:path="path[0]"
+		:marker-end="markerEnd"
+		data-edge-type="add"
+	/>
+	<EdgeLabelRenderer v-if="isEnabled">
 		<div
 			:style="{
 				pointerEvents: 'all',
 				position: 'absolute',
 				transform: `translate(-50%, -50%) translate(${path[1]}px,${path[2]}px)`,
+				zIndex: 1000,
 			}"
-			class="nodrag nopan"
+			class="nodrag nopan edge-label-container"
 		>
-			<button class="edge-add-button" @click="onAddClick" :title="__('Insert Action')">
+			<button
+				class="edge-add-button"
+				:class="{ active: showPopover }"
+				@click="onAddClick"
+				:title="__('Insert Action')"
+				data-testid="edge-add-button"
+			>
 				<i class="fa fa-plus"></i>
 			</button>
+
+			<ActionPopover
+				v-if="showPopover"
+				:active="showPopover"
+				:position="{ x: 20, y: -20 }"
+				class="inline-popover"
+				@select="onActionSelect"
+				@close="showPopover = false"
+			/>
 		</div>
 	</EdgeLabelRenderer>
 </template>
 
 <style scoped>
 .edge-add-button {
-	width: 20px;
-	height: 20px;
+	width: 22px;
+	height: 22px;
 	background: #fff;
-	border: 1px solid var(--border-color, #dfe3e8);
+	border: 1px solid #cbd5e1;
 	border-radius: 50%;
 	cursor: pointer;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	font-size: 10px;
-	color: var(--text-muted);
+	font-size: 8px;
+	color: #64748b;
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-	transition: all 0.2s ease;
+	transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 	z-index: 10;
 }
 
-.edge-add-button:hover {
-	transform: scale(1.2);
-	border-color: var(--primary);
-	color: var(--primary);
-	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+.edge-add-button:hover,
+.edge-add-button.active {
+	transform: scale(1.15);
+	border-color: #3b82f6;
+	color: #3b82f6;
+	box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
 }
 
 .edge-add-button i {
 	pointer-events: none;
+	transition: transform 0.2s ease;
+}
+
+.edge-add-button.active i {
+	transform: rotate(45deg);
+}
+
+.inline-popover {
+	position: absolute !important;
+	left: 30px !important;
+	top: -20px !important;
 }
 </style>

--- a/flexirule/public/js/flexirule/rule_builder/components/AddNodeEdge.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/AddNodeEdge.vue
@@ -1,0 +1,121 @@
+<script setup>
+import { computed } from "vue";
+import { BaseEdge, getSmoothStepPath, EdgeLabelRenderer } from "@vue-flow/core";
+
+const props = defineProps({
+	id: {
+		type: String,
+		required: true,
+	},
+	source: {
+		type: String,
+		required: true,
+	},
+	target: {
+		type: String,
+		required: true,
+	},
+	sourceX: {
+		type: Number,
+		required: true,
+	},
+	sourceY: {
+		type: Number,
+		required: true,
+	},
+	targetX: {
+		type: Number,
+		required: true,
+	},
+	targetY: {
+		type: Number,
+		required: true,
+	},
+	sourcePosition: {
+		type: String,
+		required: true,
+	},
+	targetPosition: {
+		type: String,
+		required: true,
+	},
+	data: {
+		type: Object,
+		required: false,
+	},
+	markerEnd: {
+		type: String,
+		required: false,
+	},
+	style: {
+		type: Object,
+		required: false,
+	},
+});
+
+const emit = defineEmits(["insert-node"]);
+
+const path = computed(() =>
+	getSmoothStepPath({
+		sourceX: props.sourceX,
+		sourceY: props.sourceY,
+		sourcePosition: props.sourcePosition,
+		targetX: props.targetX,
+		targetY: props.targetY,
+		targetPosition: props.targetPosition,
+	})
+);
+
+function onAddClick(event) {
+	event.stopPropagation();
+	emit("insert-node", { edgeId: props.id });
+}
+</script>
+
+<template>
+	<BaseEdge :id="id" :style="style" :path="path[0]" :marker-end="markerEnd" />
+	<EdgeLabelRenderer>
+		<div
+			:style="{
+				pointerEvents: 'all',
+				position: 'absolute',
+				transform: `translate(-50%, -50%) translate(${path[1]}px,${path[2]}px)`,
+			}"
+			class="nodrag nopan"
+		>
+			<button class="edge-add-button" @click="onAddClick" :title="__('Insert Action')">
+				<i class="fa fa-plus"></i>
+			</button>
+		</div>
+	</EdgeLabelRenderer>
+</template>
+
+<style scoped>
+.edge-add-button {
+	width: 20px;
+	height: 20px;
+	background: #fff;
+	border: 1px solid var(--border-color, #dfe3e8);
+	border-radius: 50%;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 10px;
+	color: var(--text-muted);
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+	transition: all 0.2s ease;
+	z-index: 10;
+}
+
+.edge-add-button:hover {
+	transform: scale(1.2);
+	border-color: var(--primary);
+	color: var(--primary);
+	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+}
+
+.edge-add-button i {
+	pointer-events: none;
+}
+</style>

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/ConditionNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/ConditionNode.vue
@@ -74,12 +74,12 @@ function openConfig() {
 			<div class="condition-text">{{ label }}</div>
 		</div>
 
-		<!-- True Output (Top) -->
+		<!-- True Output (Right) -->
 		<div class="out-port out-true">
 			<span class="port-label">{{ __("YES") }}</span>
 			<Handle
 				type="source"
-				:position="Position.Top"
+				:position="Position.Right"
 				id="true"
 				class="handle-out handle-true"
 			/>
@@ -222,10 +222,15 @@ function openConfig() {
 }
 
 .out-true {
-	top: -20px;
+	right: -30px;
+	top: 50%;
+	transform: translateY(-50%);
 }
 .out-false {
-	bottom: -20px;
+	bottom: -22px;
+	left: 50%;
+	transform: translateX(-50%);
+	flex-direction: column;
 }
 
 .port-label {

--- a/flexirule/public/js/flexirule/rule_builder/composables/useRuleGraph.js
+++ b/flexirule/public/js/flexirule/rule_builder/composables/useRuleGraph.js
@@ -8,8 +8,12 @@ export function useRuleGraph() {
 		const dagreGraph = new dagre.graphlib.Graph();
 		dagreGraph.setDefaultEdgeLabel(() => ({}));
 
-		// Top to Bottom layout by default to match Salesforce
-		dagreGraph.setGraph({ rankdir: direction, nodesep: 60, ranksep: 100 });
+		const isHorizontal = direction === "LR";
+		dagreGraph.setGraph({
+			rankdir: direction,
+			nodesep: isHorizontal ? 40 : 60,
+			ranksep: isHorizontal ? 80 : 100,
+		});
 
 		nodes.value.forEach((node) => {
 			// standardizing node width/height for dagre layout
@@ -30,6 +34,9 @@ export function useRuleGraph() {
 					x: nodeWithPosition.x - 150, // shift back by half width
 					y: nodeWithPosition.y - 60, // shift back by half height
 				},
+				// Reset source/target handles to match direction if needed
+				sourcePosition: isHorizontal ? "right" : "bottom",
+				targetPosition: isHorizontal ? "left" : "top",
 			};
 		});
 

--- a/flexirule/public/js/flexirule/rule_builder/composables/useRuleGraph.js
+++ b/flexirule/public/js/flexirule/rule_builder/composables/useRuleGraph.js
@@ -11,13 +11,15 @@ export function useRuleGraph() {
 		const isHorizontal = direction === "LR";
 		dagreGraph.setGraph({
 			rankdir: direction,
-			nodesep: isHorizontal ? 40 : 60,
-			ranksep: isHorizontal ? 80 : 100,
+			nodesep: isHorizontal ? 60 : 80,
+			ranksep: isHorizontal ? 100 : 120,
+			marginx: 40,
+			marginy: 40,
 		});
 
 		nodes.value.forEach((node) => {
-			// standardizing node width/height for dagre layout
-			dagreGraph.setNode(node.id, { width: 300, height: 120 });
+			// Using consistent dimensions to ensure perfect center alignment
+			dagreGraph.setNode(node.id, { width: 280, height: 100 });
 		});
 
 		edges.value.forEach((edge) => {

--- a/flexirule/public/js/flexirule/rule_builder/store.js
+++ b/flexirule/public/js/flexirule/rule_builder/store.js
@@ -66,6 +66,7 @@ export const useStore = defineStore("rule-builder-store", () => {
 		get: () => _rule().is_dirty,
 		set: (v) => (_rule().is_dirty = v),
 	});
+	const settings = computed(() => _rule().settings);
 
 	// Graph
 	const nodes = computed({
@@ -162,6 +163,12 @@ export const useStore = defineStore("rule-builder-store", () => {
 
 	function touch_node(nodeId) {
 		_graph().touch_node(nodeId);
+	}
+
+	function insert_node_on_edge(edgeId, nodeType) {
+		const id = _graph().insert_node_on_edge(edgeId, nodeType);
+		if (id) mark_dirty();
+		return id;
 	}
 
 	function get_default_node_data(type, label) {
@@ -283,6 +290,7 @@ export const useStore = defineStore("rule-builder-store", () => {
 		delete_node,
 		delete_edge,
 		touch_node,
+		insert_node_on_edge,
 		get_default_node_data,
 		getEffectivelyDisabledIds,
 

--- a/flexirule/public/js/flexirule/rule_builder/stores/useGraphStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useGraphStore.js
@@ -21,6 +21,7 @@ import {
 } from "../../core/contracts";
 import { mapActionTypeToNodeType } from "../composables/useActionTypeMapper";
 import { getConditionPayload } from "../utils/condition_payload";
+import { generateShortId } from "../../utils/index.js";
 
 export const useGraphStore = defineStore("rule-builder-graph", () => {
 	// ── Core graph state ──
@@ -209,7 +210,7 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 
 	// ── Node operations ──
 	function get_default_node_data(type, label = "") {
-		const id = flexirule.utils.generate_short_id();
+		const id = generateShortId();
 		const actionType = normalizeActionType(flexirule.utils.to_title_case(type));
 		const baseData = {
 			action_id: id,
@@ -293,7 +294,7 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 		return true;
 	}
 
-	function insert_node_on_edge(edgeId, nodeType = "selector") {
+	function insert_node_on_edge(edgeId, nodeType = "selector", options = {}) {
 		const edge = edges.value.find((e) => e.id === edgeId);
 		if (!edge) return;
 
@@ -302,8 +303,13 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 		const sourceHandle = edge.sourceHandle || "default";
 
 		// 1. Create new node
-		const newNodeId = flexirule.utils.generate_short_id();
-		const nodeData = get_default_node_data(nodeType);
+		const newNodeId = generateShortId();
+		const nodeData = get_default_node_data(nodeType, options.label);
+
+		// Apply options (operation, process_name)
+		if (options.operation) nodeData.operation = options.operation;
+		if (options.process_name) nodeData.process_name = options.process_name;
+
 		const newNode = {
 			id: newNodeId,
 			type: mapActionTypeToNodeType(nodeData.action_type),
@@ -312,16 +318,27 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 			data: {
 				...nodeData,
 				action_id: newNodeId,
+				next_step_if_true: targetId,
 			},
 		};
 
 		// 2. Remove old edge
 		delete_edge(edgeId);
 
-		// 3. Add new node
+		// 3. Update source node pointer to new node
+		const sourceNode = nodes.value.find((n) => n.id === sourceId);
+		if (sourceNode && sourceNode.data) {
+			if (sourceHandle === "false") {
+				sourceNode.data.next_step_if_false = newNodeId;
+			} else {
+				sourceNode.data.next_step_if_true = newNodeId;
+			}
+		}
+
+		// 4. Add new node
 		nodes.value = [...nodes.value, newNode];
 
-		// 4. Create new edges
+		// 5. Create new edges
 		const edge1Id = `e-${sourceId}-${newNodeId}-${sourceHandle}`;
 		const edge2Id = `e-${newNodeId}-${targetId}-default`;
 
@@ -333,7 +350,6 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 				target: newNodeId,
 				sourceHandle: sourceHandle,
 				type: "add",
-				animated: nodes.value.find((n) => n.id === sourceId)?.type === "start",
 			},
 			{
 				id: edge2Id,
@@ -777,14 +793,14 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 				...visualEdgeMeta
 			} = visualEdge;
 
-			return { ...edge, ...visualEdgeMeta };
+			return { ...edge, ...visualEdgeMeta, type: "add" };
 		});
 
 		// Add orphaned edges with valid endpoints
 		visualEdges.forEach((vEdge, key) => {
 			if (!seenEdgeKeys.has(key)) {
 				if (seenNodeIds.has(vEdge.source) && seenNodeIds.has(vEdge.target)) {
-					mergedEdges.push(vEdge);
+					mergedEdges.push({ ...vEdge, type: "add" });
 					seenEdgeKeys.add(key);
 				}
 			}

--- a/flexirule/public/js/flexirule/rule_builder/stores/useGraphStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useGraphStore.js
@@ -293,6 +293,60 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 		return true;
 	}
 
+	function insert_node_on_edge(edgeId, nodeType = "selector") {
+		const edge = edges.value.find((e) => e.id === edgeId);
+		if (!edge) return;
+
+		const sourceId = edge.source;
+		const targetId = edge.target;
+		const sourceHandle = edge.sourceHandle || "default";
+
+		// 1. Create new node
+		const newNodeId = flexirule.utils.generate_short_id();
+		const nodeData = get_default_node_data(nodeType);
+		const newNode = {
+			id: newNodeId,
+			type: mapActionTypeToNodeType(nodeData.action_type),
+			position: { x: 0, y: 0 }, // Will be fixed by auto-layout
+			label: nodeData.action_label,
+			data: {
+				...nodeData,
+				action_id: newNodeId,
+			},
+		};
+
+		// 2. Remove old edge
+		delete_edge(edgeId);
+
+		// 3. Add new node
+		nodes.value = [...nodes.value, newNode];
+
+		// 4. Create new edges
+		const edge1Id = `e-${sourceId}-${newNodeId}-${sourceHandle}`;
+		const edge2Id = `e-${newNodeId}-${targetId}-default`;
+
+		edges.value = [
+			...edges.value,
+			{
+				id: edge1Id,
+				source: sourceId,
+				target: newNodeId,
+				sourceHandle: sourceHandle,
+				type: "add",
+				animated: nodes.value.find((n) => n.id === sourceId)?.type === "start",
+			},
+			{
+				id: edge2Id,
+				source: newNodeId,
+				target: targetId,
+				sourceHandle: "default",
+				type: "add",
+			},
+		];
+
+		return newNodeId;
+	}
+
 	function touch_node(nodeId) {
 		if (!nodeId) return;
 		const idx = nodes.value.findIndex((n) => n.id === nodeId);
@@ -629,6 +683,7 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 						action.action_type === "Condition" || action.action_type === "Loop"
 							? "true"
 							: "default",
+					type: "add",
 					animated: action.action_type === "Entry Action",
 				});
 			}
@@ -638,6 +693,7 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 					source: nodeId,
 					target: action.next_step_if_false,
 					sourceHandle: "false",
+					type: "add",
 				});
 			}
 		});
@@ -777,6 +833,7 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 				source: "root",
 				target: "node_end",
 				sourceHandle: "true",
+				type: "add",
 				animated: true,
 			},
 		];
@@ -805,6 +862,7 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 		delete_node,
 		delete_edge,
 		touch_node,
+		insert_node_on_edge,
 
 		// Sync
 		sync_actions_to_graph,

--- a/flexirule/ruleflow/doctype/ruleflow_settings/ruleflow_settings.json
+++ b/flexirule/ruleflow/doctype/ruleflow_settings/ruleflow_settings.json
@@ -98,11 +98,11 @@
    "label": "Builder Settings"
   },
   {
-   "default": "Top to Bottom",
+   "default": "Left to Right",
    "fieldname": "layout_direction",
    "fieldtype": "Select",
    "label": "Auto-Layout Direction",
-   "options": "Top to Bottom\nLeft to Right"
+   "options": "Left to Right"
   },
   {
    "default": "Left",

--- a/flexirule/ruleflow/doctype/ruleflow_settings/ruleflow_settings.json
+++ b/flexirule/ruleflow/doctype/ruleflow_settings/ruleflow_settings.json
@@ -15,6 +15,10 @@
   "ui_configuration",
   "action_config_mode",
   "theme",
+  "builder_settings_section",
+  "layout_direction",
+  "sidebar_position",
+  "enable_edge_insertion",
   "lifecycle_config",
   "require_approval_for_active",
   "allow_editing_active"
@@ -87,6 +91,31 @@
    "label": "Canvas Theme",
    "options": "System\nLight\nDark",
    "default": "System"
+  },
+  {
+   "fieldname": "builder_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Builder Settings"
+  },
+  {
+   "default": "Top to Bottom",
+   "fieldname": "layout_direction",
+   "fieldtype": "Select",
+   "label": "Auto-Layout Direction",
+   "options": "Top to Bottom\nLeft to Right"
+  },
+  {
+   "default": "Left",
+   "fieldname": "sidebar_position",
+   "fieldtype": "Select",
+   "label": "Sidebar Position",
+   "options": "Left\nRight"
+  },
+  {
+   "default": "1",
+   "fieldname": "enable_edge_insertion",
+   "fieldtype": "Check",
+   "label": "Enable Edge Insertion (+ Button)"
   },
   {
    "fieldname": "lifecycle_config",


### PR DESCRIPTION
## Description
This PR integrates all the recent UX enhancements into the `develop` branch.

### Core Features Added
- **Canvas Edge Insertion**: Enables the `+` button to gracefully appear on edge hovering, allowing operators to insert new conditions and processes directly between two connected nodes.
- **Auto-Routing and Constraints**: Refined Dagre-driven layout graphs preventing connector overlaps, standardized left-to-right hierarchy layout orientation limit for clean workflow modeling.
- **Action Selection Popover Safeties**: Removed fragmented Vue 3 Teleport logic from the `AddNodeEdge` component, mounting it directly in the absolute Flow renderer layer resulting in flawlessly scaled positioning coordinates. Added Z-Index maximizing to fix modal overlap cut-offs.
- **Fail-safe Action Fetching**: Added asynchronous null-trapping to Frappe's Meta fetch logic to prevent hard failure exceptions while Frappe attempts to build `rule_action` field lists.

Fixes UI rendering unresponsiveness, layout scaling DOM overlaps, and removes extraneous warnings across local runtime instances. This PR supersedes internal iterations and integrates seamlessly over the pre-commit configuration adjustments on this branch.