### PR TITLE
Fix GitHub Pages build failure by escaping Liquid-like syntax

### DIFF
--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -59,10 +59,10 @@ A sophisticated rich-text editor based on Tiptap that seamlessly blends static t
 
 ### ✨ Key Features & Innovation
 
-- **Visual Logic Blocks:** Instead of writing complex Jinja tags (`{% if ... %}`), users insert visual "Badges" for conditions and loops.
+- **Visual Logic Blocks:** Instead of writing complex Jinja tags ({% raw %}`{% if ... %}`{% endraw %}), users insert visual "Badges" for conditions and loops.
 - **Nested Recursive Editing:** Double-clicking a logic badge opens a "Bottom Panel" containing another instance of `TextGeneratorControl`, allowing users to define content for "IF TRUE", "ELSE", or "LOOP BODY" in a structured, hierarchical way.
 - **Slash Commands & Mentions:**
-    - Typing `@` or `{{` triggers a field picker for inserting dynamic variables.
+    - Typing `@` or {% raw %}`{{`{% endraw %} triggers a field picker for inserting dynamic variables.
     - Typing `/` opens a logic block picker.
 - **Live Jinja Synchronization:** Seamlessly toggles between a "Visual" mode and a "Raw Jinja" mode, ensuring compatibility for power users while maintaining simplicity for others.
 - **Context-Aware Iterators:** Inside a loop block, the variable picker automatically includes properties of the current loop item (e.g., `item.qty`).
@@ -80,12 +80,12 @@ The `FlexStructuredValueControl` is a hybrid, single-line input field that seaml
 
 - **Context-Aware Static Mode:** Automatically renders the appropriate Frappe control (Link, Select, Check, etc.) based on the target field's type.
 - **Tiptap-Powered Expression Mode:** A single-line rich-text editor that supports:
-    - **@ Mentions**: For inserting document fields or context variables.
-    - **Slash Commands (/)**: A command palette for inserting advanced logic tokens like formulas, formatters, and localizations.
+    - **@ Mentions:** For inserting document fields or context variables.
+    - **Slash Commands (/):** A command palette for inserting advanced logic tokens like formulas, formatters, and localizations.
 - **Unified UI:** Users can switch between static input and dynamic expressions without leaving the field. Typing `@` or `/` in a static field automatically upgrades it to expression mode.
 - **Tokenized Logic Chips:** Advanced logic is represented as compact, color-coded "chips" (e.g., 🧮 Formula, 🎨 Format) that open a specialized configuration popover when clicked.
-- **Field-Type Intelligent Filtering**: The command palette (/) intelligently filters available logic tokens based on the field's data type (e.g., only showing currency formatting for numeric fields).
-- **Single-Line Constraint**: Custom Tiptap extensions ensure the editor remains a single line, ideal for grid-based configurations like the Assignment action.
+- **Field-Type Intelligent Filtering:** The command palette (/) intelligently filters available logic tokens based on the field's data type (e.g., only showing currency formatting for numeric fields).
+- **Single-Line Constraint:** Custom Tiptap extensions ensure the editor remains a single line, ideal for grid-based configurations like the Assignment action.
 
 ---
 

--- a/docs/actions/assignment.md
+++ b/docs/actions/assignment.md
@@ -80,7 +80,7 @@ The configuration is stored as a JSON array of assignment objects. The engine ha
 		"target": "vars.counter",
 		"operator": "increment",
 		"value_mode": "resolver",
-		"value_template": "{{ 1 }}",
+		"value_template": "{% raw %}{{ 1 }}{% endraw %}",
 		"value_template_ui": {
 			"kind": "math_formula",
 			"constant_b": 1

--- a/docs/actions/query_records.md
+++ b/docs/actions/query_records.md
@@ -12,7 +12,7 @@ The **Query Records** action retrieves data from any DocType in the system.
 
 ## Filters
 
-The visual filter builder allows you to define complex query criteria. You can use literal values or dynamic references from the context (e.g., `{{ doc.customer }}`).
+The visual filter builder allows you to define complex query criteria. You can use literal values or dynamic references from the context (e.g., {% raw %}`{{ doc.customer }}`{% endraw %}).
 
 ## Results
 


### PR DESCRIPTION
This PR fixes a GitHub Pages build failure caused by Jekyll misinterpreting Jinja/Liquid-like syntax in the documentation. By wrapping these tags in `{% raw %}` and `{% endraw %}`, we ensure Jekyll treats them as literal text. Additionally, a minor formatting issue in `docs/CONTROLS.md` was corrected for better consistency.

---
*PR created automatically by Jules for task [2009921270157331926](https://jules.google.com/task/2009921270157331926) started by @Sendipad*