### PR TITLE
Update Documentation and Resolve Conflicts

### DIFF
--- a/docs/engine/execution_engine.md
+++ b/docs/engine/execution_engine.md
@@ -18,18 +18,6 @@ The engine provides enterprise-grade reliability features for handling failures 
 
 ### Exponential Backoff Math
 When an action is configured with `on_error: "Retry"`, the engine uses an exponential backoff strategy:
-<<<<<<< HEAD
-- **Delay Formula**: `wait_time = 2 ** attempt` seconds.
-- **Example**: Attempt 1 (2s), Attempt 2 (4s), Attempt 3 (8s).
-- **Safety**: Retries are automatically disabled if the context flag `_in_sync_hook` is set, preventing unsafe sleeps in synchronous DocType events.
-
-### Savepoint / Rollback Management
-For actions with the `transactional` flag or `on_error: "Rollback"`, the engine uses atomic database savepoints:
-1.  **Creation**: A savepoint is created with the naming convention `flexirule_action_{action_id}`.
-2.  **Execution**: The action handler is executed within a try-except block.
-3.  **Rollback**: If an error occurs, the engine rolls back specifically to the action's savepoint, ensuring partial failures don't corrupt the entire transaction state.
-4.  **Cleanup**: Savepoints are released upon successful completion of the action.
-=======
 - **Delay Formula**: `wait_time = 2 ** current_attempt` seconds.
 - **Example**: Attempt 1 (1s), Attempt 2 (2s), Attempt 3 (4s).
 - **Safety**: Retries are automatically disabled inside synchronous hooks (e.g., `Before Save`) to prevent blocking the web worker. If a retry is attempted in a sync hook, a `ValidationError` is raised.
@@ -42,7 +30,6 @@ For actions with the `transactional` flag or `on_error: "Rollback"`, the engine 
 2.  **Execution**: The handler runs.
 3.  **Rollback**: If an error occurs and rollback is required, `frappe.db.rollback(save_point=...)` is called, reverting only the changes made by that specific action, not the entire transaction.
 4.  **Release**: On success, the savepoint is released (only for Process actions).
->>>>>>> origin/develop
 
 ### Reentrancy Guards
 To prevent infinite recursive loops, the `RuleCoordinator` implements a global reentrancy guard:

--- a/docs/reference/doctypes.md
+++ b/docs/reference/doctypes.md
@@ -40,7 +40,7 @@ Represents a single executable node within a Rule's graph.
 | :--- | :--- | :--- | :--- |
 | `action_id` | Data | Action ID | Unique ID for the node. Used for graph edges. |
 | `action_label` | Data | Label | User-defined label displayed on the node. |
-| `action_type` | Select | Step Type | Category: `Condition`, `Process`, `Loop`, `Assignment`, etc. |
+| `action_type` | Select | Step Type | Category: `Condition`, `Process`, `Loop`, `Assignment`, etc. Replaces legacy `Set Value`. |
 | `process_name` | Link | Process | Link to a `Process` DocType. |
 | `rule` | Link | Rule | Link to a sub-rule (for `Sub-Rule` type). |
 | `operation` | Autocomplete | Mode | Operation mode for this action. |
@@ -57,9 +57,9 @@ Represents a single executable node within a Rule's graph.
 | `reference_docname` | Dynamic Link| Reference Document | Specific document reference. |
 | `condition_json` | Code | Condition (JSON) | Condition expression for `Condition` type. |
 | `compiled_expression`| Code | Compiled Expression (Python)| Python version of the condition. |
-| `target_field` | Data | Target Field | Field to update (e.g., `doc.status`). |
+| `target_field` | Data | Target Field | Field to update (e.g., `doc.status`). **Legacy**: Used by the old 'Set Value' action. |
 | `value_template` | Code | Action Template | Jinja template for values or notifications. |
-| `config` | Code | Configuration (JSON) | Parameters for the action. |
+| `config` | Code | Configuration (JSON) | Parameters for the action (e.g., Assignment batch data). |
 | `mutation_mode` | Select | Result Handling | How to apply results (e.g., `Set Doc Field`). |
 | `return_variable` | Data | Save Result As | Name to save this step's result under. |
 | `return_type` | Select | Result Type | Expected data structure. |


### PR DESCRIPTION
This PR cleans up the project documentation by:
1. Resolving a merge conflict in `docs/engine/execution_engine.md` that was left with conflict markers.
2. Updating the `DocType Reference` to clarify that the `Assignment` action type has replaced the legacy `Set Value` action.
3. Marking the `target_field` in `Rule Action` as legacy and clarifying that `config` is used for Assignment batch data.

---
*PR created automatically by Jules for task [18132681511683449068](https://jules.google.com/task/18132681511683449068) started by @Sendipad*