### PR TITLE
refactor: unify dynamic value compilation and resolution (FlexValue core)

### DIFF
--- a/flexirule/ruleflow/core/action_handlers/assignment.py
+++ b/flexirule/ruleflow/core/action_handlers/assignment.py
@@ -14,6 +14,7 @@ from flexirule.ruleflow.core.context_manager import ContextManager
 from flexirule.ruleflow.core.exceptions import MethodExecutionError
 from flexirule.ruleflow.core.operators import AssignmentOperatorRegistry
 from flexirule.ruleflow.core.process_runtime_v2 import AFTER_EVENT_MUTATION_BLOCKLIST
+from flexirule.ruleflow.core.flex_value import FlexValueCompiler, FlexValueRuntime
 
 
 class AssignmentHandler(ActionHandler):
@@ -110,29 +111,7 @@ class AssignmentHandler(ActionHandler):
 		return value_template
 
 	def _resolve_context_path(self, context: dict, path: str | None):
-		if not path:
-			return None
-
-		parts = str(path).split(".")
-		base = parts[0]
-		if base == "doc":
-			current = context.get("doc")
-		elif base == "vars":
-			current = context.get("vars", {})
-		else:
-			return None
-
-		for part in parts[1:]:
-			if current is None:
-				return None
-			if isinstance(current, dict):
-				current = current.get(part)
-			elif hasattr(current, "get"):
-				current = current.get(part)
-			else:
-				return None
-
-		return current
+		return FlexValueRuntime.resolve_context_path(context, path)
 
 	def _to_config_cache_key(self, config) -> str:
 		if isinstance(config, str):
@@ -221,96 +200,7 @@ class AssignmentHandler(ActionHandler):
 
 	@classmethod
 	def _compile_operand_spec(cls, row: dict, requires_value: bool) -> dict:
-		if not requires_value:
-			return {
-				"value_source": "none",
-				"value_literal": None,
-				"value_template": None,
-				"value_path": None,
-			}
-
-		# Check if the new unified 'value' key holds a structured object
-		val_obj = row.get("value")
-		if isinstance(val_obj, dict) and "mode" in val_obj:
-			mode = val_obj.get("mode")
-			if mode in {"static", "link", "dynamic_link"}:
-				return {
-					"value_source": "literal",
-					"value_literal": val_obj.get("value"),
-					"value_template": None,
-					"value_path": None,
-				}
-			if mode == "variable":
-				return {
-					"value_source": "context_path",
-					"value_literal": None,
-					"value_template": None,
-					"value_path": cls._normalize_context_path(val_obj.get("path")),
-				}
-			# Formula/Resolver/Formatter etc compile to Jinja
-			compiled_jinja = cls._compile_structured_value_to_jinja(val_obj)
-			return {
-				"value_source": "jinja",
-				"value_literal": None,
-				"value_template": compiled_jinja,
-				"value_path": None,
-			}
-
-		explicit_source = row.get("value_source")
-		if explicit_source in {"literal", "context_path", "jinja"}:
-			return {
-				"value_source": explicit_source,
-				"value_literal": row.get("value_literal"),
-				"value_template": row.get("value_template") or row.get("value"),
-				"value_path": cls._normalize_context_path(row.get("value_path")),
-			}
-
-		value_template = row.get("value_template")
-		if value_template is None:
-			value_template = row.get("value")
-
-		ui_val = row.get("value_template_ui")
-		value_ui = ui_val if isinstance(ui_val, dict) else {}
-		mode = value_ui.get("mode")
-
-		if mode in {"static", "link", "dynamic_link"}:
-			return {
-				"value_source": "literal",
-				"value_literal": value_ui.get("value"),
-				"value_template": None,
-				"value_path": None,
-			}
-
-		if mode == "variable":
-			return {
-				"value_source": "context_path",
-				"value_literal": None,
-				"value_template": None,
-				"value_path": cls._normalize_context_path(value_ui.get("path")),
-			}
-
-		if isinstance(value_template, str):
-			contains_jinja = "{{" in value_template or "{%" in value_template
-			if mode in {"formula", "resolver"} or contains_jinja:
-				return {
-					"value_source": "jinja",
-					"value_literal": None,
-					"value_template": value_template,
-					"value_path": None,
-				}
-			return {
-				"value_source": "literal",
-				"value_literal": value_template,
-				"value_template": None,
-				"value_path": None,
-			}
-
-		return {
-			"value_source": "literal",
-			"value_literal": value_template,
-			"value_template": None,
-			"value_path": None,
-		}
+		return FlexValueCompiler.compile_operand(row, requires_value=requires_value)
 
 	@staticmethod
 	def _compile_when_expression(row: dict) -> str:

--- a/flexirule/ruleflow/core/action_handlers/query_records.py
+++ b/flexirule/ruleflow/core/action_handlers/query_records.py
@@ -20,6 +20,7 @@ from frappe.utils import add_days, get_first_day, get_last_day, getdate, nowdate
 from flexirule.ruleflow.core.action_handlers import ActionHandler, HandlerRegistry
 from flexirule.ruleflow.core.permissions import can_skip_permissions
 from flexirule.ruleflow.utils.mapping import apply_input_mapping
+from flexirule.ruleflow.core.flex_value import FlexValueRuntime
 
 
 class QueryRecordsHandler(ActionHandler):
@@ -292,48 +293,12 @@ class QueryRecordsHandler(ActionHandler):
 			)
 
 	def _resolve_value_expression_with_context(self, value, context, ref_label: str):
-		if isinstance(value, list):
-			return [self._resolve_value_expression_with_context(v, context, ref_label) for v in value]
-		if isinstance(value, str) and "{" in value:
-			if value.startswith("{") and value.endswith("}") and value.count("{") == 1:
-				inner_expr = value[1 : len(value) - 1]
-				return self._safe_eval_with_context(inner_expr, context, ref_label)
-			import re
+		def _evaluate(expr, expr_context, expr_ref):
+			return self._safe_eval_with_context(expr, expr_context, expr_ref)
 
-			def replace(match):
-				expr = match.group(1)
-				result = self._safe_eval_with_context(expr, context, ref_label)
-				return str(result)
-
-			return re.sub(r"{(.*?)}", replace, value)
-		return value
+		return FlexValueRuntime.resolve_expressions(value, context, _evaluate, ref_label)
 
 	def _resolve_filters_with_context(self, filters, context, ref_label: str):
-		if not filters:
-			return filters
-		if isinstance(filters, list):
-			resolved_list = []
-			for idx, item in enumerate(filters):
-				child_ref = f"{ref_label}[{idx}]"
-				if isinstance(item, dict) and ("field" in item or "fieldname" in item):
-					resolved_list.append(
-						{
-							k: self._resolve_value_expression_with_context(v, context, f"{child_ref}.{k}")
-							for k, v in item.items()
-						}
-					)
-				elif isinstance(item, list | dict):
-					resolved_list.append(self._resolve_filters_with_context(item, context, child_ref))
-				else:
-					resolved_list.append(
-						self._resolve_value_expression_with_context(item, context, child_ref)
-					)
-			return resolved_list
-		if isinstance(filters, dict):
-			return {
-				key: self._resolve_value_expression_with_context(value, context, f"{ref_label}.{key}")
-				for key, value in filters.items()
-			}
 		return self._resolve_value_expression_with_context(filters, context, ref_label)
 
 	def _resolve_query_filters(self, config, context, action=None):

--- a/flexirule/ruleflow/core/flex_value.py
+++ b/flexirule/ruleflow/core/flex_value.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026, FlexiRule and contributors
+# For license information, please see license.txt
+
+"""Unified FlexValue compiler/runtime helpers.
+
+Centralizes dynamic value schema normalization and resolution so action handlers
+use one deterministic contract.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import frappe
+
+FLEX_VALUE_SOURCES = {"literal", "context_path", "jinja"}
+
+
+class FlexValueCompiler:
+	"""Compile heterogeneous authoring payloads into normalized operand specs."""
+
+	@classmethod
+	def compile_operand(cls, row: dict, *, requires_value: bool) -> dict[str, Any]:
+		if not requires_value:
+			return {"value_source": "none", "value_literal": None, "value_template": None, "value_path": None}
+
+		val_obj = row.get("value")
+		if isinstance(val_obj, dict) and "mode" in val_obj:
+			return cls._compile_structured_mode(val_obj)
+
+		explicit_source = row.get("value_source")
+		if explicit_source in FLEX_VALUE_SOURCES:
+			return {
+				"value_source": explicit_source,
+				"value_literal": row.get("value_literal"),
+				"value_template": row.get("value_template") or row.get("value"),
+				"value_path": cls.normalize_context_path(row.get("value_path")),
+			}
+
+		value_template = row.get("value_template") if row.get("value_template") is not None else row.get("value")
+		value_ui = row.get("value_template_ui") if isinstance(row.get("value_template_ui"), dict) else {}
+		mode = value_ui.get("mode")
+
+		if mode in {"static", "link", "dynamic_link"}:
+			return {"value_source": "literal", "value_literal": value_ui.get("value"), "value_template": None, "value_path": None}
+		if mode == "variable":
+			return {"value_source": "context_path", "value_literal": None, "value_template": None, "value_path": cls.normalize_context_path(value_ui.get("path"))}
+		if isinstance(value_template, str):
+			contains_jinja = "{{" in value_template or "{%" in value_template
+			if mode in {"formula", "resolver"} or contains_jinja:
+				return {"value_source": "jinja", "value_literal": None, "value_template": value_template, "value_path": None}
+		return {"value_source": "literal", "value_literal": value_template, "value_template": None, "value_path": None}
+
+	@classmethod
+	def _compile_structured_mode(cls, val_obj: dict[str, Any]) -> dict[str, Any]:
+		mode = val_obj.get("mode")
+		if mode in {"static", "link", "dynamic_link"}:
+			return {"value_source": "literal", "value_literal": val_obj.get("value"), "value_template": None, "value_path": None}
+		if mode == "variable":
+			return {"value_source": "context_path", "value_literal": None, "value_template": None, "value_path": cls.normalize_context_path(val_obj.get("path"))}
+		return {"value_source": "jinja", "value_literal": None, "value_template": cls.compile_structured_to_jinja(val_obj), "value_path": None}
+
+	@classmethod
+	def compile_structured_to_jinja(cls, val: dict[str, Any]) -> str:
+		if not val:
+			return ""
+		mode = val.get("mode")
+		if mode in {"static", "link", "dynamic_link"}:
+			return str(val.get("value") if val.get("value") is not None else "")
+		if mode == "variable":
+			path = cls.normalize_context_path(val.get("path"))
+			return f"{{{{ {path} }}}}" if path else ""
+		if mode == "formula":
+			return f"{{{{ {val.get('expression') or ''} }}}}"
+		if mode in {"formatter", "normalize", "resolver", "condition"}:
+			config = val.get("config") or {}
+			return f"{{{{ resolve_dynamic({json.dumps({'mode': mode, 'value': val.get('value'), 'expression': val.get('expression'), 'config': config, 'steps': val.get('steps'), 'formatter': val.get('formatter')})}) }}}}"
+		return ""
+
+	@staticmethod
+	def normalize_context_path(path: Any) -> str | None:
+		if not path:
+			return None
+		path_str = str(path).strip()
+		if not path_str:
+			return None
+		if path_str.startswith("doc.") or path_str.startswith("vars."):
+			return path_str
+		return f"vars.{path_str}"
+
+
+class FlexValueRuntime:
+	"""Runtime utilities for expression interpolation and context resolution."""
+
+	@staticmethod
+	def resolve_context_path(context: dict, path: str | None):
+		if not path:
+			return None
+		parts = str(path).split(".")
+		current = context.get("doc") if parts[0] == "doc" else context.get("vars", {}) if parts[0] == "vars" else None
+		for part in parts[1:]:
+			if current is None:
+				return None
+			current = current.get(part) if isinstance(current, dict) or hasattr(current, "get") else None
+		return current
+
+	@staticmethod
+	def resolve_expressions(value: Any, context: dict, evaluator, ref_label: str):
+		if isinstance(value, list):
+			return [FlexValueRuntime.resolve_expressions(v, context, evaluator, ref_label) for v in value]
+		if isinstance(value, dict):
+			return {
+				k: FlexValueRuntime.resolve_expressions(v, context, evaluator, f"{ref_label}.{k}") for k, v in value.items()
+			}
+		if isinstance(value, str) and "{" in value:
+			if value.startswith("{") and value.endswith("}") and value.count("{") == 1:
+				return evaluator(value[1:-1], context, ref_label)
+			return re.sub(r"{(.*?)}", lambda m: str(evaluator(m.group(1), context, ref_label)), value)
+		return value


### PR DESCRIPTION
### Motivation
- Remove duplicated per-handler dynamic value logic and converge value compilation/resolution into a single deterministic contract for assignments, query filters, and future consumers.
- Provide a stable foundation for later work (precompilation, caching, normalized schemas, and unified frontend/backend authoring) by centralizing normalization and traversal primitives.

### Description
- Add `flexirule/ruleflow/core/flex_value.py` with `FlexValueCompiler` to normalize authored payloads into a runtime operand spec and `FlexValueRuntime` to resolve context paths and `{expr}` interpolation.
- Refactor `AssignmentHandler` (`flexirule/ruleflow/core/action_handlers/assignment.py`) to delegate operand compilation and context-path resolution to `FlexValueCompiler`/`FlexValueRuntime` and remove duplicated conversion logic.
- Refactor `QueryRecordsHandler` (`flexirule/ruleflow/core/action_handlers/query_records.py`) to use `FlexValueRuntime.resolve_expressions` with a safe-eval wrapper for nested filter and expression traversal.
- Minimal API-preserving changes: import adjustments and replacement of local helpers with centralized calls so handlers share consistent semantics.

### Testing
- Ran module compilation with `python -m compileall flexirule/ruleflow/core/flex_value.py flexirule/ruleflow/core/action_handlers/assignment.py flexirule/ruleflow/core/action_handlers/query_records.py`, which succeeded.
- Ran `pytest -q flexirule/ruleflow/tests/test_assignment_resolver.py`, which failed to run in this environment due to missing runtime dependency `frappe` (ModuleNotFoundError), so tests could not be executed here.
- Ran `pre-commit` locally as per workflow, which could not be executed in this environment because `pre-commit` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1098a71fe8832baec1315e3a9cb199)