### PR TITLE
Fix YAML syntax in deploy-landing-page workflow

### DIFF
--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -82,12 +82,12 @@ jobs:
           # Fix JSX issue by configuring esbuild loader for .js files globally
           cat >> config/_default/hugo.toml <<EOF
 
-[module]
-  [module.hugo-build]
-    [[module.hugo-build.getjs-loader]]
-      extension = ".js"
-      loader = "jsx"
-EOF
+          [module]
+            [module.hugo-build]
+              [[module.hugo-build.getjs-loader]]
+                extension = ".js"
+                loader = "jsx"
+          EOF
 
           # Use our custom menu
           mkdir -p config/_default/menus


### PR DESCRIPTION
The workflow file `.github/workflows/deploy-landing-page.yml` had a syntax error because a heredoc block was not properly indented within a YAML `run` step. This change indents the TOML configuration block and its `EOF` marker, making the YAML file valid. Local verification with `PyYAML` confirms the fix.

---
*PR created automatically by Jules for task [16161006909749007789](https://jules.google.com/task/16161006909749007789) started by @Sendipad*