### PR TITLE
Modernize GitHub Pages Deployment Workflow

### DIFF
--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -3,24 +3,38 @@ name: Deploy Landing Page
 on:
   push:
     branches:
-      - develop # Or the user's primary branch name
+      - develop
     paths:
       - 'landing-page/**'
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./landing-page
-          publish_branch: gh-pages
+          path: './landing-page'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
I've modernized your GitHub Pages deployment workflow to use the latest GitHub-recommended method. This should resolve the issue where your site was rendering the repository's README instead of the landing page.

Key changes:
- Updated `.github/workflows/deploy-landing-page.yml` to use `actions/upload-pages-artifact` and `actions/deploy-pages`.
- Added necessary permissions (`pages: write`, `id-token: write`) for secure deployment.
- Configured the workflow to deploy specifically from the `landing-page` directory.

**Action Required:**
To enable this new workflow, you must update your repository settings:
1. Go to your repository on GitHub.
2. Navigate to **Settings** > **Pages**.
3. Under **Build and deployment** > **Source**, change the dropdown from "Deploy from a branch" to **"GitHub Actions"**.

Once changed, the next push to the `develop` branch (or a manual trigger of the workflow) will deploy your landing page correctly.

---
*PR created automatically by Jules for task [11398698805755545697](https://jules.google.com/task/11398698805755545697) started by @Sendipad*