### PR TITLE
Fix lint formatting issues from GitHub Actions

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/controls/TextGeneratorControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/TextGeneratorControl.vue
@@ -441,10 +441,16 @@ const editor = new Editor({
 						{ type: "text", text: " " },
 					];
 					if (type === "conditional") {
-						content.push({ type: "logic", attrs: { type, isStart: false, isElse: true, _key: key } });
+						content.push({
+							type: "logic",
+							attrs: { type, isStart: false, isElse: true, _key: key },
+						});
 						content.push({ type: "text", text: " " });
 					}
-					content.push({ type: "logic", attrs: { type, isStart: false, isElse: false, _key: key } });
+					content.push({
+						type: "logic",
+						attrs: { type, isStart: false, isElse: false, _key: key },
+					});
 					editor.chain().focus().insertContentAt(range, content).run();
 				},
 				render: () => createSuggestionRenderer(),

--- a/flexirule/public/js/flexirule/rule_builder/utils/text_generator.js
+++ b/flexirule/public/js/flexirule/rule_builder/utils/text_generator.js
@@ -242,7 +242,12 @@ export function convertSegmentsToHtml(segments, variableOptions = []) {
 				process(seg.then_segments || []);
 
 				if (seg.else_segments && seg.else_segments.length > 0) {
-					const elseAttrs = { type: "conditional", isStart: false, isElse: true, _key: seg._key };
+					const elseAttrs = {
+						type: "conditional",
+						isStart: false,
+						isElse: true,
+						_key: seg._key,
+					};
 					htmlParts.push(
 						`<span data-type="logic" class="tg-badge tg-badge-else" data-logic-type='${encodeData(
 							elseAttrs
@@ -251,7 +256,12 @@ export function convertSegmentsToHtml(segments, variableOptions = []) {
 					process(seg.else_segments);
 				}
 
-				const endAttrs = { type: "conditional", isStart: false, isElse: false, _key: seg._key };
+				const endAttrs = {
+					type: "conditional",
+					isStart: false,
+					isElse: false,
+					_key: seg._key,
+				};
 				htmlParts.push(
 					`<span data-type="logic" class="tg-badge tg-badge-end" data-logic-type='${encodeData(
 						endAttrs

--- a/flexirule/public/js/flexirule/rule_builder/utils/tiptap_extensions.js
+++ b/flexirule/public/js/flexirule/rule_builder/utils/tiptap_extensions.js
@@ -56,7 +56,8 @@ export const LogicNode = Node.create({
 		return {
 			type: {
 				default: "conditional",
-				parseHTML: (el) => decodeData(el.getAttribute("data-logic-type")).type || "conditional",
+				parseHTML: (el) =>
+					decodeData(el.getAttribute("data-logic-type")).type || "conditional",
 			},
 			_key: {
 				default: null,

--- a/flexirule/public/js/flexirule/utils/clipboard.js
+++ b/flexirule/public/js/flexirule/utils/clipboard.js
@@ -1,15 +1,18 @@
 export function copyText(text) {
 	if (!text) return;
-	
+
 	// Try native API first
 	if (navigator?.clipboard && window.isSecureContext) {
-		navigator.clipboard.writeText(text).then(() => {
-			if (window.frappe) {
-				frappe.show_alert({ message: __("Copied to clipboard"), indicator: "blue" }, 2);
-			}
-		}).catch(() => {
-			fallbackCopy(text);
-		});
+		navigator.clipboard
+			.writeText(text)
+			.then(() => {
+				if (window.frappe) {
+					frappe.show_alert({ message: __("Copied to clipboard"), indicator: "blue" }, 2);
+				}
+			})
+			.catch(() => {
+				fallbackCopy(text);
+			});
 	} else {
 		fallbackCopy(text);
 	}

--- a/flexirule/ruleflow/core/action_handlers/simple_actions.py
+++ b/flexirule/ruleflow/core/action_handlers/simple_actions.py
@@ -338,7 +338,9 @@ class NotifyHandler(ActionHandler):
 	def _render_template(self, template, context, engine=None):
 		template = template or ""
 		# nosemgrep: frappe-semgrep-rules.rules.security.frappe-ssti
-		return frappe.render_template(template, self._template_context(context, engine))  # nosemgrep: frappe-ssti
+		return frappe.render_template(
+			template, self._template_context(context, engine)
+		)  # nosemgrep: frappe-ssti
 
 	def _render_scalar(self, value, context):
 		if value is None:


### PR DESCRIPTION
### Motivation
- The GitHub linter workflow auto-fixes formatting issues reported by `pre-commit` and `prettier`, and this patch applies those auto-fixes so the repository passes the formatting hooks.

### Description
- Applied auto-formatting and whitespace fixes reported by `pre-commit` and `prettier` to frontend files and a single Python wrap for consistent formatting.
- Files updated: `flexirule/public/js/flexirule/utils/clipboard.js`, `flexirule/public/js/flexirule/rule_builder/utils/text_generator.js`, `flexirule/public/js/flexirule/rule_builder/controls/TextGeneratorControl.vue`, `flexirule/public/js/flexirule/rule_builder/utils/tiptap_extensions.js`, and `flexirule/ruleflow/core/action_handlers/simple_actions.py`.
- Changes are formatting-only (whitespace, line-wrapping, object literal layout) and do not alter runtime logic.

### Testing
- Ran `pre-commit run --all-files` which completed successfully and all configured hooks passed after the fixes.
- Ran `semgrep ci --config ./frappe-semgrep-rules/rules --config r/python.lang.correctness`, which executed but reported 12 blocking findings unrelated to these formatting-only changes (security/translation issues remain to be addressed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27297e478832f8d8743da80c26b9a)