### PR TITLE
Add drag-and-drop support to condition builder

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/components/condition_builder/CollectionUI.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/condition_builder/CollectionUI.vue
@@ -14,8 +14,15 @@ const props = defineProps({
 
 const emit = defineEmits(["remove"]);
 
-const { addCondition, addGroup } = inject("conditionActions");
+const { addCondition, addGroup, onDrop } = inject("conditionActions");
 const store = useStore();
+
+const isDragOver = ref(false);
+
+function handleDrop() {
+	isDragOver.value = false;
+	onDrop(props.node.where);
+}
 
 const aliasValue = computed(() => {
 	const rawAlias = String(props.node.alias || "").trim();
@@ -263,7 +270,13 @@ onMounted(fetchChildMeta);
 		</div>
 
 		<!-- Nested conditions -->
-		<div class="pl-3 border-left">
+		<div
+			class="pl-3 border-left nested-conditions"
+			:class="{ 'drag-over': isDragOver }"
+			@dragover.prevent.stop="isDragOver = true"
+			@dragleave.stop="isDragOver = false"
+			@drop.prevent.stop="handleDrop"
+		>
 			<div v-if="!node.where?.conditions?.length" class="text-muted py-2 text-sm text-center">
 				{{ __("No conditions in collection. Click + to add.") }}
 			</div>
@@ -283,5 +296,11 @@ onMounted(fetchChildMeta);
 <style scoped>
 .collection-ui {
 	border-left: 4px solid var(--blue-500) !important;
+}
+
+.nested-conditions.drag-over {
+	background: rgba(var(--primary-rgb), 0.05);
+	box-shadow: inset 0 0 0 2px var(--primary);
+	border-radius: 4px;
 }
 </style>

--- a/flexirule/public/js/flexirule/rule_builder/components/condition_builder/ConditionBuilder.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/condition_builder/ConditionBuilder.vue
@@ -40,21 +40,21 @@
 		</div>
 
 		<!-- Conditions List -->
-		<div class="conditions-container">
+		<div
+			class="conditions-container"
+			:class="{ 'drag-over': isDragOver }"
+			@dragover.prevent.stop="isDragOver = true"
+			@dragleave="isDragOver = false"
+			@drop.stop="handleRootDrop"
+		>
 			<div v-if="!rootGroup.conditions?.length" class="empty-state">
 				<div class="empty-icon">
 					<i class="fa fa-filter"></i>
 				</div>
-				<p class="empty-text">{{ __("No conditions defined yet") }}</p>
-				<button
-					v-if="!readOnly"
-					class="btn btn-sm btn-primary mt-2"
-					@click="addCondition(rootGroup)"
-				>
-					{{ __("Add First Condition") }}
-				</button>
+				<p class="empty-text">
+					{{ __("No conditions defined yet. Click 'Condition' or 'Group' to start.") }}
+				</p>
 			</div>
-
 			<div
 				v-for="(node, idx) in rootGroup.conditions"
 				:key="node.id || idx"
@@ -67,6 +67,14 @@
 					:docFields="docFields"
 					:readOnly="readOnly"
 				/>
+			</div>
+			<!-- Spacer to make dropping at the end easier -->
+			<div
+				class="drop-spacer"
+				v-if="rootGroup.conditions?.length > 0 && !readOnly"
+				:class="{ active: isDragOver }"
+			>
+				<span v-if="isDragOver">{{ __("Drop here to move to top level") }}</span>
 			</div>
 		</div>
 	</div>
@@ -172,6 +180,61 @@ function removeNode(targetGroup, index) {
 	}
 }
 
+function isDescendantOf(parent, targetId) {
+	if (parent.id === targetId) return true;
+	if (parent.conditions) {
+		for (const cond of parent.conditions) {
+			if (cond.id === targetId) return true;
+			if (cond.conditions && isDescendantOf(cond, targetId)) return true;
+			if (cond.where && isDescendantOf(cond.where, targetId)) return true;
+		}
+	}
+	return false;
+}
+
+function moveNode(fromGroup, fromIndex, toGroup, toIndex) {
+	if (!fromGroup.conditions || fromGroup.conditions[fromIndex] === undefined) return;
+	if (!toGroup.conditions) toGroup.conditions = [];
+
+	const node = fromGroup.conditions[fromIndex];
+
+	// Guard: Cannot drop a group into itself or its descendants
+	if (node.conditions || node.where) {
+		if (isDescendantOf(node, toGroup.id)) {
+			console.warn(
+				"FlexiRule: Illegal move - cannot drop a group into itself or its descendants."
+			);
+			return;
+		}
+	}
+
+	fromGroup.conditions.splice(fromIndex, 1);
+
+	if (toIndex === -1) {
+		toGroup.conditions.push(node);
+	} else {
+		toGroup.conditions.splice(toIndex, 0, node);
+	}
+}
+
+// Drag and Drop state
+const dragInfo = reactive({
+	fromGroup: null,
+	fromIndex: -1,
+});
+
+function onDragStart(node, group, index) {
+	dragInfo.fromGroup = group;
+	dragInfo.fromIndex = index;
+}
+
+function onDrop(toGroup, toIndex = -1) {
+	if (!dragInfo.fromGroup) return;
+	moveNode(dragInfo.fromGroup, dragInfo.fromIndex, toGroup, toIndex);
+	dragInfo.fromGroup = null;
+	dragInfo.fromIndex = -1;
+}
+
 // Operator config from backend
 const operatorConfig = ref({
 	fieldtype_operators: {},
@@ -193,8 +256,23 @@ async function loadOperatorConfig() {
 
 onMounted(loadOperatorConfig);
 
+const isDragOver = ref(false);
+
+function handleRootDrop() {
+	isDragOver.value = false;
+	onDrop(rootGroup);
+}
+
 // Provide actions and config to all descendant components
-provide("conditionActions", { addCondition, addGroup, addCollection, removeNode });
+provide("conditionActions", {
+	addCondition,
+	addGroup,
+	addCollection,
+	removeNode,
+	moveNode,
+	onDragStart,
+	onDrop,
+});
 provide(
 	"docFields",
 	computed(() => props.docFields)
@@ -287,6 +365,35 @@ provide(
 	display: flex;
 	flex-direction: column;
 	gap: 12px;
+	min-height: 100px;
+	padding: 10px;
+	border-radius: 12px;
+	transition: all 0.2s;
+}
+
+.conditions-container.drag-over {
+	background: rgba(var(--primary-rgb, 36, 144, 239), 0.08);
+	box-shadow: inset 0 0 0 2px var(--primary);
+	border-radius: 12px;
+}
+
+.drop-spacer {
+	height: 40px;
+	margin-top: 8px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 8px;
+	border: 1px dashed transparent;
+	color: var(--primary);
+	font-size: 11px;
+	font-weight: 600;
+	transition: all 0.2s;
+}
+
+.drop-spacer.active {
+	border-color: var(--primary);
+	background: rgba(var(--primary-rgb, 36, 144, 239), 0.05);
 }
 
 .empty-state {

--- a/flexirule/public/js/flexirule/rule_builder/components/condition_builder/ConditionGroupUI.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/condition_builder/ConditionGroupUI.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { inject } from "vue";
+import { inject, ref } from "vue";
 /**
  * ConditionGroupUI - Nested group editor with AND/OR toggle
  */
@@ -13,11 +13,24 @@ const props = defineProps({
 
 const emit = defineEmits(["remove"]);
 
-const { addCondition, addGroup, addCollection, removeNode } = inject("conditionActions");
+const { addCondition, addGroup, addCollection, removeNode, onDrop } = inject("conditionActions");
+
+const isDragOver = ref(false);
+
+function handleDrop(e) {
+	isDragOver.value = false;
+	onDrop(props.group);
+}
 </script>
 
 <template>
-	<div class="condition-group-ui">
+	<div
+		class="condition-group-ui"
+		:class="{ 'drag-over': isDragOver }"
+		@dragover.prevent.stop="isDragOver = true"
+		@dragleave.stop="isDragOver = false"
+		@drop.prevent.stop="handleDrop"
+	>
 		<!-- Header -->
 		<div class="group-header">
 			<div class="logic-toggle small">
@@ -84,6 +97,8 @@ const { addCondition, addGroup, addCollection, removeNode } = inject("conditionA
 					:readOnly="readOnly"
 				/>
 			</div>
+			<!-- Spacer for easier dropping -->
+			<div class="group-drop-spacer" v-if="!readOnly"></div>
 		</div>
 	</div>
 </template>
@@ -104,13 +119,34 @@ const { addCondition, addGroup, addCollection, removeNode } = inject("conditionA
 }
 
 .logic-toggle.small {
-	background: #f1f5f9;
+	background: #e2e8f0;
 	padding: 2px;
+	border-radius: 6px;
+	display: flex;
 }
 
-.logic-toggle.small .logic-btn {
-	padding: 3px 10px;
+.logic-btn {
+	border: none;
+	background: transparent;
+	padding: 4px 12px;
+	border-radius: 4px;
 	font-size: 10px;
+	font-weight: 700;
+	color: #64748b;
+	transition: all 0.2s;
+	cursor: pointer;
+}
+
+.logic-btn.active {
+	background: white;
+	color: var(--primary);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.condition-group-ui.drag-over {
+	border-color: var(--primary);
+	background: rgba(var(--primary-rgb), 0.05);
+	box-shadow: inset 0 0 0 2px var(--primary);
 }
 
 .group-actions {
@@ -170,5 +206,10 @@ const { addCondition, addGroup, addCollection, removeNode } = inject("conditionA
 
 .node-wrapper {
 	margin-bottom: 4px;
+}
+
+.group-drop-spacer {
+	height: 20px;
+	margin-top: 4px;
 }
 </style>

--- a/flexirule/public/js/flexirule/rule_builder/components/condition_builder/ConditionNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/condition_builder/ConditionNode.vue
@@ -15,43 +15,71 @@ const props = defineProps({
 	readOnly: { type: Boolean, default: false },
 });
 
-const { removeNode } = inject("conditionActions");
+const { removeNode, onDragStart } = inject("conditionActions");
 
 function handleRemove() {
 	removeNode(props.parentGroup, props.index);
 }
+
+function handleDragStart(e) {
+	// CRITICAL: Stop propagation so parent ConditionNode wrappers
+	// don't overwrite dragInfo with their own (parent group) data.
+	// Without this, dragging a child condition inside a group causes
+	// the group itself to be registered as the drag source.
+	e.stopPropagation();
+	onDragStart(props.node, props.parentGroup, props.index);
+	e.dataTransfer.effectAllowed = "move";
+	e.dataTransfer.setData("text/plain", props.node.id || "");
+}
 </script>
 
 <template>
-	<!-- Leaf Condition: has left operand -->
-	<SimpleCondition
-		v-if="node.left"
-		:node="node"
-		:docFields="docFields"
-		:readOnly="readOnly"
-		@remove="handleRemove"
-	/>
+	<div class="condition-node-draggable" draggable="true" @dragstart="handleDragStart">
+		<!-- Leaf Condition: has left operand -->
+		<SimpleCondition
+			v-if="node.left"
+			:node="node"
+			:docFields="docFields"
+			:readOnly="readOnly"
+			@remove="handleRemove"
+		/>
 
-	<!-- Nested Group: has conditions array, no where -->
-	<ConditionGroupUI
-		v-else-if="node.conditions && !node.where"
-		:group="node"
-		:docFields="docFields"
-		:readOnly="readOnly"
-		@remove="handleRemove"
-	/>
+		<!-- Nested Group: has conditions array, no where -->
+		<ConditionGroupUI
+			v-else-if="node.conditions && !node.where"
+			:group="node"
+			:docFields="docFields"
+			:readOnly="readOnly"
+			@remove="handleRemove"
+		/>
 
-	<!-- Collection: has where clause -->
-	<CollectionUI
-		v-else-if="node.where"
-		:node="node"
-		:docFields="docFields"
-		:readOnly="readOnly"
-		@remove="handleRemove"
-	/>
+		<!-- Collection: has where clause -->
+		<CollectionUI
+			v-else-if="node.where"
+			:node="node"
+			:docFields="docFields"
+			:readOnly="readOnly"
+			@remove="handleRemove"
+		/>
 
-	<!-- Fallback for unknown node types -->
-	<div v-else class="text-danger p-2 border rounded">
-		{{ __("Unknown condition type") }}
+		<!-- Fallback for unknown node types -->
+		<div v-else class="text-danger p-2 border rounded">
+			{{ __("Unknown condition type") }}
+		</div>
 	</div>
 </template>
+
+<style scoped>
+.condition-node-draggable {
+	cursor: grab;
+	transition: opacity 0.2s;
+}
+
+.condition-node-draggable:active {
+	cursor: grabbing;
+}
+
+.condition-node-draggable[draggable="true"]:hover {
+	opacity: 0.9;
+}
+</style>

--- a/flexirule/public/js/flexirule/rule_builder/components/condition_builder/SimpleCondition.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/condition_builder/SimpleCondition.vue
@@ -29,10 +29,20 @@ const context = inject("conditionContext", { alias: "doc" });
 const dynamicLinkDocType = ref("");
 
 // Find the selected field metadata
+const lastValidField = ref(null);
 const selectedField = computed(() => {
 	const ref = props.node.left?.ref;
 	if (!ref) return null;
-	return props.docFields.find((f) => f.value === ref);
+	const found = props.docFields.find((f) => f.value === ref);
+	if (found) {
+		lastValidField.value = found;
+		return found;
+	}
+	// Fallback to last known good metadata during transitions (e.g. drag-and-drop)
+	if (lastValidField.value?.value === ref) {
+		return lastValidField.value;
+	}
+	return null;
 });
 
 const doctypeContextRefs = ["doctype", "rule.document_type", "caller.document_type"];
@@ -194,7 +204,8 @@ const wrappedValue = computed({
 		if ((ft !== "Link" && ft !== "Dynamic Link") || isDoctypeContextField.value) return val;
 
 		// If value is empty, return empty
-		if (!val) return op === "in" || op === "not in" ? [] : "";
+		if (val === undefined || val === null || val === "")
+			return op === "in" || op === "not in" ? [] : "";
 
 		// If it's a tuple [DocType, Value], return Value
 		if (Array.isArray(val) && val.length === 2 && typeof val[0] === "string") {
@@ -365,7 +376,7 @@ const valueType = computed({
 	border: 1px solid #e9ecef;
 	border-radius: 4px;
 	padding: 6px;
-	transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+	transition: border-color 0.2s, background-color 0.2s;
 }
 
 .simple-condition:hover {
@@ -377,6 +388,7 @@ const valueType = computed({
 	grid-template-columns: 1.5fr 0.8fr 2.5fr auto;
 	gap: 8px;
 	align-items: center;
+	overflow: visible !important;
 }
 
 .condition-col {
@@ -423,6 +435,7 @@ const valueType = computed({
 	min-width: 0;
 	display: flex;
 	flex-direction: column;
+	overflow: visible !important;
 }
 
 .dynamic-dt-picker {

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/ActionSelectorNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/ActionSelectorNode.vue
@@ -264,11 +264,12 @@ function onCreate() {
 		selectedPreset.value.selected_label ||
 		action_type;
 	// Map Action Type to VueFlow node type using the same logic as App.vue
-	const nodeType = mapActionTypeToNodeType(action_type);
+	const node = store.nodes[nodeIndex];
+	if (!node) return;
 
 	const nodeData = store.get_default_node_data(action_type.toLowerCase(), label);
-	const suggestedParentId = store.nodes[nodeIndex].data?.suggested_parent_id;
-	const suggestedSourceHandle = store.nodes[nodeIndex].data?.suggested_source_handle || "default";
+	const suggestedParentId = node.data?.suggested_parent_id;
+	const suggestedSourceHandle = node.data?.suggested_source_handle || "default";
 
 	// Pre-fill process/operation data from selected preset
 	if (selectedPreset.value.operation) {

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/RuleConfigModal.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/RuleConfigModal.vue
@@ -290,7 +290,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch } from "vue";
+import { ref, computed, watch, onMounted, onUnmounted } from "vue";
 import ResizablePanel from "./ResizablePanel.vue";
 import InputPanel from "./InputPanel.vue";
 import ConfigurationPanel from "./ConfigurationPanel.vue";
@@ -410,6 +410,53 @@ function getIcon(type) {
 	};
 	return icons[type.toLowerCase()] || "fa fa-circle";
 }
+
+// -- Keyboard Shortcuts --
+function handleKeydown(e) {
+	if (!props.modelValue) return;
+
+	// Esc to close
+	if (e.key === "Escape") {
+		cancel();
+		e.preventDefault();
+		e.stopPropagation();
+	}
+
+	// Ctrl+S to save
+	if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+		if (!ruleStore.is_read_only) {
+			save();
+			e.preventDefault();
+			e.stopPropagation();
+		}
+	}
+
+	// Ctrl+Up to previous node
+	if ((e.ctrlKey || e.metaKey) && e.key === "ArrowUp") {
+		if (currentNodeIndex.value > 0) {
+			ruleStore.prev_config_node();
+			e.preventDefault();
+			e.stopPropagation();
+		}
+	}
+
+	// Ctrl+Down to next node
+	if ((e.ctrlKey || e.metaKey) && e.key === "ArrowDown") {
+		if (currentNodeIndex.value < totalNodes.value - 1) {
+			ruleStore.next_config_node();
+			e.preventDefault();
+			e.stopPropagation();
+		}
+	}
+}
+
+onMounted(() => {
+	window.addEventListener("keydown", handleKeydown);
+});
+
+onUnmounted(() => {
+	window.removeEventListener("keydown", handleKeydown);
+});
 </script>
 
 <style scoped>

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/ConditionStep.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/ConditionStep.vue
@@ -130,12 +130,12 @@ function updateConditions(val) {
 }
 
 function save() {
-	if (!props.node.data) return;
+	if (!props.node?.data) return;
 
 	// Strip IDs
 	const clean = dehydrate(localConditions.value);
 
-	if (props.node?.type === "start") {
+	if (props.node.type === "start") {
 		props.node.data.trigger_condition = clean;
 	} else {
 		props.node.data.config = clean;
@@ -267,13 +267,14 @@ const docFields = computed(() => {
 });
 
 async function refreshVariableFields() {
-	if (!props.node?.id || props.node?.type === "start") {
+	const nodeId = props.node?.id;
+	if (!nodeId || props.node?.type === "start") {
 		variableFields.value = [];
 		return;
 	}
 
 	try {
-		const available = await store.getAvailableVariables(props.node.id);
+		const available = await store.getAvailableVariables(nodeId);
 		variableFields.value = (available || []).filter((field) =>
 			field?.value?.startsWith("vars.")
 		);
@@ -284,7 +285,10 @@ async function refreshVariableFields() {
 
 // Load metadata on mount if needed
 onMounted(async () => {
-	const doctype = props.node.data?.document_type || store.rule_doc?.document_type;
+	const node = props.node;
+	if (!node) return;
+
+	const doctype = node.data?.document_type || store.rule_doc?.document_type;
 	if (doctype && !store.doc_fields.length) {
 		await store.fetch_metadata(doctype);
 	}
@@ -294,12 +298,14 @@ onMounted(async () => {
 watch(
 	() => [
 		props.node?.id,
-		store.nodes.map((node) => [
-			node.id,
-			node.data?.return_variable,
-			node.data?.return_type,
-			node.data?.resolved_output_schema,
-		]),
+		(store.nodes || [])
+			.filter(Boolean)
+			.map((node) => [
+				node.id,
+				node.data?.return_variable,
+				node.data?.return_type,
+				node.data?.resolved_output_schema,
+			]),
 	],
 	() => {
 		refreshVariableFields();
@@ -342,6 +348,11 @@ defineExpose({
 .condition-step-header h5 {
 	font-size: 13px;
 	font-weight: 600;
+}
+
+.condition-builder-container {
+	position: relative;
+	z-index: 10;
 }
 
 .condition-builder-container :deep(.condition-builder) {

--- a/flexirule/public/js/flexirule/rule_builder/controls/MultiCheckControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/MultiCheckControl.vue
@@ -1,10 +1,9 @@
 <script setup>
 /**
- * MultiCheckControl - Wrapper for Frappe's MultiCheck control
- * Provides a list of checkboxes for multiple selection.
- * Options should be an array of {label, value} or {label, value, checked}.
+ * MultiCheckControl - Pure Vue implementation for multiple selection.
+ * Replaces legacy Frappe MultiCheck to ensure stability and avoid flickering.
  */
-import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
+import { ref, computed, watch } from "vue";
 
 const props = defineProps({
 	df: Object,
@@ -15,20 +14,20 @@ const props = defineProps({
 
 const emit = defineEmits(["update:modelValue"]);
 
-const wrapper = ref(null);
-const control = ref(null);
-let processing_update = false;
 const show_popover = ref(false);
 
+// Internal state for selected values
 const selectedValues = computed(() => {
-	if (Array.isArray(props.modelValue)) return props.modelValue;
-	if (typeof props.modelValue === "string" && props.modelValue) {
-		return props.modelValue
+	const val = props.modelValue;
+	if (Array.isArray(val)) return val.map((v) => String(v));
+	if (val === undefined || val === null || val === "") return [];
+	if (typeof val === "string") {
+		return val
 			.split(",")
 			.map((s) => s.trim())
 			.filter(Boolean);
 	}
-	return [];
+	return [String(val)];
 });
 
 const selectedCount = computed(() => selectedValues.value.length);
@@ -40,11 +39,30 @@ const summaryLabel = computed(() => {
 	return __("{0} Selected", [count]);
 });
 
+// Normalize options into {label, value} objects
+const normalizedOptions = computed(() => {
+	let options = props.df.options || [];
+	if (typeof options === "string") {
+		return options
+			.split("\n")
+			.map((o) => o.trim())
+			.filter(Boolean)
+			.map((o) => ({ label: __(o), value: o }));
+	}
+	if (Array.isArray(options)) {
+		return options.map((o) => {
+			const val = typeof o === "object" ? o.value : o;
+			const label = typeof o === "object" ? o.label : o;
+			return { label: __(label), value: String(val) };
+		});
+	}
+	return [];
+});
+
 function togglePopover() {
 	if (props.read_only) return;
 	show_popover.value = !show_popover.value;
 	if (show_popover.value) {
-		// Close when clicking outside
 		setTimeout(() => {
 			const handleOutsideClick = (e) => {
 				if (
@@ -60,115 +78,30 @@ function togglePopover() {
 	}
 }
 
-function make_control() {
-	if (!wrapper.value) return;
-	wrapper.value.innerHTML = "";
+function toggleOption(value) {
+	if (props.read_only) return;
+	const current = [...selectedValues.value];
+	const index = current.indexOf(String(value));
 
-	const current_selection = selectedValues.value;
-
-	// Robust Options Parsing with Selection State
-	let options = props.df.options || [];
-	if (typeof options === "string") {
-		options = options
-			.split("\n")
-			.map((o) => o.trim())
-			.filter(Boolean)
-			.map((o) => ({
-				label: o,
-				value: o,
-				checked: current_selection.includes(o),
-			}));
-	} else if (Array.isArray(options)) {
-		options = options.map((o) => {
-			const val = typeof o === "object" ? o.value : o;
-			const label = typeof o === "object" ? o.label : o;
-			return {
-				label: label,
-				value: val,
-				checked: current_selection.some((s) => String(s) === String(val)),
-			};
-		});
+	if (index > -1) {
+		current.splice(index, 1);
+	} else {
+		current.push(String(value));
 	}
 
-	try {
-		control.value = frappe.ui.form.make_control({
-			parent: wrapper.value,
-			df: {
-				...props.df,
-				fieldtype: "MultiCheck",
-				label: props.df.label,
-				options: options,
-				read_only: props.read_only,
-				on_change: () => {
-					if (processing_update) return;
-					const val = control.value.get_value();
-
-					processing_update = true;
-					emit("update:modelValue", val);
-					// Allow vue to process update before resetting flag
-					setTimeout(() => {
-						processing_update = false;
-					}, 50);
-				},
-			},
-			render_input: true,
-		});
-
-		if (current_selection.length > 0) {
-			processing_update = true;
-			control.value.set_value(current_selection);
-			setTimeout(() => {
-				processing_update = false;
-			}, 50);
-		}
-	} catch (e) {
-		console.error("Failed to create MultiCheck control", e);
-		wrapper.value.innerHTML = `<div class="text-danger">Error loading control: ${e.message}</div>`;
-	}
+	emit("update:modelValue", current);
 }
 
-onMounted(() => {
-	make_control();
-});
+function checkAll() {
+	if (props.read_only) return;
+	const all = normalizedOptions.value.map((o) => o.value);
+	emit("update:modelValue", all);
+}
 
-watch(
-	() => props.modelValue,
-	(val) => {
-		if (!control.value || processing_update) return;
-
-		const currentVal = control.value.get_value() || [];
-		const newVal = Array.isArray(val)
-			? val
-			: typeof val === "string"
-			? val.split(",").map((s) => s.trim())
-			: [val];
-
-		// Sort and stringify for deep comparison
-		const currentSorted = [...currentVal].sort();
-		const newSorted = [...newVal].sort();
-
-		if (JSON.stringify(currentSorted) !== JSON.stringify(newSorted)) {
-			processing_update = true;
-			control.value.set_value(newVal);
-			setTimeout(() => {
-				processing_update = false;
-			}, 50);
-		}
-	},
-	{ deep: true }
-);
-
-// Watch df changes but only recreate if critical properties change
-watch(
-	() => [props.df.options, props.df.read_only],
-	() => {
-		make_control();
-	}
-);
-
-onBeforeUnmount(() => {
-	// Cleanup if necessary
-});
+function uncheckAll() {
+	if (props.read_only) return;
+	emit("update:modelValue", []);
+}
 </script>
 
 <template>
@@ -177,7 +110,7 @@ onBeforeUnmount(() => {
 			{{ __(df.label) }}
 		</div>
 
-		<!-- Dropdown Mode (for Grid) -->
+		<!-- Dropdown Mode -->
 		<template v-if="hideLabel">
 			<div
 				class="dropdown-trigger form-control input-xs"
@@ -188,14 +121,64 @@ onBeforeUnmount(() => {
 				<i class="fa fa-chevron-down ml-2 text-muted" style="font-size: 10px"></i>
 			</div>
 
-			<div v-show="show_popover" class="multi-check-popover dropdown-menu show">
-				<div class="popover-inner" ref="wrapper"></div>
+			<div v-show="show_popover" class="multi-check-popover">
+				<div
+					class="popover-actions border-bottom p-2 d-flex align-items-center justify-content-start"
+				>
+					<button class="btn btn-xs btn-link p-0 mr-3" @click.stop="checkAll">
+						<i class="fa fa-check-square-o mr-1"></i> {{ __("Check All") }}
+					</button>
+					<button class="btn btn-xs btn-link p-0 text-muted" @click.stop="uncheckAll">
+						<i class="fa fa-square-o mr-1"></i> {{ __("Uncheck All") }}
+					</button>
+				</div>
+				<div class="popover-inner">
+					<div
+						v-for="opt in normalizedOptions"
+						:key="opt.value"
+						class="checkbox-item"
+						@click.stop="toggleOption(opt.value)"
+					>
+						<input
+							type="checkbox"
+							:checked="selectedValues.includes(opt.value)"
+							:disabled="read_only"
+							@click.stop="toggleOption(opt.value)"
+						/>
+						<span class="option-label">{{ opt.label }}</span>
+					</div>
+				</div>
 			</div>
 		</template>
 
-		<!-- Normal Mode -->
+		<!-- Normal Mode (Inline) -->
 		<template v-else>
-			<div class="control-wrapper" ref="wrapper"></div>
+			<div class="control-wrapper inline-wrapper">
+				<div class="inline-actions mb-2 d-flex gap-2" v-if="!read_only">
+					<button class="btn btn-xs btn-link p-0" @click.stop="checkAll">
+						{{ __("All") }}
+					</button>
+					<button class="btn btn-xs btn-link p-0 text-muted" @click.stop="uncheckAll">
+						{{ __("None") }}
+					</button>
+				</div>
+				<div class="options-grid">
+					<div
+						v-for="opt in normalizedOptions"
+						:key="opt.value"
+						class="checkbox-item"
+						@click.stop="toggleOption(opt.value)"
+					>
+						<input
+							type="checkbox"
+							:checked="selectedValues.includes(opt.value)"
+							:disabled="read_only"
+							@click.stop="toggleOption(opt.value)"
+						/>
+						<span class="option-label">{{ opt.label }}</span>
+					</div>
+				</div>
+			</div>
 		</template>
 
 		<div v-if="df.description && !hideLabel" class="description text-muted mt-1">
@@ -204,20 +187,10 @@ onBeforeUnmount(() => {
 	</div>
 </template>
 
-<script>
-export default {
-	name: "MultiCheckControl",
-};
-</script>
-
 <style scoped>
 .multi-check-control {
-	margin-bottom: var(--margin-md);
-	position: relative;
-}
-.multi-check-control.in-grid {
 	margin-bottom: 0;
-	width: 100%;
+	position: relative;
 }
 
 .dropdown-trigger {
@@ -228,67 +201,84 @@ export default {
 	user-select: none;
 	background-color: var(--control-bg, #f1f5f9);
 	border: 1px solid transparent;
-	transition: border-color 0.2s, box-shadow 0.2s;
-}
-
-.dropdown-trigger:hover:not(.disabled) {
-	border-color: var(--border-color, #cbd5e1);
+	transition: border-color 0.2s;
+	height: 28px;
+	padding: 4px 8px;
+	border-radius: 6px;
 }
 
 .dropdown-trigger.has-value {
-	border-color: var(--primary-color, var(--primary, #2490ef));
-	color: var(--primary-color, var(--primary, #2490ef));
-	font-weight: 500;
+	border-color: var(--primary);
+	color: var(--primary);
+	font-weight: 600;
 	background-color: #fff;
-}
-
-.dropdown-trigger.disabled {
-	cursor: not-allowed;
-	opacity: 0.6;
 }
 
 .multi-check-popover {
 	position: absolute;
-	top: calc(100% + 4px);
+	top: 100%;
 	left: 0;
-	z-index: 1050;
-	background: var(--card-bg, #fff);
-	border: 1px solid var(--border-color, #d1d8dd);
-	border-radius: var(--border-radius-md, 4px);
-	box-shadow: var(--shadow-sm, 0 2px 6px rgba(0, 0, 0, 0.15));
-	min-width: 200px;
-	max-width: 320px;
-	max-height: 280px;
-	overflow-y: auto;
-	margin: 0;
-	padding: 0;
+	z-index: 2000;
+	background: #ffffff !important;
+	border: 1px solid #d1d8dd;
+	border-radius: 8px;
+	box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+	min-width: 220px;
+	max-height: 350px;
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+	margin-top: 4px;
 }
 
 .popover-inner {
-	padding: 8px 12px;
+	padding: 8px;
+	overflow-y: auto;
 }
 
-.control-wrapper {
-	min-height: 35px;
-	padding: 8px;
-	border: 1px solid var(--border-color, #d1d8dd);
-	border-radius: var(--border-radius-sm, 4px);
-	background-color: var(--control-bg, #f1f5f9);
+.control-wrapper.inline-wrapper {
+	padding: 12px;
+	background: #fff;
+	border: 1px solid #e2e8f0;
+	border-radius: 8px;
 }
-:deep(.form-group) {
-	margin-bottom: 0 !important;
+
+.options-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+	gap: 8px;
 }
-:deep(.unit-checkbox) {
-	margin-bottom: 4px;
-	display: block;
-}
-:deep(.checkbox) {
-	margin: 0;
+
+.checkbox-item {
 	display: flex;
 	align-items: center;
+	gap: 8px;
+	padding: 6px 8px;
+	border-radius: 4px;
+	cursor: pointer;
+	transition: background 0.15s;
+	user-select: none;
 }
-:deep(.checkbox label) {
-	margin: 0 0 0 8px;
-	font-weight: normal;
+
+.checkbox-item:hover {
+	background: #f1f5f9;
+}
+
+.checkbox-item input {
+	cursor: pointer;
+	margin: 0;
+}
+
+.option-label {
+	font-size: 12px;
+	color: #1e293b;
+	white-space: nowrap;
+	overflow: hidden;
+	text-truncate: ellipsis;
+}
+
+.popover-actions .btn-link {
+	font-size: 11px;
+	text-decoration: none;
 }
 </style>


### PR DESCRIPTION
## Summary
This PR adds drag-and-drop functionality to the condition builder, allowing users to reorder conditions and groups visually. It also improves the MultiCheckControl by implementing it as a pure Vue component for better stability.

## Changes Made

### Drag-and-Drop Support in Condition Builder
- Added drag-and-drop handlers to condition nodes, groups, and collections
- Implemented moveNode function with safeguards against invalid moves (e.g., dropping a group into itself)
- Added visual feedback during drag operations with drag-over states
- Updated ConditionNode to be draggable with proper event handling

### MultiCheckControl Improvements  
- Replaced Frappe's MultiCheck control with a pure Vue implementation
- Added dropdown mode and inline mode for different use cases
- Implemented check all/uncheck all functionality
- Improved styling and user experience

### RuleConfigModal Enhancements
- Added keyboard shortcuts: Esc to close, Ctrl+S to save, Ctrl+Up/Down to navigate nodes
- Better event handling with onMounted/onUnmounted lifecycle hooks

### Other Improvements
- Enhanced SimpleCondition with better field metadata handling during transitions
- Minor fixes to ActionSelectorNode and ConditionStep for robustness

## Testing
- All pre-commit hooks pass (trailing whitespace, prettier formatting, etc.)
- Changes maintain backward compatibility
- Drag-and-drop prevents invalid operations like circular references