### PR TITLE
Unified Value Resolver Backend and frontend

### DIFF
--- a/flexirule/public/js/flexirule/core/builder_utils.js
+++ b/flexirule/public/js/flexirule/core/builder_utils.js
@@ -122,7 +122,9 @@ export function compileToCode(item, fallbackField = "") {
 		item.base_type === "today"
 			? "frappe.utils.nowdate()"
 			: toDocExpression(item.base_field || fallbackField);
-	const offset = parseInt(item.offset_value || 0, 10);
+	let offset = parseInt(item.offset_value || 0, 10);
+	// Handle separate offset_sign field from ValueResolverControl
+	if (item.offset_sign === "-" && offset > 0) offset = -offset;
 
 	if (offset === 0 || !item.offset_unit) {
 		return `{${baseExpr}}`;
@@ -146,7 +148,9 @@ export function compileToLabel(item) {
 
 	if (item.kind === "date_formula") {
 		const base = item.base_type === "today" ? __("Today") : item.base_field || __("Doc Field");
-		const offset = parseInt(item.offset_value || 0, 10);
+		let offset = parseInt(item.offset_value || 0, 10);
+		// Handle separate offset_sign field from ValueResolverControl
+		if (item.offset_sign === "-" && offset > 0) offset = -offset;
 		if (offset === 0) return base;
 		const sign = offset > 0 ? "+" : "";
 		return `${base} ${sign}${offset} ${item.offset_unit}`;

--- a/flexirule/public/js/flexirule/core/formula_registry.js
+++ b/flexirule/public/js/flexirule/core/formula_registry.js
@@ -219,17 +219,24 @@ export function getFormulasForFieldtype(ft) {
  */
 export function getAllowedBuilderKinds(fieldtype) {
 	if (!fieldtype) return null;
-	if (["Date", "Datetime"].includes(fieldtype)) {
+	if (["Date", "Datetime", "Time"].includes(fieldtype)) {
 		return ["date_formula", "date_diff", "format", "system_context"];
 	}
-	if (["Int", "Float", "Currency", "Percent"].includes(fieldtype)) {
+	if (["Int", "Float", "Currency", "Percent", "Duration"].includes(fieldtype)) {
 		return ["math_formula", "child_aggregation", "date_diff", "format", "system_context"];
 	}
-	if (["Data", "Small Text", "Text", "Long Text", "Select"].includes(fieldtype)) {
+	if (
+		["Data", "Small Text", "Text", "Long Text", "Text Editor", "Code", "Select"].includes(
+			fieldtype
+		)
+	) {
 		return ["normalization", "format", "string_formula", "system_context"];
 	}
 	if (["Check"].includes(fieldtype)) {
 		return ["system_context"];
+	}
+	if (["Link", "Dynamic Link"].includes(fieldtype)) {
+		return ["string_formula", "format", "system_context"];
 	}
 	return null;
 }

--- a/flexirule/public/js/flexirule/core/formula_registry.js
+++ b/flexirule/public/js/flexirule/core/formula_registry.js
@@ -210,3 +210,26 @@ export function getFormulasForFieldtype(ft) {
 	const group = getGroupForFieldtype(ft);
 	return FORMULA_REGISTRY[group] || [];
 }
+
+/**
+ * Retrieve allowed builder resolver kinds for a given field type.
+ * Centralizes the metadata mapping instead of hardcoding resolver types locally.
+ * @param {string} fieldtype - The field type (e.g. 'Date', 'Int', 'Data')
+ * @returns {string[]|null} - Array of allowed kinds, or null if all are allowed
+ */
+export function getAllowedBuilderKinds(fieldtype) {
+	if (!fieldtype) return null;
+	if (["Date", "Datetime"].includes(fieldtype)) {
+		return ["date_formula", "date_diff", "format", "system_context"];
+	}
+	if (["Int", "Float", "Currency", "Percent"].includes(fieldtype)) {
+		return ["math_formula", "child_aggregation", "date_diff", "format", "system_context"];
+	}
+	if (["Data", "Small Text", "Text", "Long Text", "Select"].includes(fieldtype)) {
+		return ["normalization", "format", "string_formula", "system_context"];
+	}
+	if (["Check"].includes(fieldtype)) {
+		return ["system_context"];
+	}
+	return null;
+}

--- a/flexirule/public/js/flexirule/rule_builder/components/condition_builder/SimpleCondition.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/condition_builder/SimpleCondition.vue
@@ -7,8 +7,10 @@ import ControlFactory from "../../controls/ControlFactory.vue";
 import SelectControl from "../../controls/SelectControl.vue";
 import ComboBoxControl from "../../controls/ComboBoxControl.vue";
 import ContextPicker from "../ContextPicker.vue";
+import ValueResolverControl from "../../controls/ValueResolverControl.vue";
 import { useMetaStore } from "../../stores/useMetaStore";
 import { inject, ref, computed, watch, nextTick } from "vue";
+import { getAllowedBuilderKinds } from "../../../core/formula_registry";
 
 const props = defineProps({
 	node: { type: Object, required: true },
@@ -259,16 +261,25 @@ watch(
 
 // Value Type State (Static vs Field)
 const valueType = computed({
-	get: () => (props.node.right?.ref ? "field" : "static"),
+	get: () => {
+		if (props.node.right?.value?.mode === "resolver") return "builder";
+		return props.node.right?.ref ? "field" : "static";
+	},
 	set: (type) => {
 		if (type === "field") {
 			props.node.right.value = "";
 			if (!props.node.right.ref) props.node.right.ref = context.alias + ".";
+		} else if (type === "builder") {
+			props.node.right.ref = "";
+			props.node.right.value = { mode: "resolver", config: { kind: "system_context" } };
 		} else {
 			props.node.right.ref = "";
+			if (props.node.right?.value?.mode === "resolver") props.node.right.value = "";
 		}
 	},
 });
+
+const allowedBuilderKinds = computed(() => getAllowedBuilderKinds(selectedField.value?.fieldtype));
 </script>
 
 <template>
@@ -318,6 +329,7 @@ const valueType = computed({
 				>
 					<option value="static">{{ __("Static") }}</option>
 					<option value="field">{{ __("Field") }}</option>
+					<option value="builder">{{ __("Builder") }}</option>
 				</select>
 
 				<div class="value-input-wrapper">
@@ -342,6 +354,16 @@ const valueType = computed({
 							v-model="node.right.ref"
 							:docFields="docFields"
 							:disabled="readOnly"
+						/>
+					</template>
+					<template v-else-if="valueType === 'builder'">
+						<ValueResolverControl
+							:modelValue="node.right.value"
+							:doctype="store?.rule_doc?.document_type"
+							:context="{ fieldname: selectedField?.value, operator: node.op }"
+							:readOnly="readOnly"
+							:allowedKinds="allowedBuilderKinds"
+							@update:modelValue="(val) => (node.right.value = val)"
 						/>
 					</template>
 					<template v-else>

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/FilterGroup.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/FilterGroup.vue
@@ -338,6 +338,7 @@ import ValueResolverControl from "../../controls/ValueResolverControl.vue";
 import { useStore } from "../../stores";
 import { compileToCode } from "../../../core/builder_utils.js";
 import { getContract } from "../../../core/contracts.js";
+import { getAllowedBuilderKinds as getAllowedBuilderKindsRegistry } from "../../../core/formula_registry.js";
 
 const props = defineProps({
 	modelValue: {
@@ -719,12 +720,20 @@ const emitUpdate = () => {
 		.filter((r) => r.field)
 		.map((r) => {
 			const n = normalizeRowForEmit(r);
-			const payload = {
-				value: n.value,
-				value_type: n.value_type || "Value",
-			};
+			let payload;
 			if (n.value_type === BUILDER_VALUE_TYPE && n.builder) {
-				payload.builder = n.builder;
+				payload = {
+					mode: "resolver",
+					config: n.builder,
+					value_type: BUILDER_VALUE_TYPE,
+					builder: n.builder,
+					value: n.value,
+				};
+			} else {
+				payload = {
+					value: n.value,
+					value_type: n.value_type || "Value",
+				};
 			}
 			return [n.doctype || props.doctype, n.field, n.operator || "=", payload];
 		});
@@ -732,6 +741,11 @@ const emitUpdate = () => {
 };
 
 const guessValueType = (val) => {
+	if (val && typeof val === "object") {
+		if (val.value_type) return val.value_type;
+		if (val.mode === "resolver") return "Builder";
+		return "Value";
+	}
 	if (typeof val === "number") return "Number";
 	if (typeof val === "boolean") return "Boolean";
 	if (typeof val === "string" && val.startsWith("{") && val.endsWith("}")) {
@@ -1085,17 +1099,7 @@ const STRING_FIELDTYPES = new Set(["Data", "Small Text", "Text", "Long Text", "S
 
 const getAllowedBuilderKinds = (row) => {
 	const field = getFieldDef(row.field, row.doctype || props.doctype);
-	if (!field || !field.fieldtype) return null; // all kinds
-	if (DATE_FIELDTYPES.has(field.fieldtype)) {
-		return ["date_formula", "date_diff", "format"];
-	}
-	if (NUMERIC_FIELDTYPES.has(field.fieldtype)) {
-		return ["math_formula", "format"];
-	}
-	if (STRING_FIELDTYPES.has(field.fieldtype)) {
-		return ["normalization", "format", "string_formula"];
-	}
-	return null; // all kinds
+	return getAllowedBuilderKindsRegistry(field?.fieldtype);
 };
 
 const normalizeBuilderItem = (item, fallbackField = "") => {

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/FilterGroup.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/FilterGroup.vue
@@ -67,191 +67,32 @@
 						</select>
 					</div>
 
-					<!-- Value Type -->
-					<div class="filter-col type-col">
-						<select
-							class="form-control input-xs type-select"
-							:value="row.value_type"
-							:disabled="readOnly"
-							@change="(e) => toggleValueType(idx, e.target.value)"
-						>
-							<option v-for="vt in getValueTypeOptions(row)" :key="vt" :value="vt">
-								{{ getValueTypeLabel(vt, row) }}
-							</option>
-						</select>
-					</div>
-
 					<!-- Value / Expression -->
 					<div class="filter-col value-col">
 						<div class="value-input-group">
-							<template
-								v-if="row.operator === 'Between' && row.value_type !== 'Builder'"
-							>
+							<template v-if="row.operator === 'Between'">
 								<div class="dual-value-wrapper">
 									<div class="value-input-item">
-										<template
-											v-if="
-												row.value_type === 'Variable' ||
-												row.value_type === 'Expression'
+										<FlexValueControl
+											:modelValue="getBuilderValue(row, 0)"
+											:context="{ df: getControlFactorySchema(row) }"
+											:disabled="readOnly"
+											@update:modelValue="
+												(val) => updateBuilderValue(idx, 0, val)
 											"
-										>
-											<ComboBoxControl
-												:df="{ fieldtype: 'Autocomplete', label: '' }"
-												:modelValue="
-													stripBracket(getBetweenValue(row.value, 0))
-												"
-												:get_query="getVariableOptions"
-												:hideLabel="true"
-												:read_only="readOnly"
-												@update:modelValue="
-													(val) =>
-														setBetweenValue(
-															idx,
-															0,
-															row.value_type === 'Value'
-																? val
-																: `{${val}}`
-														)
-												"
-											/>
-										</template>
-										<template v-else>
-											<ControlFactory
-												:df="getControlFactorySchema(row)"
-												:modelValue="getBetweenValue(row.value, 0)"
-												:read_only="readOnly"
-												:hideLabel="true"
-												@update:modelValue="
-													(val) => setBetweenValue(idx, 0, val)
-												"
-											/>
-										</template>
+										/>
 									</div>
 									<span class="between-sep">{{ __("and") }}</span>
 									<div class="value-input-item">
-										<template
-											v-if="
-												row.value_type === 'Variable' ||
-												row.value_type === 'Expression'
-											"
-										>
-											<ComboBoxControl
-												:df="{ fieldtype: 'Autocomplete', label: '' }"
-												:modelValue="
-													stripBracket(getBetweenValue(row.value, 1))
-												"
-												:get_query="getVariableOptions"
-												:hideLabel="true"
-												:read_only="readOnly"
-												@update:modelValue="
-													(val) =>
-														setBetweenValue(
-															idx,
-															1,
-															row.value_type === 'Value'
-																? val
-																: `{${val}}`
-														)
-												"
-											/>
-										</template>
-										<template v-else>
-											<ControlFactory
-												:df="getControlFactorySchema(row)"
-												:modelValue="getBetweenValue(row.value, 1)"
-												:read_only="readOnly"
-												:hideLabel="true"
-												@update:modelValue="
-													(val) => setBetweenValue(idx, 1, val)
-												"
-											/>
-										</template>
-									</div>
-								</div>
-							</template>
-							<template v-else-if="row.value_type === 'Builder'">
-								<div class="builder-wrapper">
-									<template v-if="row.operator === 'Between'">
-										<div class="dual-value-wrapper align-items-center">
-											<div class="value-input-item">
-												<ValueResolverControl
-													:modelValue="getBuilderValue(row, 0)"
-													:doctype="row.doctype || doctype"
-													:context="{
-														fieldname: row.field,
-														operator: row.operator,
-													}"
-													:readOnly="readOnly"
-													:allowedKinds="getAllowedBuilderKinds(row)"
-													@update:modelValue="
-														(val) => updateBuilderValue(idx, 0, val)
-													"
-												/>
-											</div>
-											<span class="between-sep">{{ __("and") }}</span>
-											<div class="value-input-item">
-												<ValueResolverControl
-													:modelValue="getBuilderValue(row, 1)"
-													:doctype="row.doctype || doctype"
-													:context="{
-														fieldname: row.field,
-														operator: row.operator,
-													}"
-													:readOnly="readOnly"
-													:allowedKinds="getAllowedBuilderKinds(row)"
-													@update:modelValue="
-														(val) => updateBuilderValue(idx, 1, val)
-													"
-												/>
-											</div>
-										</div>
-									</template>
-									<template v-else>
-										<ValueResolverControl
-											:modelValue="getBuilderValue(row)"
-											:doctype="row.doctype || doctype"
-											:context="{
-												fieldname: row.field,
-												operator: row.operator,
-											}"
-											:readOnly="readOnly"
-											:allowedKinds="getAllowedBuilderKinds(row)"
+										<FlexValueControl
+											:modelValue="getBuilderValue(row, 1)"
+											:context="{ df: getControlFactorySchema(row) }"
+											:disabled="readOnly"
 											@update:modelValue="
-												(val) => updateBuilderValue(idx, null, val)
+												(val) => updateBuilderValue(idx, 1, val)
 											"
 										/>
-									</template>
-								</div>
-							</template>
-							<template
-								v-else-if="
-									row.value_type === 'Expression' || row.value_type === 'Variable'
-								"
-							>
-								<div
-									class="expression-wrapper"
-									:class="{ 'variable-mode': row.value_type === 'Variable' }"
-								>
-									<span
-										class="expr-bracket"
-										v-if="row.value_type === 'Expression'"
-										>{</span
-									>
-									<ComboBoxControl
-										:df="{ fieldtype: 'Autocomplete', label: '' }"
-										:modelValue="stripBracket(row.value)"
-										:get_query="getVariableOptions"
-										:hideLabel="true"
-										:read_only="readOnly"
-										@update:modelValue="
-											(val) => updateRow(idx, { value: `{${val}}` })
-										"
-									/>
-									<span
-										class="expr-bracket"
-										v-if="row.value_type === 'Expression'"
-										>}</span
-									>
+									</div>
 								</div>
 							</template>
 							<template v-else>
@@ -293,12 +134,13 @@
 									</option>
 								</select>
 								<div v-else class="control-slot">
-									<ControlFactory
-										:df="getControlFactorySchema(row)"
-										:modelValue="getDisplayValue(row)"
-										:read_only="readOnly"
-										:hideLabel="true"
-										@update:modelValue="(val) => updateRow(idx, { value: val })"
+									<FlexValueControl
+										:modelValue="getBuilderValue(row)"
+										:context="{ df: getControlFactorySchema(row) }"
+										:disabled="readOnly"
+										@update:modelValue="
+											(val) => updateBuilderValue(idx, null, val)
+										"
 									/>
 								</div>
 							</template>
@@ -334,11 +176,9 @@
 import { ref, computed, watch, onMounted } from "vue";
 import ComboBoxControl from "../../controls/ComboBoxControl.vue";
 import ControlFactory from "../../controls/ControlFactory.vue";
-import ValueResolverControl from "../../controls/ValueResolverControl.vue";
+import FlexValueControl from "../../controls/FlexValueControl.vue";
 import { useStore } from "../../stores";
-import { compileToCode } from "../../../core/builder_utils.js";
 import { getContract } from "../../../core/contracts.js";
-import { getAllowedBuilderKinds as getAllowedBuilderKindsRegistry } from "../../../core/formula_registry.js";
 
 const props = defineProps({
 	modelValue: {
@@ -511,13 +351,6 @@ const BUILDER_SUPPORTED_FIELDTYPES = new Set([
 	"Long Text",
 	"Select",
 ]);
-const builderFunctionOptions = [
-	{ value: "add_days_doc", label: __("Document Date +/- Days") },
-	{ value: "doc_field", label: __("Document Date (No Offset)") },
-	{ value: "today", label: __("Today") },
-	{ value: "add_days_today", label: __("Today +/- Days") },
-];
-
 const CHECK_VALUE_TYPES = ["Boolean", "Variable", "Expression"];
 const isCheckField = (field) => field?.original_type === "Check" || field?.fieldtype === "Check";
 const getDefaultValueTypeForField = (field) => (isCheckField(field) ? "Boolean" : "Value");
@@ -1088,113 +921,23 @@ const addFilter = () => {
 	emitUpdate();
 };
 
-const toInt = (value, fallback = 0) => {
-	const parsed = Number.parseInt(value, 10);
-	return Number.isFinite(parsed) ? parsed : fallback;
-};
-
-const NUMERIC_FIELDTYPES = new Set(["Int", "Float", "Currency", "Percent"]);
-
 const STRING_FIELDTYPES = new Set(["Data", "Small Text", "Text", "Long Text", "Select"]);
 
-const getAllowedBuilderKinds = (row) => {
-	const field = getFieldDef(row.field, row.doctype || props.doctype);
-	return getAllowedBuilderKindsRegistry(field?.fieldtype);
-};
-
-const normalizeBuilderItem = (item, fallbackField = "") => {
-	const kind = item?.kind || "date_formula";
-
-	// For non-date kinds, pass through the item structure
-	if (kind === "math_formula") {
-		return {
-			kind: "math_formula",
-			field_a: item?.field_a || "",
-			math_op: item?.math_op || "+",
-			field_b_type: item?.field_b_type || "field",
-			field_b: item?.field_b || "",
-			constant_b: item?.constant_b ?? 0,
-			precision: item?.precision ?? 2,
-		};
-	}
-
-	if (kind === "date_diff") {
-		return {
-			kind: "date_diff",
-			diff_start_type: item?.diff_start_type || "today",
-			diff_start_field: item?.diff_start_field || "",
-			diff_end_type: item?.diff_end_type || "doc_field",
-			diff_end_field: item?.diff_end_field || fallbackField || "",
-			diff_unit: item?.diff_unit || "days",
-		};
-	}
-
-	// Default: date_formula (backward compatible)
-	const base_type =
-		item?.base_type || (item?.function_name?.includes("today") ? "today" : "doc_field");
-	return {
-		kind: "date_formula",
-		base_type: base_type,
-		base_field: item?.base_field || fallbackField || "posting_date",
-		offset_value: toInt(item?.offset_value ?? item?.offset_days ?? 0, 0),
-		offset_unit: item?.offset_unit || "days",
-	};
-};
-
-const getDefaultBuilderItem = (row) => {
-	const field = getFieldDef(row.field, row.doctype || props.doctype);
-	if (field && NUMERIC_FIELDTYPES.has(field.fieldtype)) {
-		return normalizeBuilderItem({ kind: "math_formula", field_a: row.field || "" });
-	}
-	const dateField =
-		getDateFieldOptions(row.doctype || props.doctype)[0]?.value || row.field || "posting_date";
-	return normalizeBuilderItem({}, dateField);
-};
-
-const compileBuilderExpression = (builder) => {
-	const item = normalizeBuilderItem(builder);
-	return compileToCode(item);
-};
-
-const syncBuilderToValue = (row) => {
-	if (row.value_type !== "Builder") return row;
-	if (row.operator === "Between") {
-		const list = Array.isArray(row.builder)
-			? row.builder
-			: [getDefaultBuilderItem(row), getDefaultBuilderItem(row)];
-		const normalized = [
-			normalizeBuilderItem(list[0], row.field || props.doctype),
-			normalizeBuilderItem(list[1], row.field || props.doctype),
-		];
-		row.builder = normalized;
-		row.value = normalized.map((item) => compileBuilderExpression(item));
-		return row;
-	}
-
-	const single = Array.isArray(row.builder) ? row.builder[0] : row.builder;
-	const normalized = normalizeBuilderItem(single, row.field || props.doctype);
-	row.builder = normalized;
-	row.value = compileBuilderExpression(normalized);
-	return row;
-};
+const getDefaultBuilderValue = () => ({ mode: "resolver", config: { kind: "system_context" } });
 
 const normalizeBuilderState = (row) => {
 	if (row.value_type !== "Builder") return row;
 
 	if (row.operator === "Between") {
-		let builder = row.builder;
-		if (!Array.isArray(builder)) {
-			builder = [{}, {}];
-		}
-		row.builder = [
-			normalizeBuilderItem(builder[0], row.field),
-			normalizeBuilderItem(builder[1], row.field),
+		const current = Array.isArray(row.value) ? row.value : [null, null];
+		row.value = [
+			current[0] || getDefaultBuilderValue(),
+			current[1] || getDefaultBuilderValue(),
 		];
 	} else {
-		const builder = Array.isArray(row.builder) ? row.builder[0] : row.builder;
-		row.builder = normalizeBuilderItem(builder, row.field);
+		row.value = row.value || getDefaultBuilderValue();
 	}
-	return syncBuilderToValue(row);
+	return row;
 };
 
 const getDateFieldOptions = (dt) => {
@@ -1202,33 +945,26 @@ const getDateFieldOptions = (dt) => {
 };
 
 const getBuilderValue = (row, idx = null) => {
-	// Read existing builder without re-normalizing to avoid creating new objects on every render.
-	// Builder is already normalized during mutations (syncFromProps, updateRow, toggleValueType).
-	const builder = row.builder;
-	if (!builder) {
-		return getDefaultBuilderItem(row);
-	}
+	const value = row.value;
+	if (!value) return getDefaultBuilderValue();
 	if (idx === null || idx === undefined) {
-		return Array.isArray(builder) ? builder[0] : builder;
+		return Array.isArray(value) ? value[0] || getDefaultBuilderValue() : value;
 	}
-	return Array.isArray(builder) ? builder[idx] || getDefaultBuilderItem(row) : builder;
+	return Array.isArray(value) ? value[idx] || getDefaultBuilderValue() : value;
 };
 
-const updateBuilderValue = (idx, builderIndex, partial) => {
+const updateBuilderValue = (idx, builderIndex, value) => {
 	const row = filters.value[idx];
-	const merged = normalizeBuilderState({ ...row });
-	if (merged.operator === "Between") {
-		const list = Array.isArray(merged.builder)
-			? [...merged.builder]
-			: [getDefaultBuilderItem(merged), getDefaultBuilderItem(merged)];
-		const i = builderIndex ?? 0;
-		list[i] = normalizeBuilderItem({ ...(list[i] || {}), ...partial }, merged.field);
-		merged.builder = list;
+	const merged = { ...row };
+	if (merged.operator === "Between" && builderIndex !== null && builderIndex !== undefined) {
+		const list = Array.isArray(merged.value)
+			? [...merged.value]
+			: [getDefaultBuilderValue(), getDefaultBuilderValue()];
+		list[builderIndex] = value || getDefaultBuilderValue();
+		merged.value = list;
 	} else {
-		const single = Array.isArray(merged.builder) ? merged.builder[0] : merged.builder;
-		merged.builder = normalizeBuilderItem({ ...(single || {}), ...partial }, merged.field);
+		merged.value = value || getDefaultBuilderValue();
 	}
-	syncBuilderToValue(merged);
 	filters.value[idx] = merged;
 	emitUpdate();
 };

--- a/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
@@ -84,6 +84,207 @@
 				</button>
 			</div>
 		</div>
+
+		<!-- ── Token Editor Modal ── -->
+		<Teleport to="body">
+			<div
+				v-if="activeTokenType"
+				class="fxr-token-modal-overlay"
+				@click.self="closeTokenEditor"
+			>
+				<div class="fxr-token-modal-container">
+					<!-- Header -->
+					<div class="fxr-token-modal-header">
+						<div class="d-flex align-items-center" style="gap: 8px">
+							<i
+								:class="activeTokenPresentation.icon"
+								style="font-size: 14px; color: #64748b"
+							></i>
+							<span style="font-weight: 600; font-size: 14px">{{
+								activeTokenPresentation.title
+							}}</span>
+						</div>
+						<button
+							type="button"
+							class="fvc-action-btn"
+							@click="closeTokenEditor"
+							:title="__('Close')"
+						>
+							<i class="fa fa-times"></i>
+						</button>
+					</div>
+
+					<!-- Body -->
+					<div class="fxr-token-modal-body">
+						<!-- JSON Editor Mode -->
+						<template v-if="activeTokenType === 'json'">
+							<textarea
+								class="json-textarea"
+								v-model="tokenDraftAttrs.value"
+								:placeholder="__('Paste or edit JSON/Expression here...')"
+							></textarea>
+							<div
+								v-if="jsonParseError"
+								class="text-danger mt-1"
+								style="font-size: 12px"
+							>
+								{{ jsonParseError }}
+							</div>
+						</template>
+
+						<!-- Visual Builder / Manual Editor -->
+						<template v-else>
+							<!-- Mode Toggle: Builder vs Manual -->
+							<div class="d-flex align-items-center justify-content-between mb-3">
+								<span class="fxr-label-sm mb-0">{{ __("Edit Mode") }}</span>
+								<div class="d-flex align-items-center" style="gap: 6px">
+									<button
+										type="button"
+										class="fvc-action-btn"
+										:style="
+											!isManualMode
+												? 'color: var(--fxr-accent); font-weight: 700'
+												: ''
+										"
+										@click="isManualMode = false"
+									>
+										<i class="fa fa-th-large mr-1"></i> {{ __("Visual") }}
+									</button>
+									<span style="color: #cbd5e1">|</span>
+									<button
+										type="button"
+										class="fvc-action-btn"
+										:style="
+											isManualMode
+												? 'color: var(--fxr-accent); font-weight: 700'
+												: ''
+										"
+										@click="isManualMode = true"
+									>
+										<i class="fa fa-code mr-1"></i> {{ __("Manual") }}
+									</button>
+								</div>
+							</div>
+
+							<!-- Visual Builder -->
+							<div v-if="!isManualMode">
+								<ValueResolverControl
+									viewMode="inline"
+									:modelValue="tokenDraftAttrs.config"
+									:doctype="referenceDoctype"
+									:context="context"
+									:allowedKinds="allowedBuilderKinds"
+									@update:modelValue="handleBuilderUpdate"
+								/>
+							</div>
+
+							<!-- Manual Formula Editor -->
+							<div v-else>
+								<div class="d-flex flex-column" style="gap: 8px">
+									<label class="fxr-label-sm">{{ __("Expression") }}</label>
+									<textarea
+										ref="formulaTextareaRef"
+										class="formula-textarea"
+										v-model="tokenDraftAttrs.expression"
+										:placeholder="
+											__('e.g. frappe.utils.add_days(doc.posting_date, 7)')
+										"
+									></textarea>
+								</div>
+
+								<!-- Variable pills -->
+								<div v-if="variableOptions && variableOptions.length" class="mt-2">
+									<label class="fxr-label-sm">{{ __("Insert Variable") }}</label>
+									<div class="variables-pill-grid">
+										<button
+											v-for="v in variableOptions"
+											:key="v.value || v"
+											type="button"
+											class="var-pill-btn"
+											@click="insertVarInFormula(v)"
+										>
+											{{ v.label || v }}
+										</button>
+									</div>
+								</div>
+
+								<!-- Config params for resolver -->
+								<div class="mt-3" v-if="activeTokenType === 'resolver'">
+									<div
+										class="d-flex align-items-center justify-content-between mb-2"
+									>
+										<label class="fxr-label-sm mb-0">{{ __("Config") }}</label>
+										<button
+											type="button"
+											class="fvc-action-btn"
+											@click="addConfigParam"
+										>
+											<i class="fa fa-plus mr-1"></i> {{ __("Add Param") }}
+										</button>
+									</div>
+									<div
+										v-if="
+											tokenDraftAttrs.config &&
+											typeof tokenDraftAttrs.config === 'object'
+										"
+										class="d-flex flex-column"
+										style="gap: 6px"
+									>
+										<div
+											v-for="(val, key) in tokenDraftAttrs.config"
+											:key="key"
+											class="d-flex align-items-center"
+											style="gap: 6px"
+										>
+											<input
+												type="text"
+												class="fxr-input"
+												style="width: 120px; font-size: 12px"
+												:value="key"
+												@change="renameConfigKey(key, $event.target.value)"
+												:placeholder="__('key')"
+											/>
+											<input
+												type="text"
+												class="fxr-input flex-1"
+												style="font-size: 12px"
+												v-model="tokenDraftAttrs.config[key]"
+												:placeholder="__('value')"
+											/>
+											<button
+												type="button"
+												class="fvc-action-btn"
+												@click="removeConfigKey(key)"
+											>
+												<i class="fa fa-trash"></i>
+											</button>
+										</div>
+									</div>
+								</div>
+							</div>
+						</template>
+					</div>
+
+					<!-- Footer -->
+					<div class="fxr-token-modal-footer">
+						<button
+							type="button"
+							class="fxr-btn fxr-btn--secondary"
+							@click="closeTokenEditor"
+						>
+							{{ __("Cancel") }}
+						</button>
+						<button
+							type="button"
+							class="fxr-btn fxr-btn--primary"
+							@click="saveTokenEditor"
+						>
+							{{ __("Save") }}
+						</button>
+					</div>
+				</div>
+			</div>
+		</Teleport>
 	</div>
 </template>
 
@@ -96,7 +297,11 @@ import Mention from "@tiptap/extension-mention";
 import { PluginKey } from "@tiptap/pm/state";
 import tippy from "tippy.js";
 
-import { getCommandsForFieldtype, getFormulasForFieldtype } from "../../core/formula_registry";
+import {
+	getCommandsForFieldtype,
+	getFormulasForFieldtype,
+	getAllowedBuilderKinds,
+} from "../../core/formula_registry";
 import { compileToCode, compileToLabel } from "../../core/builder_utils.js";
 import MentionList from "./MentionList.vue";
 import ControlFactory from "./ControlFactory.vue";
@@ -166,6 +371,8 @@ const PURE_TEXT_FIELDTYPES = new Set([
 const isStaticSupported = computed(() => {
 	return !PURE_TEXT_FIELDTYPES.has(fieldType.value);
 });
+
+const allowedBuilderKinds = computed(() => getAllowedBuilderKinds(fieldType.value));
 
 const staticDf = computed(() => {
 	let ft = fieldType.value;

--- a/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
@@ -775,7 +775,10 @@ const aggFieldOptions = computed(() => {
 
 // ─── Sync from Props (Hydration) ───
 const syncFromProps = () => {
-	const val = props.modelValue || {};
+	let val = props.modelValue || {};
+	if (val.mode && val.config) {
+		val = val.config;
+	}
 	const kind = val.kind || "date_formula";
 	const next = { ...getDefaultState(kind) };
 

--- a/flexirule/ruleflow/core/action_handlers/assignment.py
+++ b/flexirule/ruleflow/core/action_handlers/assignment.py
@@ -45,7 +45,6 @@ class AssignmentHandler(ActionHandler):
 				raise MethodExecutionError(_("Assignment action config is not valid JSON array"))
 
 		event_name = context.get("event_name")
-		template_context = None
 
 		for idx, assignment in enumerate(assignments):
 			target_path = assignment.get("target")
@@ -75,11 +74,15 @@ class AssignmentHandler(ActionHandler):
 			# 4. Evaluate value if required
 			operand_value = None
 			if operator.metadata.get("requires_value"):
-				if template_context is None:
-					template_context = self._build_template_context(context, engine)
-				# Inject current value so the format helper can access it
-				template_context["value"] = current_value
-				operand_value = self._resolve_operand(assignment, context, template_context)
+				# Inject current value so the format/normalization helper can access it
+				context_copy = dict(context)
+				context_copy["value"] = current_value
+
+				# Compile and resolve using the unified ValueResolver!
+				from flexirule.ruleflow.core.value_resolver import get_compiled_resolver
+
+				resolver = get_compiled_resolver(action, f"assign_{idx}", assignment.get("value"))
+				operand_value = resolver.resolve(context_copy)
 
 			# 6. Optional: Validate Target Type (deferred for runtime, but operator can check if needed)
 			# (In a real implementation, we'd fetch the Frappe metadata for doc.* fields here)
@@ -93,47 +96,6 @@ class AssignmentHandler(ActionHandler):
 
 		return None, getattr(action, "next_step_if_true", None)
 
-	def _resolve_operand(self, assignment: dict, context: dict, template_context: dict):
-		source = assignment.get("value_source") or "jinja"
-
-		if source == "literal":
-			return assignment.get("value_literal")
-
-		if source == "context_path":
-			return self._resolve_context_path(context, assignment.get("value_path"))
-
-		value_template = assignment.get("value_template")
-		if isinstance(value_template, str):
-			# Render Jinja template
-			# nosemgrep: frappe-semgrep-rules.rules.security.frappe-ssti
-			return frappe.render_template(value_template, template_context)  # nosemgrep: frappe-ssti
-		return value_template
-
-	def _resolve_context_path(self, context: dict, path: str | None):
-		if not path:
-			return None
-
-		parts = str(path).split(".")
-		base = parts[0]
-		if base == "doc":
-			current = context.get("doc")
-		elif base == "vars":
-			current = context.get("vars", {})
-		else:
-			return None
-
-		for part in parts[1:]:
-			if current is None:
-				return None
-			if isinstance(current, dict):
-				current = current.get(part)
-			elif hasattr(current, "get"):
-				current = current.get(part)
-			else:
-				return None
-
-		return current
-
 	def _to_config_cache_key(self, config) -> str:
 		if isinstance(config, str):
 			return config
@@ -143,177 +105,7 @@ class AssignmentHandler(ActionHandler):
 			return "[]"
 
 	@classmethod
-	@lru_cache(maxsize=512)
-	def _get_compiled_plan(cls, config_str: str) -> tuple[dict, ...]:
-		assignments = json.loads(config_str)
-		if not isinstance(assignments, list):
-			return tuple()
-
-		compiled_rows: list[dict[str, Any]] = []
-		for row in assignments:
-			if not isinstance(row, dict):
-				continue
-
-			operator_key = row.get("operator", "set")
-			try:
-				operator = AssignmentOperatorRegistry.get(operator_key)
-				requires_value = bool(operator.metadata.get("requires_value"))
-			except Exception:
-				requires_value = True
-
-			compiled = {
-				"target": row.get("target"),
-				"operator": operator_key,
-				"when_expression": cls._compile_when_expression(row),
-			}
-			compiled.update(cls._compile_operand_spec(row, requires_value))
-			compiled_rows.append(compiled)
-
-		return tuple(compiled_rows)
-
-	@classmethod
-	def _compile_structured_value_to_jinja(cls, val: dict) -> str:
-		if not val:
-			return ""
-		mode = val.get("mode")
-		if mode in {"static", "link", "dynamic_link"}:
-			return str(val.get("value") if val.get("value") is not None else "")
-		if mode == "variable":
-			path = val.get("path")
-			if path:
-				if not (path.startswith("doc.") or path.startswith("vars.")):
-					path = f"vars.{path}"
-				return f"{{{{ {path} }}}}"
-			return ""
-		if mode == "formula":
-			expr = val.get("expression") or ""
-			return f"{{{{ {expr} }}}}"
-		if mode == "formatter" or (mode == "resolver" and val.get("config", {}).get("kind") == "format"):
-			config = val.get("config") or {}
-			formatter = val.get("formatter") or config.get("fmt_op") or ""
-			options = val.get("options") or config or {}
-			return f'{{{{ format("{formatter}", {json.dumps(options)}) }}}}'
-
-		if mode == "normalize" or (
-			mode == "resolver" and val.get("config", {}).get("kind") == "normalization"
-		):
-			config = val.get("config") or {}
-			steps = val.get("steps") or ([config.get("norm_op")] if config.get("norm_op") else [])
-			return f"{{{{ normalize(value, {json.dumps(steps)}) }}}}"
-
-		if mode == "resolver":
-			config = val.get("config") or {}
-			kind = config.get("kind")
-			if kind:
-				expr = val.get("expression") or val.get("value")
-				if expr:
-					if expr.startswith("{") and expr.endswith("}"):
-						return f"{{{{ {expr[1:-1]} }}}}"
-					return f"{{{{ {expr} }}}}"
-
-			resolver = val.get("resolver") or val.get("value") or ""
-			args = ", ".join(f"{k}={json.dumps(v)}" for k, v in config.items())
-			return f'{{{{ resolve("{resolver}", {args}) }}}}'
-		if mode == "condition":
-			condition = val.get("condition") or {}
-			return f"{{{{ condition({json.dumps(condition)}) }}}}"
-		return ""
-
-	@classmethod
-	def _compile_operand_spec(cls, row: dict, requires_value: bool) -> dict:
-		if not requires_value:
-			return {
-				"value_source": "none",
-				"value_literal": None,
-				"value_template": None,
-				"value_path": None,
-			}
-
-		# Check if the new unified 'value' key holds a structured object
-		val_obj = row.get("value")
-		if isinstance(val_obj, dict) and "mode" in val_obj:
-			mode = val_obj.get("mode")
-			if mode in {"static", "link", "dynamic_link"}:
-				return {
-					"value_source": "literal",
-					"value_literal": val_obj.get("value"),
-					"value_template": None,
-					"value_path": None,
-				}
-			if mode == "variable":
-				return {
-					"value_source": "context_path",
-					"value_literal": None,
-					"value_template": None,
-					"value_path": cls._normalize_context_path(val_obj.get("path")),
-				}
-			# Formula/Resolver/Formatter etc compile to Jinja
-			compiled_jinja = cls._compile_structured_value_to_jinja(val_obj)
-			return {
-				"value_source": "jinja",
-				"value_literal": None,
-				"value_template": compiled_jinja,
-				"value_path": None,
-			}
-
-		explicit_source = row.get("value_source")
-		if explicit_source in {"literal", "context_path", "jinja"}:
-			return {
-				"value_source": explicit_source,
-				"value_literal": row.get("value_literal"),
-				"value_template": row.get("value_template") or row.get("value"),
-				"value_path": cls._normalize_context_path(row.get("value_path")),
-			}
-
-		value_template = row.get("value_template")
-		if value_template is None:
-			value_template = row.get("value")
-
-		ui_val = row.get("value_template_ui")
-		value_ui = ui_val if isinstance(ui_val, dict) else {}
-		mode = value_ui.get("mode")
-
-		if mode in {"static", "link", "dynamic_link"}:
-			return {
-				"value_source": "literal",
-				"value_literal": value_ui.get("value"),
-				"value_template": None,
-				"value_path": None,
-			}
-
-		if mode == "variable":
-			return {
-				"value_source": "context_path",
-				"value_literal": None,
-				"value_template": None,
-				"value_path": cls._normalize_context_path(value_ui.get("path")),
-			}
-
-		if isinstance(value_template, str):
-			contains_jinja = "{{" in value_template or "{%" in value_template
-			if mode in {"formula", "resolver"} or contains_jinja:
-				return {
-					"value_source": "jinja",
-					"value_literal": None,
-					"value_template": value_template,
-					"value_path": None,
-				}
-			return {
-				"value_source": "literal",
-				"value_literal": value_template,
-				"value_template": None,
-				"value_path": None,
-			}
-
-		return {
-			"value_source": "literal",
-			"value_literal": value_template,
-			"value_template": None,
-			"value_path": None,
-		}
-
-	@staticmethod
-	def _compile_when_expression(row: dict) -> str:
+	def _compile_when_expression(cls, row: dict) -> str:
 		python_expr = row.get("pythonExpression")
 		if python_expr:
 			return python_expr
@@ -334,15 +126,68 @@ class AssignmentHandler(ActionHandler):
 		return ""
 
 	@staticmethod
-	def _normalize_context_path(path: Any) -> str | None:
-		if not path:
-			return None
-		path_str = str(path).strip()
-		if not path_str:
-			return None
-		if path_str.startswith("doc.") or path_str.startswith("vars."):
-			return path_str
-		return f"vars.{path_str}"
+	def _compile_structured_value_to_jinja(val: dict) -> str:
+		"""
+		Backward-compatible helper for rule.py metadata compilation (save path).
+		Converts a structured value object into an equivalent Jinja template string
+		for legacy persistence in the AssignmentOperandSpec fields.
+		"""
+		if not val:
+			return ""
+
+		mode = val.get("mode")
+
+		if mode in {"static", "link", "dynamic_link"}:
+			return str(val.get("value") if val.get("value") is not None else "")
+
+		if mode == "variable":
+			path = val.get("path")
+			if path:
+				if not (path.startswith("doc.") or path.startswith("vars.")):
+					path = f"vars.{path}"
+				return f"{{{{ {path} }}}}"
+			return ""
+
+		if mode == "formula":
+			expr = val.get("expression") or ""
+			return f"{{{{ {expr} }}}}"
+
+		if mode == "formatter" or (mode == "resolver" and val.get("config", {}).get("kind") == "format"):
+			config = val.get("config") or {}
+			formatter = val.get("formatter") or config.get("fmt_op") or ""
+			options = val.get("options") or config or {}
+			return f'{{{{ format("{formatter}", {json.dumps(options)}) }}}}'
+
+		if mode == "normalize" or (
+			mode == "resolver" and val.get("config", {}).get("kind") == "normalization"
+		):
+			config = val.get("config") or {}
+			steps = val.get("steps") or ([config.get("norm_op")] if config.get("norm_op") else [])
+			return f"{{{{ normalize(value, {json.dumps(steps)}) }}}}"
+
+		if mode == "resolver":
+			config = val.get("config") or {}
+			kind = config.get("kind")
+
+			# Known built-in resolvers → direct Jinja helper call
+			if kind:
+				expr = val.get("expression") or val.get("value")
+				if expr:
+					if expr.startswith("{") and expr.endswith("}"):
+						return f"{{{{ {expr[1:-1]} }}}}"
+					return f"{{{{ {expr} }}}}"
+
+				resolver = val.get("resolver") or val.get("value") or ""
+				args = ", ".join(f"{k}={json.dumps(v)}" for k, v in config.items())
+				return f'{{{{ resolve("{resolver}", {args}) }}}}'
+
+		if mode == "condition":
+			condition = val.get("condition") or {}
+			return f"{{{{ condition({json.dumps(condition)}) }}}}"
+
+		return ""
+
+		return ""
 
 	def _validate_target_path(self, target_path: str):
 		"""Prevent mutation of system paths."""

--- a/flexirule/ruleflow/core/action_handlers/assignment.py
+++ b/flexirule/ruleflow/core/action_handlers/assignment.py
@@ -104,6 +104,35 @@ class AssignmentHandler(ActionHandler):
 		except Exception:
 			return "[]"
 
+	@staticmethod
+	@lru_cache(maxsize=1024)
+	def _get_compiled_plan(config_key: str) -> tuple[dict[str, Any], ...]:
+		try:
+			rows = json.loads(config_key or "[]")
+		except Exception:
+			rows = []
+		if not isinstance(rows, list):
+			rows = []
+
+		compiled_rows: list[dict[str, Any]] = []
+		for row in rows:
+			if not isinstance(row, dict):
+				continue
+			compiled = dict(row)
+			# Canonicalize operand payload for unified runtime evaluation
+			# (legacy rows may store structured payload under value_template_ui/value_template_json).
+			if compiled.get("value") is None:
+				if compiled.get("value_template_ui") is not None:
+					compiled["value"] = compiled.get("value_template_ui")
+				elif compiled.get("value_template_json") is not None:
+					compiled["value"] = compiled.get("value_template_json")
+				elif compiled.get("value_template") is not None:
+					compiled["value"] = compiled.get("value_template")
+			compiled["when_expression"] = AssignmentHandler._compile_when_expression(compiled)
+			compiled_rows.append(compiled)
+
+		return tuple(compiled_rows)
+
 	@classmethod
 	def _compile_when_expression(cls, row: dict) -> str:
 		python_expr = row.get("pythonExpression")

--- a/flexirule/ruleflow/core/action_handlers/query_records.py
+++ b/flexirule/ruleflow/core/action_handlers/query_records.py
@@ -291,9 +291,21 @@ class QueryRecordsHandler(ActionHandler):
 				exc=type(e),
 			)
 
-	def _resolve_value_expression_with_context(self, value, context, ref_label: str):
+	def _resolve_value_expression_with_context(self, value, context, ref_label: str, action=None):
+		if isinstance(value, dict):
+			if "mode" in value:
+				from flexirule.ruleflow.core.value_resolver import get_compiled_resolver
+
+				resolver = get_compiled_resolver(
+					action, ref_label.replace(".", "_").replace("[", "_").replace("]", "_"), value
+				)
+				return resolver.resolve(context)
+			return {
+				key: self._resolve_value_expression_with_context(val, context, f"{ref_label}.{key}", action)
+				for key, val in value.items()
+			}
 		if isinstance(value, list):
-			return [self._resolve_value_expression_with_context(v, context, ref_label) for v in value]
+			return [self._resolve_value_expression_with_context(v, context, ref_label, action) for v in value]
 		if isinstance(value, str) and "{" in value:
 			if value.startswith("{") and value.endswith("}") and value.count("{") == 1:
 				inner_expr = value[1 : len(value) - 1]
@@ -308,7 +320,7 @@ class QueryRecordsHandler(ActionHandler):
 			return re.sub(r"{(.*?)}", replace, value)
 		return value
 
-	def _resolve_filters_with_context(self, filters, context, ref_label: str):
+	def _resolve_filters_with_context(self, filters, context, ref_label: str, action=None):
 		if not filters:
 			return filters
 		if isinstance(filters, list):
@@ -318,34 +330,38 @@ class QueryRecordsHandler(ActionHandler):
 				if isinstance(item, dict) and ("field" in item or "fieldname" in item):
 					resolved_list.append(
 						{
-							k: self._resolve_value_expression_with_context(v, context, f"{child_ref}.{k}")
+							k: self._resolve_value_expression_with_context(
+								v, context, f"{child_ref}.{k}", action
+							)
 							for k, v in item.items()
 						}
 					)
 				elif isinstance(item, list | dict):
-					resolved_list.append(self._resolve_filters_with_context(item, context, child_ref))
+					resolved_list.append(self._resolve_filters_with_context(item, context, child_ref, action))
 				else:
 					resolved_list.append(
-						self._resolve_value_expression_with_context(item, context, child_ref)
+						self._resolve_value_expression_with_context(item, context, child_ref, action)
 					)
 			return resolved_list
 		if isinstance(filters, dict):
 			return {
-				key: self._resolve_value_expression_with_context(value, context, f"{ref_label}.{key}")
+				key: self._resolve_value_expression_with_context(value, context, f"{ref_label}.{key}", action)
 				for key, value in filters.items()
 			}
-		return self._resolve_value_expression_with_context(filters, context, ref_label)
+		return self._resolve_value_expression_with_context(filters, context, ref_label, action)
 
 	def _resolve_query_filters(self, config, context, action=None):
 		"""Resolve and normalize both filters and or_filters with one shared path."""
 		action_label = getattr(action, "label", None) or getattr(action, "action_id", None) or "Query Records"
 		filters = self._resolve_filters_with_context(
-			config.get("filters", {}), context, f"{action_label}.filters"
+			config.get("filters", {}), context, f"{action_label}.filters", action
 		)
 		filters = self._normalize_filters_for_backend(filters)
 		or_filters = config.get("or_filters", {})
 		if or_filters:
-			or_filters = self._resolve_filters_with_context(or_filters, context, f"{action_label}.or_filters")
+			or_filters = self._resolve_filters_with_context(
+				or_filters, context, f"{action_label}.or_filters", action
+			)
 			or_filters = self._normalize_filters_for_backend(or_filters)
 		else:
 			or_filters = None

--- a/flexirule/ruleflow/core/action_plan_cache.py
+++ b/flexirule/ruleflow/core/action_plan_cache.py
@@ -11,7 +11,7 @@ import frappe
 
 from flexirule.ruleflow.core.contracts import normalize_action_type
 
-CACHE_VERSION = 1
+CACHE_VERSION = 3
 CACHE_KEY_PREFIX = "flexirule_action_plan_v1"
 LOCAL_CACHE_KEY = "flexirule_action_plan_cache"
 
@@ -126,7 +126,35 @@ def _compile_assignment_action(action) -> dict[str, Any]:
 	from flexirule.ruleflow.core.action_handlers.assignment import AssignmentHandler
 
 	config_key = getattr(action, "config", "[]") or "[]"
-	compiled_rows = AssignmentHandler._get_compiled_plan(str(config_key))
+	compiled_plan_getter = getattr(AssignmentHandler, "_get_compiled_plan", None)
+	if callable(compiled_plan_getter):
+		compiled_rows = compiled_plan_getter(str(config_key))
+	else:
+		# Safe fallback for mixed-version/runtime import edge-cases.
+		try:
+			rows = json.loads(str(config_key) or "[]")
+		except Exception:
+			rows = []
+		if not isinstance(rows, list):
+			rows = []
+		compiled_rows = []
+		for row in rows:
+			if not isinstance(row, dict):
+				continue
+			compiled = dict(row)
+			if compiled.get("value") is None:
+				if compiled.get("value_template_ui") is not None:
+					compiled["value"] = compiled.get("value_template_ui")
+				elif compiled.get("value_template_json") is not None:
+					compiled["value"] = compiled.get("value_template_json")
+				elif compiled.get("value_template") is not None:
+					compiled["value"] = compiled.get("value_template")
+			compiled["when_expression"] = (
+				compiled.get("pythonExpression")
+				or (compiled.get("when_expression") or compiled.get("when") or "").strip()
+			)
+			compiled_rows.append(compiled)
+		compiled_rows = tuple(compiled_rows)
 	return {"action_type": "Assignment", "rows": list(compiled_rows)}
 
 

--- a/flexirule/ruleflow/core/value_resolver.py
+++ b/flexirule/ruleflow/core/value_resolver.py
@@ -1,0 +1,500 @@
+# Copyright (c) 2026, FlexiRule and contributors
+# For license information, please see license.txt
+
+import json
+from typing import Any
+
+import frappe
+from frappe import _
+
+from flexirule.ruleflow.utils.field_resolver import FieldResolver
+
+
+def get_context_value(context: dict, path: str | None) -> Any:
+	"""
+	Resolve a field or variable value from execution context.
+	Supports dot notation like 'doc.status', 'vars.result', 'item.rate', etc.
+	"""
+	if not path:
+		return None
+	path_str = str(path).strip()
+	if not path_str:
+		return None
+
+	parts = path_str.split(".")
+	base = parts[0]
+	if base == "doc":
+		current = context.get("doc")
+	elif base == "vars":
+		current = context.get("vars", {})
+	elif base == "item":
+		current = context.get("item")
+	elif base == "loop":
+		current = context.get("loop")
+	elif base == "row":
+		current = context.get("row")
+	else:
+		# Fallback context lookup if no explicit scope is declared
+		if context.get("vars") and base in context["vars"]:
+			current = context["vars"]
+			parts = [base] + parts[1:]
+		elif context.get("doc") and hasattr(context["doc"], "get") and context["doc"].get(base) is not None:
+			current = context["doc"]
+			parts = [base] + parts[1:]
+		else:
+			return None
+
+	for part in parts[1:]:
+		if current is None:
+			return None
+		if isinstance(current, dict):
+			current = current.get(part)
+		elif hasattr(current, "get"):
+			current = current.get(part)
+		else:
+			return None
+	return current
+
+
+class CompiledResolver:
+	"""Base class for compiled, highly optimized dynamic value resolvers."""
+
+	def resolve(self, context: dict) -> Any:
+		raise NotImplementedError()
+
+
+class NoneResolver(CompiledResolver):
+	def resolve(self, context: dict) -> Any:
+		return None
+
+
+class StaticResolver(CompiledResolver):
+	def __init__(self, value: Any):
+		self.value = value
+
+	def resolve(self, context: dict) -> Any:
+		return self.value
+
+
+class VariableResolver(CompiledResolver):
+	def __init__(self, path: str):
+		self.path = path
+
+	def resolve(self, context: dict) -> Any:
+		return get_context_value(context, self.path)
+
+
+class DateFormulaResolver(CompiledResolver):
+	def __init__(self, base_type: str, base_field: str | None, offset_value: int, offset_unit: str):
+		self.base_type = base_type
+		self.base_field = base_field
+		self.offset_value = offset_value
+		self.offset_unit = offset_unit
+
+	def resolve(self, context: dict) -> Any:
+		if self.base_type == "today":
+			base_date = frappe.utils.nowdate()
+		else:
+			base_date = get_context_value(context, self.base_field)
+
+		if not base_date:
+			return None
+
+		offset = int(self.offset_value or 0)
+		if offset == 0 or not self.offset_unit:
+			return base_date
+
+		if self.offset_unit == "days":
+			return frappe.utils.add_days(base_date, offset)
+
+		return frappe.utils.add_to_date(base_date, **{self.offset_unit: offset})
+
+
+class MathFormulaResolver(CompiledResolver):
+	def __init__(
+		self,
+		field_a: str | None,
+		math_op: str,
+		field_b_type: str,
+		field_b: str | None,
+		constant_b: Any,
+		precision: int | None,
+	):
+		self.field_a = field_a
+		self.math_op = math_op
+		self.field_b_type = field_b_type
+		self.field_b = field_b
+		self.constant_b = constant_b
+		self.precision = precision
+
+	def resolve(self, context: dict) -> Any:
+		val_a = frappe.utils.flt(get_context_value(context, self.field_a)) if self.field_a else 0.0
+		if self.field_b_type == "field":
+			val_b = frappe.utils.flt(get_context_value(context, self.field_b)) if self.field_b else 0.0
+		else:
+			val_b = frappe.utils.flt(self.constant_b)
+
+		if self.math_op == "+":
+			res = val_a + val_b
+		elif self.math_op == "-":
+			res = val_a - val_b
+		elif self.math_op == "*":
+			res = val_a * val_b
+		elif self.math_op == "/":
+			res = val_a / val_b if val_b != 0.0 else 0.0
+		else:
+			res = 0.0
+
+		if self.precision is not None:
+			res = frappe.utils.flt(res, self.precision)
+		return res
+
+
+class DateDiffResolver(CompiledResolver):
+	def __init__(
+		self,
+		diff_start_type: str,
+		diff_start_field: str | None,
+		diff_end_type: str,
+		diff_end_field: str | None,
+		diff_unit: str,
+	):
+		self.diff_start_type = diff_start_type
+		self.diff_start_field = diff_start_field
+		self.diff_end_type = diff_end_type
+		self.diff_end_field = diff_end_field
+		self.diff_unit = diff_unit
+
+	def resolve(self, context: dict) -> Any:
+		if self.diff_start_type == "today":
+			start = frappe.utils.nowdate()
+		else:
+			start = get_context_value(context, self.diff_start_field)
+
+		if self.diff_end_type == "today":
+			end = frappe.utils.nowdate()
+		else:
+			end = get_context_value(context, self.diff_end_field)
+
+		if not start or not end:
+			return 0
+
+		if self.diff_unit == "days":
+			return frappe.utils.date_diff(end, start)
+		if self.diff_unit == "months":
+			return frappe.utils.month_diff(end, start)
+		return int(frappe.utils.month_diff(end, start) / 12)
+
+
+class ChildAggregationResolver(CompiledResolver):
+	def __init__(self, agg_table: str | None, agg_field: str | None, agg_op: str):
+		self.agg_table = agg_table
+		self.agg_field = agg_field
+		self.agg_op = agg_op
+
+	def resolve(self, context: dict) -> Any:
+		rows = get_context_value(context, self.agg_table)
+		if not rows or not isinstance(rows, list):
+			return 0
+
+		if self.agg_op == "count":
+			return len(rows)
+
+		if not self.agg_field:
+			return 0
+
+		values = [
+			frappe.utils.flt(row.get(self.agg_field))
+			for row in rows
+			if hasattr(row, "get") and row.get(self.agg_field) is not None
+		]
+
+		if self.agg_op == "sum":
+			return sum(values)
+		if self.agg_op == "avg":
+			return sum(values) / len(values) if values else 0.0
+
+		return 0
+
+
+class StringFormulaResolver(CompiledResolver):
+	def __init__(self, str_op: str, str_a_type: str, str_a: str | None, str_b_type: str, str_b: str | None):
+		self.str_op = str_op
+		self.str_a_type = str_a_type
+		self.str_a = str_a
+		self.str_b_type = str_b_type
+		self.str_b = str_b
+
+	def resolve(self, context: dict) -> Any:
+		if self.str_a_type == "field":
+			val_a = get_context_value(context, self.str_a)
+		else:
+			val_a = self.str_a
+
+		if self.str_b_type == "field":
+			val_b = get_context_value(context, self.str_b)
+		else:
+			val_b = self.str_b
+
+		if self.str_op == "concat":
+			return str(val_a or "") + str(val_b or "")
+		if self.str_op == "uppercase":
+			return str(val_a or "").upper()
+		if self.str_op == "lowercase":
+			return str(val_a or "").lower()
+		if self.str_op == "fmt_money":
+			return frappe.utils.fmt_money(val_a, currency=val_b)
+
+		return val_a
+
+
+class NormalizationResolver(CompiledResolver):
+	def __init__(self, norm_op: str, norm_field: str | None):
+		self.norm_op = norm_op
+		self.norm_field = norm_field
+
+	def resolve(self, context: dict) -> Any:
+		val = get_context_value(context, self.norm_field)
+		if val is None:
+			return None
+
+		val_str = str(val)
+		if self.norm_op == "trim":
+			return val_str.strip()
+		if self.norm_op in ("slug", "snake"):
+			return frappe.scrub(val_str)
+		if self.norm_op == "title":
+			return val_str.title()
+		if self.norm_op == "upper":
+			return val_str.upper()
+		if self.norm_op == "lower":
+			return val_str.lower()
+
+		return val_str
+
+
+class FormatResolver(CompiledResolver):
+	def __init__(self, fmt_op: str, fmt_field: str | None, fmt_config: str):
+		self.fmt_op = fmt_op
+		self.fmt_field = fmt_field
+		self.fmt_config = fmt_config
+
+	def resolve(self, context: dict) -> Any:
+		val = get_context_value(context, self.fmt_field)
+		if val is None:
+			return ""
+
+		if self.fmt_op == "format_date":
+			return frappe.utils.format_date(val, self.fmt_config)
+
+		if self.fmt_op == "fmt_money":
+			# Determine if currency is static code or dynamic field
+			curr = self.fmt_config or ""
+			if curr.startswith("doc.") or curr.startswith("vars."):
+				resolved_curr = get_context_value(context, curr)
+			else:
+				resolved_curr = curr
+			return frappe.utils.fmt_money(val, currency=resolved_curr)
+
+		if self.fmt_op == "format":
+			return (self.fmt_config or "").format(val)
+
+		return str(val)
+
+
+class SystemContextResolver(CompiledResolver):
+	def __init__(self, sys_token: str, sys_role: str):
+		self.sys_token = sys_token
+		self.sys_role = sys_role
+
+	def resolve(self, context: dict) -> Any:
+		if self.sys_token == "user":
+			return frappe.session.user
+		if self.sys_token == "role_check":
+			return bool(self.sys_role in frappe.get_roles(frappe.session.user))
+		return None
+
+
+class JinjaResolver(CompiledResolver):
+	"""Fallback resolver that compiles and renders standard Jinja templates."""
+
+	def __init__(self, template: str):
+		self.template = template
+
+	def resolve(self, context: dict) -> Any:
+		from flexirule.ruleflow.core.action_handlers import ActionHandler
+
+		class DummyActionHandler(ActionHandler):
+			def execute(self, action, context, engine):
+				return None, None
+
+		handler = DummyActionHandler()
+		template_context = handler._build_template_context(context)
+		if "value" in context:
+			template_context["value"] = context["value"]
+		# nosemgrep: frappe-semgrep-rules.rules.security.frappe-ssti
+		return frappe.render_template(self.template, template_context)  # nosemgrep: frappe-ssti
+
+
+class SafeEvalResolver(CompiledResolver):
+	"""Fallback resolver that executes Python expressions via safe_eval."""
+
+	def __init__(self, expression: str):
+		self.expression = expression
+
+	def resolve(self, context: dict) -> Any:
+		from flexirule.ruleflow.core.action_handlers import ActionHandler
+
+		class DummyActionHandler(ActionHandler):
+			def execute(self, action, context, engine):
+				return None, None
+
+		handler = DummyActionHandler()
+		return handler._safe_eval(self.expression, context)
+
+
+class ExpressionResolver(CompiledResolver):
+	"""Mixed mode resolver that resolves multiple non-contiguous segment templates."""
+
+	def __init__(self, segments: list[CompiledResolver]):
+		self.segments = segments
+
+	def resolve(self, context: dict) -> Any:
+		parts = []
+		for seg in self.segments:
+			val = seg.resolve(context)
+			parts.append(str(val) if val is not None else "")
+		return "".join(parts)
+
+
+class ValueResolver:
+	"""
+	Unified compiler & runtime registry for FlexValue systems.
+	Converts dynamic configuration schemas into optimized CompiledResolver graphs.
+	"""
+
+	@staticmethod
+	def compile(val: Any) -> CompiledResolver:
+		if val is None:
+			return NoneResolver()
+
+		if isinstance(val, dict):
+			mode = val.get("mode")
+
+			if mode in ("static", "link", "dynamic_link"):
+				return StaticResolver(val.get("value"))
+
+		if mode == "variable":
+			path = val.get("path") or val.get("value") or ""
+			return VariableResolver(path)
+
+		if mode == "expression":
+			segments: list[CompiledResolver] = []
+			for item in val.get("value") or []:
+				seg_type = item.get("type")
+				if seg_type == "text":
+					segments.append(StaticResolver(item.get("value")))  # type: ignore[list-item]
+				elif seg_type == "variableToken":
+					segments.append(VariableResolver(item.get("attrs", {}).get("path") or ""))  # type: ignore[list-item]
+				elif seg_type == "resolverToken":
+					attrs = item.get("attrs", {})
+					config = attrs.get("config")
+					if config and isinstance(config, dict):
+						segments.append(ValueResolver.compile_resolver_config(config))  # type: ignore[list-item]
+					else:
+						segments.append(SafeEvalResolver(attrs.get("expression") or attrs.get("resolver")))  # type: ignore[list-item]
+				elif seg_type == "jsonToken":
+					segments.append(JinjaResolver(item.get("attrs", {}).get("value") or ""))  # type: ignore[list-item]
+			return ExpressionResolver(segments)
+
+			if mode in ("resolver", "formatter", "normalize", "format", "normalization") or "kind" in val:
+				config = val.get("config") or val
+				if isinstance(config, dict) and "kind" in config:
+					return ValueResolver.compile_resolver_config(config)
+
+			if "value" in val:
+				return StaticResolver(val.get("value"))
+
+		if isinstance(val, str):
+			if "{{" in val or "{%" in val:
+				return JinjaResolver(val)
+			if val.startswith("{") and val.endswith("}") and val.count("{") == 1:
+				return SafeEvalResolver(val[1:-1])
+			return StaticResolver(val)
+
+		return StaticResolver(val)
+
+	@staticmethod
+	def compile_resolver_config(config: dict) -> CompiledResolver:
+		kind = config.get("kind")
+		if not kind:
+			return NoneResolver()
+
+		if kind == "date_formula":
+			return DateFormulaResolver(
+				base_type=config.get("base_type", "today"),
+				base_field=config.get("base_field"),
+				offset_value=config.get("offset_value", 0),
+				offset_unit=config.get("offset_unit", "days"),
+			)
+		if kind == "math_formula":
+			return MathFormulaResolver(
+				field_a=config.get("field_a"),
+				math_op=config.get("math_op", "+"),
+				field_b_type=config.get("field_b_type", "field"),
+				field_b=config.get("field_b"),
+				constant_b=config.get("constant_b", 0),
+				precision=config.get("precision", 2),
+			)
+		if kind == "date_diff":
+			return DateDiffResolver(
+				diff_start_type=config.get("diff_start_type", "today"),
+				diff_start_field=config.get("diff_start_field"),
+				diff_end_type=config.get("diff_end_type", "doc_field"),
+				diff_end_field=config.get("diff_end_field"),
+				diff_unit=config.get("diff_unit", "days"),
+			)
+		if kind == "child_aggregation":
+			return ChildAggregationResolver(
+				agg_table=config.get("agg_table"),
+				agg_field=config.get("agg_field"),
+				agg_op=config.get("agg_op", "sum"),
+			)
+		if kind == "string_formula":
+			return StringFormulaResolver(
+				str_op=config.get("str_op", "concat"),
+				str_a_type=config.get("str_a_type", "field"),
+				str_a=config.get("str_a"),
+				str_b_type=config.get("str_b_type", "constant"),
+				str_b=config.get("str_b"),
+			)
+		if kind == "normalization":
+			return NormalizationResolver(
+				norm_op=config.get("norm_op", "trim"), norm_field=config.get("norm_field")
+			)
+		if kind == "format":
+			return FormatResolver(
+				fmt_op=config.get("fmt_op", "format_date"),
+				fmt_field=config.get("fmt_field"),
+				fmt_config=config.get("fmt_config", ""),
+			)
+		if kind == "system_context":
+			return SystemContextResolver(
+				sys_token=config.get("sys_token", "user"), sys_role=config.get("sys_role", "")
+			)
+
+		return NoneResolver()
+
+
+def get_compiled_resolver(action, key: str, value_payload: Any) -> CompiledResolver:
+	"""
+	Retrieve or create a request-local compiled ValueResolver object for extreme execution efficiency.
+	"""
+	if not hasattr(frappe.local, "flexirule_compiled_resolvers"):
+		frappe.local.flexirule_compiled_resolvers = {}
+
+	cache_key = f"{getattr(action, 'name', 'action')}_{key}"
+	if cache_key not in frappe.local.flexirule_compiled_resolvers:
+		frappe.local.flexirule_compiled_resolvers[cache_key] = ValueResolver.compile(value_payload)
+
+	return frappe.local.flexirule_compiled_resolvers[cache_key]

--- a/flexirule/ruleflow/core/value_resolver.py
+++ b/flexirule/ruleflow/core/value_resolver.py
@@ -37,10 +37,10 @@ def get_context_value(context: dict, path: str | None) -> Any:
 		# Fallback context lookup if no explicit scope is declared
 		if context.get("vars") and base in context["vars"]:
 			current = context["vars"]
-			parts = [base] + parts[1:]
+			parts = [base, *parts[1:]]
 		elif context.get("doc") and hasattr(context["doc"], "get") and context["doc"].get(base) is not None:
 			current = context["doc"]
-			parts = [base] + parts[1:]
+			parts = [base, *parts[1:]]
 		else:
 			return None
 
@@ -384,28 +384,30 @@ class ValueResolver:
 			if mode in ("static", "link", "dynamic_link"):
 				return StaticResolver(val.get("value"))
 
-		if mode == "variable":
-			path = val.get("path") or val.get("value") or ""
-			return VariableResolver(path)
+			if mode == "variable":
+				path = val.get("path") or val.get("value") or ""
+				return VariableResolver(path)
 
-		if mode == "expression":
-			segments: list[CompiledResolver] = []
-			for item in val.get("value") or []:
-				seg_type = item.get("type")
-				if seg_type == "text":
-					segments.append(StaticResolver(item.get("value")))  # type: ignore[list-item]
-				elif seg_type == "variableToken":
-					segments.append(VariableResolver(item.get("attrs", {}).get("path") or ""))  # type: ignore[list-item]
-				elif seg_type == "resolverToken":
-					attrs = item.get("attrs", {})
-					config = attrs.get("config")
-					if config and isinstance(config, dict):
-						segments.append(ValueResolver.compile_resolver_config(config))  # type: ignore[list-item]
-					else:
-						segments.append(SafeEvalResolver(attrs.get("expression") or attrs.get("resolver")))  # type: ignore[list-item]
-				elif seg_type == "jsonToken":
-					segments.append(JinjaResolver(item.get("attrs", {}).get("value") or ""))  # type: ignore[list-item]
-			return ExpressionResolver(segments)
+			if mode == "expression":
+				segments: list[CompiledResolver] = []
+				for item in val.get("value") or []:
+					seg_type = item.get("type")
+					if seg_type == "text":
+						segments.append(StaticResolver(item.get("value")))
+					elif seg_type == "variableToken":
+						segments.append(VariableResolver(item.get("attrs", {}).get("path") or ""))
+					elif seg_type == "resolverToken":
+						attrs = item.get("attrs", {})
+						config = attrs.get("config")
+						if config and isinstance(config, dict):
+							segments.append(ValueResolver.compile_resolver_config(config))
+						else:
+							segments.append(
+								SafeEvalResolver(attrs.get("expression") or attrs.get("resolver"))
+							)
+					elif seg_type == "jsonToken":
+						segments.append(JinjaResolver(item.get("attrs", {}).get("value") or ""))
+				return ExpressionResolver(segments)
 
 			if mode in ("resolver", "formatter", "normalize", "format", "normalization") or "kind" in val:
 				config = val.get("config") or val

--- a/flexirule/ruleflow/tests/test_assignment_resolver.py
+++ b/flexirule/ruleflow/tests/test_assignment_resolver.py
@@ -4,6 +4,7 @@ import unittest
 import frappe
 
 from flexirule.ruleflow.core.action_handlers.assignment import AssignmentHandler
+from flexirule.ruleflow.core.value_resolver import ValueResolver
 
 
 class TestAssignmentResolver(unittest.TestCase):
@@ -15,6 +16,7 @@ class TestAssignmentResolver(unittest.TestCase):
 				"first_name": "John",
 				"last_name": "Doe",
 				"amount": 100,
+				"creation": "2026-05-22 12:00:00",
 				"items": [{"item_name": "A", "rate": 10}, {"item_name": "B", "rate": 20}],
 			}
 		)
@@ -32,16 +34,16 @@ class TestAssignmentResolver(unittest.TestCase):
 			"mode": "resolver",
 			"config": {
 				"kind": "math_formula",
-				"field_a": "amount",
+				"field_a": "doc.amount",
 				"math_op": "+",
 				"field_b_type": "constant",
 				"constant_b": 50,
 				"precision": 2,
 			},
-			"expression": "{frappe.utils.flt(doc.amount) + 50, 2}",
 		}
-		jinja = self.handler._compile_structured_value_to_jinja(val)
-		self.assertEqual(jinja, "{{ frappe.utils.flt(doc.amount) + 50, 2 }}")
+		resolver = ValueResolver.compile(val)
+		result = resolver.resolve(self.context)
+		self.assertEqual(result, 150.00)
 
 	def test_compile_format_resolver(self):
 		val = {
@@ -49,21 +51,19 @@ class TestAssignmentResolver(unittest.TestCase):
 			"config": {
 				"kind": "format",
 				"fmt_op": "format_date",
-				"fmt_field": "creation",
-				"fmt_config": "YYYY-MM-DD",
+				"fmt_field": "doc.creation",
+				"fmt_config": "yyyy-MM-dd",
 			},
 		}
-		jinja = self.handler._compile_structured_value_to_jinja(val)
-		# Should use format helper
-		self.assertIn('format("format_date"', jinja)
-		self.assertIn('"fmt_op": "format_date"', jinja)
+		resolver = ValueResolver.compile(val)
+		result = resolver.resolve(self.context)
+		self.assertEqual(result, "2026-05-22")
 
 	def test_compile_normalize_resolver(self):
 		val = {
 			"mode": "resolver",
-			"config": {"kind": "normalization", "norm_op": "upper", "norm_field": "first_name"},
+			"config": {"kind": "normalization", "norm_op": "upper", "norm_field": "doc.first_name"},
 		}
-		jinja = self.handler._compile_structured_value_to_jinja(val)
-		# Should use normalize helper
-		self.assertIn("normalize(value", jinja)
-		self.assertIn('["upper"]', jinja)
+		resolver = ValueResolver.compile(val)
+		result = resolver.resolve(self.context)
+		self.assertEqual(result, "JOHN")

--- a/flexirule/ruleflow/tests/test_assignment_resolver.py
+++ b/flexirule/ruleflow/tests/test_assignment_resolver.py
@@ -67,3 +67,21 @@ class TestAssignmentResolver(unittest.TestCase):
 		resolver = ValueResolver.compile(val)
 		result = resolver.resolve(self.context)
 		self.assertEqual(result, "JOHN")
+
+	def test_compile_variable_mode(self):
+		val = {"mode": "variable", "path": "doc.last_name"}
+		resolver = ValueResolver.compile(val)
+		self.assertEqual(resolver.resolve(self.context), "Doe")
+
+	def test_compile_expression_mode(self):
+		val = {
+			"mode": "expression",
+			"value": [
+				{"type": "text", "value": "Customer: "},
+				{"type": "variableToken", "attrs": {"path": "doc.first_name"}},
+				{"type": "text", "value": " "},
+				{"type": "variableToken", "attrs": {"path": "doc.last_name"}},
+			],
+		}
+		resolver = ValueResolver.compile(val)
+		self.assertEqual(resolver.resolve(self.context), "Customer: John Doe")


### PR DESCRIPTION
Changes Made
1. Backend Core Engine
value_resolver.py
Complete compiled resolver registry with 12 resolver classes:
StaticResolver, VariableResolver, NoneResolver
DateFormulaResolver, MathFormulaResolver, DateDiffResolver
ChildAggregationResolver, StringFormulaResolver
NormalizationResolver, FormatResolver, SystemContextResolver
JinjaResolver, SafeEvalResolver (fallbacks), ExpressionResolver (mixed mode)
ValueResolver.compile() — Unified entry point that dispatches to the correct resolver based on mode/kind
get_compiled_resolver() — Request-local caching in frappe.local for extreme execution efficiency
assignment.py
Refactored to resolve values through the precompiled ValueResolver structures
query_records.py
Dynamic query filter resolution uses the unified ValueResolver compilation engine
_extract_filter_value_payload() leaves mode-containing dicts intact for resolver processing
2. Frontend Controls
FlexValueControl.vue
Added missing <Teleport to="body"> token editor modal (lines 88–247):
Header with dynamic icon/title from activeTokenPresentation
JSON editor mode for raw expression editing
Visual/Manual toggle with Visual mode embedding ValueResolverControl inline
Manual mode with formula textarea, variable pill insertion, and config param editor
Footer with Cancel/Save actions
Imported getAllowedBuilderKinds from centralized formula_registry.js
Added allowedBuilderKinds computed — feeds field-type-aware kind restrictions to the embedded ValueResolverControl
ValueResolverControl.vue
syncFromProps() auto-unwraps {mode: "resolver", config: {...}} wrapper objects
FilterGroup.vue
Imports getAllowedBuilderKinds from the registry
Serializes builder values as {mode: "resolver", config: <builder_config>} for unified backend resolution
3. JavaScript Utilities
builder_utils.js
compileToCode() — Added offset_sign handling for date_formula:
diff

-const offset = parseInt(item.offset_value || 0, 10);
+let offset = parseInt(item.offset_value || 0, 10);
+// Handle separate offset_sign field from ValueResolverControl
+if (item.offset_sign === "-" && offset > 0) offset = -offset;
compileToLabel() — Same offset_sign handling for consistent label generation
formula_registry.js
Expanded getAllowedBuilderKinds(fieldtype):