### PR TITLE
fix: keyboard event conflicts and assignment config improvements

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/App.vue
+++ b/flexirule/public/js/flexirule/rule_builder/App.vue
@@ -363,6 +363,9 @@ async function pasteFromClipboardWrapper() {
 }
 
 function handleKeydown(e) {
+	// If the config modal is open, let it handle keypress events
+	if (uiStore.show_config_modal) return;
+
 	// Don't trigger if typing in an input
 	if (["INPUT", "TEXTAREA", "SELECT"].includes(e.target.tagName) || e.target.isContentEditable)
 		return;

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/RuleConfigModal.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/RuleConfigModal.vue
@@ -614,30 +614,27 @@ function onCompactTabKeydown(event) {
 function handleKeydown(e) {
 	if (!props.modelValue) return;
 
-	// Don't trigger if typing in an input
-	if (["INPUT", "TEXTAREA", "SELECT"].includes(e.target.tagName) || e.target.isContentEditable) {
-		// Exception for Esc to close modal even if focused on input
-		if (e.key === "Escape") {
-			cancel();
-			e.preventDefault();
-		}
-		return;
-	}
-
-	// Esc to close
+	// 1. Capture ESC key to close modal
 	if (e.key === "Escape") {
 		cancel();
 		e.preventDefault();
 		e.stopPropagation();
+		return;
 	}
 
-	// Ctrl+S to save
+	// 2. Capture Ctrl+S to save (takes precedence even when inputs are focused)
 	if ((e.ctrlKey || e.metaKey) && e.key === "s") {
 		if (!ruleStore.is_read_only) {
 			save();
 			e.preventDefault();
 			e.stopPropagation();
+			return;
 		}
+	}
+
+	// Don't trigger other shortcuts if typing in an input
+	if (["INPUT", "TEXTAREA", "SELECT"].includes(e.target.tagName) || e.target.isContentEditable) {
+		return;
 	}
 
 	// Ctrl+Up/Left to previous node

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
@@ -96,7 +96,7 @@
 								:modelValue="assignment.value_template_ui"
 								:doctype="
 									getTargetDoctype(assignment.target) ||
-									store.rule?.document_type ||
+									store.rule_doc?.document_type ||
 									''
 								"
 								:readOnly="readOnly"
@@ -197,12 +197,9 @@
 			</div>
 		</div>
 
-		<button
-			class="btn btn-sm btn-default w-100 mt-2"
-			@click="addAssignment"
-			:disabled="readOnly"
-		>
-			<i class="fa fa-plus me-1"></i> {{ __("Add Assignment") }}
+		<button class="add-assignment-btn mt-2" @click="addAssignment" :disabled="readOnly">
+			<i class="fa fa-plus"></i>
+			<span>{{ __("Add Assignment") }}</span>
 		</button>
 
 		<Teleport to="body">
@@ -569,13 +566,27 @@ function clearWhenCondition() {
 	syncToNode();
 	closeWhenConditionEditor();
 }
+function getDefaultResolverKind(target) {
+	const fieldtype = getTargetFieldtype(target);
+	if (!fieldtype) return "string_formula";
+
+	if (["Int", "Float", "Percent", "Currency"].includes(fieldtype)) {
+		return "math_formula";
+	}
+	if (["Date", "Datetime"].includes(fieldtype)) {
+		return "date_formula";
+	}
+	return "string_formula";
+}
+
 function toggleValueMode(index) {
 	const current = assignments.value[index].value_mode || "template";
 	const next = current === "resolver" ? "template" : "resolver";
 	assignments.value[index].value_mode = next;
 	// Reset UI state when switching modes
 	if (next === "resolver") {
-		assignments.value[index].value_template_ui = { kind: "date_formula" };
+		const defaultKind = getDefaultResolverKind(assignments.value[index].target);
+		assignments.value[index].value_template_ui = { kind: defaultKind };
 	} else {
 		assignments.value[index].value_template_ui = { version: 2, segments: [] };
 	}
@@ -779,8 +790,11 @@ defineExpose({ validate });
 .assignment-grid-header,
 .assignment-grid-row {
 	display: grid;
-	grid-template-columns: 24% 14% 34% 20% 8%;
-	gap: 8px;
+	grid-template-columns:
+		minmax(180px, 1.2fr) minmax(110px, 0.8fr) minmax(220px, 2fr) minmax(120px, 1fr)
+		100px;
+	gap: 12px;
+	align-items: center;
 }
 
 .when-editor-cell {
@@ -816,47 +830,59 @@ defineExpose({ validate });
 	border-radius: 8px;
 	padding: 8px;
 }
+
 /* Value mode toggle + control wrapper */
 .value-mode-wrap {
 	display: flex;
 	align-items: center;
-	gap: 4px;
+	gap: 8px;
 	width: 100%;
 }
 
 .value-mode-toggle {
 	flex-shrink: 0;
-	width: 26px;
-	height: 26px;
-	padding: 0;
-	color: var(--text-muted);
-	border-color: transparent;
+	width: 32px;
+	height: 32px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 6px;
+	color: #64748b;
+	border: 1px solid #e2e8f0;
+	background: #ffffff;
+	transition: all 0.2s ease;
+	cursor: pointer;
 }
 
-.value-mode-toggle:hover {
-	color: var(--primary);
-	border-color: var(--primary-light);
-	background: color-mix(in srgb, var(--primary) 8%, transparent);
+.value-mode-toggle:hover:not(:disabled) {
+	color: var(--primary, #1e293b);
+	border-color: #cbd5e1;
+	background: #f8fafc;
 }
 
 .assignment-grid-header {
-	padding: 0 4px;
+	padding: 8px 12px;
 	font-size: 11px;
-	text-transform: uppercase;
-	letter-spacing: 0.05em;
+	font-weight: 600;
+	color: #64748b;
+	letter-spacing: 0.02em;
+	border-bottom: 1px solid #e2e8f0;
+	margin-bottom: 8px !important;
 }
 
 .assignment-grid-row {
-	background: var(--card-bg, #ffffff);
-	border: 1px solid var(--border-color, #e2e8f0);
-	border-radius: 6px;
-	padding: 4px;
-	transition: border-color 0.15s ease, box-shadow 0.15s ease;
+	background: #ffffff;
+	border: 1px solid #e2e8f0;
+	border-radius: 8px;
+	padding: 8px 12px;
+	transition: all 0.2s ease;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.02);
 }
 
 .assignment-grid-row:hover {
-	border-color: #cbd5e1;
-	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+	border-color: var(--primary, #1e293b);
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+	transform: translateY(-1px);
 }
 
 .operator-hint-text {
@@ -883,5 +909,27 @@ defineExpose({ validate });
 .empty-state:hover {
 	border-color: var(--fxr-border-strong);
 	background-color: var(--fxr-bg-hover);
+}
+
+.add-assignment-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	background: #f8fafc;
+	border: 1px dashed #cbd5e1;
+	border-radius: 8px;
+	padding: 10px;
+	width: 100%;
+	color: #475569;
+	font-weight: 500;
+	transition: all 0.2s ease;
+	cursor: pointer;
+}
+
+.add-assignment-btn:hover:not(:disabled) {
+	background: #f1f5f9;
+	border-color: var(--primary, #1e293b);
+	color: var(--primary, #1e293b);
 }
 </style>

--- a/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
@@ -549,7 +549,7 @@ const localState = ref(getDefaultState());
 
 // ─── Field Options ───
 const dateFieldOptions = computed(() => {
-	const dt = props.doctype;
+	const dt = props.doctype || store.rule_doc?.document_type;
 	if (!dt) return [];
 	const fields = store.doc_meta[dt];
 	if (!fields || !Array.isArray(fields)) return [];
@@ -567,7 +567,7 @@ const dateFieldOptions = computed(() => {
 });
 
 const numericFieldOptions = computed(() => {
-	const dt = props.doctype;
+	const dt = props.doctype || store.rule_doc?.document_type;
 	if (!dt) return [];
 	const fields = store.doc_meta[dt];
 	if (!fields || !Array.isArray(fields)) return [];
@@ -585,7 +585,7 @@ const numericFieldOptions = computed(() => {
 });
 
 const stringFieldOptions = computed(() => {
-	const dt = props.doctype;
+	const dt = props.doctype || store.rule_doc?.document_type;
 	if (!dt) return [];
 	const fields = store.doc_meta[dt];
 	if (!fields || !Array.isArray(fields)) return [];
@@ -603,7 +603,7 @@ const stringFieldOptions = computed(() => {
 });
 
 const tableFieldOptions = computed(() => {
-	const dt = props.doctype;
+	const dt = props.doctype || store.rule_doc?.document_type;
 	if (!dt) return [];
 	const fields = store.doc_meta[dt];
 	if (!fields || !Array.isArray(fields)) return [];


### PR DESCRIPTION
## Summary

### Keyboard Event Handling Fixes
- **App.vue**: Added guard in global `handleKeydown` to skip key handling when the config modal is open, preventing shortcut conflicts (e.g., Ctrl+Up/Left navigating nodes while editing config)
- **RuleConfigModal.vue**: Refactored `handleKeydown` to capture `Escape` and `Ctrl+S` **before** checking for focused inputs, ensuring modal close and save always work regardless of input focus

### Assignment Config Improvements
- **AssignmentConfig.vue**: Fixed `store.rule` → `store.rule_doc` reference to correctly resolve the document type for target field lookups
- **AssignmentConfig.vue**: Added `getDefaultResolverKind()` — intelligently selects the default resolver type based on the target field's data type:
  - `Int/Float/Percent/Currency` → `math_formula`
  - `Date/Datetime` → `date_formula`
  - All others → `string_formula`
- **AssignmentConfig.vue**: Redesigned the "Add Assignment" button with dashed border styling and improved spacing
- **AssignmentConfig.vue**: Overhauled grid layout with `minmax()` responsive columns, better padding, and hover elevation effects

### ValueResolverControl Fixes
- **ValueResolverControl.vue**: Fixed `props.doctype` fallback in `dateFieldOptions`, `numericFieldOptions`, `stringFieldOptions`, and `tableFieldOptions` to use `store.rule_doc?.document_type` when `props.doctype` is not provided

## Files Changed
- `flexirule/public/js/flexirule/rule_builder/App.vue`
- `flexirule/public/js/flexirule/rule_builder/components/rule_config/RuleConfigModal.vue`
- `flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue`
- `flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue`