### PR TITLE
Restore Condition Editor in TextGenerator component

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/components/condition_builder/ConditionBuilder.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/condition_builder/ConditionBuilder.vue
@@ -101,8 +101,22 @@ const emit = defineEmits(["update:modelValue"]);
 
 const store = useStore();
 
+/**
+ * Ensure we have a valid root group structure.
+ */
+function normalizeModel(val) {
+	if (!val || typeof val !== "object") {
+		return { op: "and", conditions: [] };
+	}
+	return {
+		op: val.op || "and",
+		conditions: Array.isArray(val.conditions) ? val.conditions : [],
+		id: val.id,
+	};
+}
+
 // Create a reactive copy of the model
-const rootGroup = reactive(JSON.parse(JSON.stringify(props.modelValue)));
+const rootGroup = reactive(normalizeModel(props.modelValue));
 
 let isUpdating = false;
 
@@ -120,14 +134,15 @@ watch(
 watch(
 	() => props.modelValue,
 	(newVal) => {
-		if (!newVal || isUpdating) return;
+		if (isUpdating) return;
 
+		const normalized = normalizeModel(newVal);
 		const currentJSON = JSON.stringify(rootGroup);
-		const newJSON = JSON.stringify(newVal);
+		const newJSON = JSON.stringify(normalized);
 
 		if (newJSON !== currentJSON) {
 			isUpdating = true;
-			Object.assign(rootGroup, JSON.parse(newJSON));
+			Object.assign(rootGroup, normalized);
 			nextTick(() => {
 				isUpdating = false;
 			});

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/NotifyConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/NotifyConfig.vue
@@ -89,11 +89,9 @@
 				</div>
 
 				<div class="form-group mb-3">
-					<TextGeneratorControl
+					<ControlFactory
 						:df="with_read_only(textGeneratorField)"
 						:modelValue="config.text_generator_ui"
-						:read_only="readOnly"
-						:variableOptions="variable_options"
 						@update:modelValue="update_template_ui"
 					/>
 				</div>

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/RaiseErrorConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/RaiseErrorConfig.vue
@@ -26,11 +26,9 @@
 			</div>
 
 			<div class="form-group mb-3">
-				<TextGeneratorControl
+				<ControlFactory
 					:df="with_read_only(textGeneratorField)"
 					:modelValue="config.text_generator_ui"
-					:read_only="readOnly"
-					:variableOptions="variable_options"
 					@update:modelValue="update_template_ui"
 				/>
 			</div>

--- a/flexirule/public/js/flexirule/rule_builder/composables/useActionConfig.js
+++ b/flexirule/public/js/flexirule/rule_builder/composables/useActionConfig.js
@@ -1,4 +1,4 @@
-import { reactive, ref, computed, watch, onMounted } from "vue";
+import { reactive, ref, computed, watch, onMounted, provide } from "vue";
 import { useStore } from "../stores";
 
 export function useActionConfig(props) {
@@ -168,6 +168,15 @@ export function useActionConfig(props) {
 		() => store.nodes,
 		() => refresh_variables(),
 		{ deep: true }
+	);
+
+	provide(
+		"variableOptions",
+		computed(() => variable_options.value)
+	);
+	provide(
+		"docFields",
+		computed(() => doctype_fields.value)
 	);
 
 	function is_field_valid(fieldname, dt_fields) {

--- a/flexirule/public/js/flexirule/rule_builder/controls/ControlFactory.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/ControlFactory.vue
@@ -199,7 +199,8 @@
 			:df="df"
 			:modelValue="modelValue"
 			:read_only="df?.read_only"
-			:variableOptions="df?.variable_options || []"
+			:variableOptions="df?.variable_options || injectedVariableOptions"
+			:docFieldOptions="df?.doc_field_options || injectedDocFields"
 			:hideLabel="hideLabel"
 			:hideDescription="hideDescription"
 			@update:modelValue="$emit('update:modelValue', $event)"
@@ -209,7 +210,7 @@
 			v-else-if="df?.fieldtype === 'Structured Value'"
 			:modelValue="modelValue"
 			:read_only="df?.read_only"
-			:variableOptions="df?.variable_options || []"
+			:variableOptions="df?.variable_options || injectedVariableOptions"
 			:compact="df?.compact || false"
 			:placeholder="df?.placeholder || ''"
 			:disabled="df?.read_only"
@@ -258,7 +259,7 @@
 </template>
 
 <script setup>
-import { nextTick, onMounted, watch, computed, defineAsyncComponent } from "vue";
+import { nextTick, onMounted, watch, computed, defineAsyncComponent, inject } from "vue";
 import ComboBoxControl from "./ComboBoxControl.vue";
 import MultiSelectList from "./MultiSelectList.vue";
 import TimePickerControl from "./TimePickerControl.vue";
@@ -271,6 +272,9 @@ import TextGeneratorControl from "./TextGeneratorControl.vue";
 // Use async components for potential circular dependencies
 const FlexiGrid = defineAsyncComponent(() => import("./FlexiGrid.vue"));
 const FlexValueControl = defineAsyncComponent(() => import("./FlexValueControl.vue"));
+
+const injectedVariableOptions = inject("variableOptions", null);
+const injectedDocFields = inject("docFields", null);
 
 const props = defineProps({
 	df: Object,

--- a/flexirule/public/js/flexirule/rule_builder/controls/TextGeneratorControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/TextGeneratorControl.vue
@@ -448,7 +448,18 @@ const editor = new Editor({
 					const type = props.id === "if" ? "conditional" : "loop";
 					const key = Math.random().toString(36).slice(2, 9);
 					const content = [
-						{ type: "logic", attrs: { type, isStart: true, _key: key } },
+						{
+							type: "logic",
+							attrs: {
+								type,
+								isStart: true,
+								_key: key,
+								condition:
+									type === "conditional" ? { op: "and", conditions: [] } : null,
+								iterator: type === "loop" ? "item" : "",
+								iterable: "",
+							},
+						},
 						{ type: "text", text: " " },
 					];
 					if (type === "conditional") {


### PR DESCRIPTION
This PR fixes a regression where the Condition Editor (AND/OR toggle and action buttons) would not appear when opening an IF logic node in the TextGeneratorControl.

Key changes:
1.  **State Initialization:** Logic nodes are now created with the required `{ op: 'and', conditions: [] }` structure in `TextGeneratorControl.vue`.
2.  **Defensive Rendering:** `ConditionBuilder.vue` now uses a `normalizeModel` helper to ensure internal state is always valid, preventing blank renders.
3.  **Automatic Propagation:** Centralized `docFields` and `variableOptions` propagation using Vue's provide/inject pattern in `useActionConfig.js` and `ControlFactory.vue`. This ensures all TextGenerator instances receive the necessary context without manual prop passing in every configuration panel.
4.  **Refactoring:** Updated `NotifyConfig.vue` and `RaiseErrorConfig.vue` to use `ControlFactory` for their message builders to benefit from the automatic context propagation.

---
*PR created automatically by Jules for task [6854166832884725173](https://jules.google.com/task/6854166832884725173) started by @abdoruzaqi*