### PR TITLE
Fix Hugo Build and Pathing for Documentation on GitHub Pages

### DIFF
--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -54,14 +54,22 @@ jobs:
           npm install
 
           # 3. Apply custom configurations
-          # Using case-insensitive sed to match baseURL or baseurl
-          sed -i 's|base[uU][rR][lL] = ".*"|baseurl = "https://sendipad.github.io/flexirule/docs/"|' config/_default/hugo.toml
+          # Update baseURL in both default and production configs
+          sed -i 's|base[uU][rR][lL] = ".*"|baseURL = "https://sendipad.github.io/flexirule/docs/"|' config/_default/hugo.toml
+          [ -f config/production/hugo.toml ] && sed -i 's|base[uU][rR][lL] = ".*"|baseURL = "https://sendipad.github.io/flexirule/docs/"|' config/production/hugo.toml
+
           sed -i 's|title = ".*"|title = "FlexiRule Documentation"|' config/_default/hugo.toml
 
-          # Use our custom menu
+          # Adjust permalinks to serve docs at the root of the /docs/ subfolder
+          # This makes content/docs/_index.md available at the Hugo site root
+          sed -i 's|docs = "/docs/:sections\[1:\]/:slug/"|docs = "/:sections[1:]/:slug/"|' config/_default/hugo.toml
+
+          # Use our custom menu - ensure directory exists
+          mkdir -p config/_default/menus
           cp ../docs-config/menus.en.toml config/_default/menus/menus.en.toml
 
           # 4. Copy content
+          # Doks expects documentation in content/docs/
           rm -rf content/docs/*
           cp -r ../docs/* content/docs/
 
@@ -71,7 +79,8 @@ jobs:
           # 6. Move output to landing page
           cd ..
           mkdir -p landing-page/docs
-          # Copy the entire public folder so assets (CSS/JS) are included.
+          # Copy the entire public folder to landing-page/docs/
+          # This ensures that assets are served from /flexirule/docs/
           cp -r temp-docs/public/* landing-page/docs/
 
       - name: Upload artifact

--- a/docs-config/menus.en.toml
+++ b/docs-config/menus.en.toml
@@ -1,6 +1,6 @@
 [[main]]
   name = "Docs"
-  url = "/docs/"
+  url = "/"
   weight = 10
 
 [[social]]


### PR DESCRIPTION
The Hugo documentation built with the Doks theme was failing to display correctly when hosted in the `/docs/` subdirectory on GitHub Pages. This was due to incorrect `baseURL` configuration and redundant path nesting in permalinks.

This change:
1.  Updates the `baseURL` to `https://sendipad.github.io/flexirule/docs/` in both default and production Hugo configurations during the build process.
2.  Adjusts Hugo permalinks for the `docs` section to be relative to the site root, preventing the generated URLs from being `/docs/docs/...`.
3.  Fixes the custom menu configuration to point to the correct documentation root.
4.  Ensures that the Hugo build artifacts are correctly merged into the `landing-page/docs` directory for deployment.
5.  Addresses code review feedback regarding Node.js versioning and TOML key casing.

---
*PR created automatically by Jules for task [15984968736082941914](https://jules.google.com/task/15984968736082941914) started by @Sendipad*