### PR TITLE
Fix flowchart bugs and add pan toggle and fix condition builder bugs

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/App.vue
+++ b/flexirule/public/js/flexirule/rule_builder/App.vue
@@ -13,18 +13,19 @@
 					:max-zoom="4"
 					:zoom-on-scroll="false"
 					:pan-on-scroll="true"
+					:pan-on-scroll-mode="'free'"
 					:zoom-on-pinch="true"
 					:snap-to-grid="true"
 					:snap-grid="[15, 15]"
-					:nodes-draggable="!isReadOnly"
+					:nodes-draggable="!isReadOnly && !panMode"
 					:nodes-connectable="!isReadOnly"
 					:elements-selectable="true"
-					:selection-on-drag="true"
-					:pan-on-drag="[2]"
+					:selection-on-drag="!panMode"
+					:pan-on-drag="panMode ? true : [2]"
 					:delete-key-active="!isReadOnly"
 					fit-view-on-init
 					:edge-types="edgeTypes"
-					:class="{ 'is-read-only-flow': isReadOnly }"
+					:class="{ 'is-read-only-flow': isReadOnly, 'is-pan-mode': panMode }"
 					@node-click="onNodeClick"
 					@node-dblclick="onNodeDblClick"
 					@pane-click="onPaneClick"
@@ -107,6 +108,14 @@
 								:title="__('Fit View')"
 							>
 								{{ __("Fit") }}
+							</button>
+							<button
+								class="btn btn-sm btn-default"
+								:class="{ active: panMode }"
+								@click="panMode = !panMode"
+								:title="__('Pan Canvas')"
+							>
+								<i class="fa fa-hand-paper-o"></i>
 							</button>
 							<button
 								class="btn btn-sm btn-default"
@@ -279,6 +288,7 @@ const { copySelectedToClipboard, pasteFromClipboard } = useClipboard();
 const flowWrapper = ref(null);
 const mousePos = ref({ x: 0, y: 0 });
 const showDisabledNodes = ref(true);
+const panMode = ref(false);
 
 function updateMousePos(e) {
 	mousePos.value = { x: e.clientX, y: e.clientY };
@@ -611,6 +621,16 @@ function onEdgeClick({ edge, event }) {
 	background-color: var(--fg-color);
 	position: relative;
 	order: 1;
+}
+
+.canvas-container :deep(.vue-flow.is-pan-mode),
+.canvas-container :deep(.vue-flow.is-pan-mode .vue-flow__pane) {
+	cursor: grab;
+}
+
+.canvas-container :deep(.vue-flow.is-pan-mode:active),
+.canvas-container :deep(.vue-flow.is-pan-mode:active .vue-flow__pane) {
+	cursor: grabbing;
 }
 
 .execution-panel {

--- a/flexirule/public/js/flexirule/rule_builder/components/AddNodeEdge.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/AddNodeEdge.vue
@@ -38,7 +38,7 @@ const isReturnEdge = computed(() => {
 });
 
 const isAfterLastEdge = computed(() => {
-	return props.data?.afterLast || props.sourceHandleId === "false" || props.id.includes("-false");
+	return props.data?.afterLast === true;
 });
 
 const isLoopBodyEdge = computed(() => {

--- a/flexirule/public/js/flexirule/rule_builder/components/condition_builder/SimpleCondition.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/condition_builder/SimpleCondition.vue
@@ -192,6 +192,17 @@ const valueFieldSchema = computed(() => {
 	return schema;
 });
 
+const valueControlKey = computed(() => {
+	const schema = valueFieldSchema.value || {};
+	return [
+		selectedField.value?.value || "",
+		props.node.op || "",
+		schema.fieldtype || "",
+		schema.options || "",
+		dynamicLinkDocType.value || "",
+	].join("|");
+});
+
 function isStructuredValue(val) {
 	return Boolean(val && typeof val === "object" && !Array.isArray(val) && val.mode);
 }
@@ -343,11 +354,13 @@ watch(
 					</div>
 
 					<FlexValueControl
+						:key="valueControlKey"
 						v-model="wrappedValue"
 						:context="{
 							df: valueFieldSchema,
 							operator: node.op,
-							referenceDoctype: store?.rule_doc?.document_type,
+							referenceDoctype:
+								valueFieldSchema.options || store?.rule_doc?.document_type,
 						}"
 						:engine="store"
 						:doc="store?.rule_doc"

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/ConditionNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/ConditionNode.vue
@@ -280,16 +280,21 @@ function openConfig() {
 	font-size: 8px;
 	font-weight: 800;
 	position: absolute;
+	background: #fff;
+	border-radius: 999px;
+	padding: 1px 4px;
+	box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
+	line-height: 1.2;
 }
 
 .out-right .port-label {
-	top: -12px;
-	left: 50%;
-	transform: translateX(-50%);
+	top: -16px;
+	left: 12px;
+	transform: none;
 }
 
 .out-bottom .port-label {
-	bottom: -12px;
+	bottom: -16px;
 	left: 50%;
 	transform: translateX(-50%);
 }

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/LoopNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/LoopNode.vue
@@ -16,7 +16,7 @@ const targetPos = computed(
 // LR layout: For Each → Right (straight right), After Last → Bottom (bypass)
 const doPos = computed(() => (isHorizontal.value ? Position.Right : Position.Bottom));
 const donePos = computed(() => (isHorizontal.value ? Position.Bottom : Position.Right));
-const returnPos = computed(() => (isHorizontal.value ? Position.Left : Position.Top));
+const returnPos = computed(() => (isHorizontal.value ? Position.Top : Position.Left));
 
 const isEffectiveDisabled = computed(() => {
 	return store.effectiveDisabledIds?.has(props.id);
@@ -246,13 +246,14 @@ function openConfig() {
 
 /* Handles */
 .loop-node-card:not(.is-vertical) .handle-done {
-	top: -5px !important;
+	top: auto !important;
+	bottom: -5px !important;
 	left: 50% !important;
 }
 
 .loop-node-card:not(.is-vertical) .handle-return {
-	left: -5px !important;
-	top: 70% !important;
+	left: 50% !important;
+	top: -5px !important;
 }
 
 .loop-node-card:not(.is-vertical) .handle-target {

--- a/flexirule/public/js/flexirule/rule_builder/composables/useRuleGraph.js
+++ b/flexirule/public/js/flexirule/rule_builder/composables/useRuleGraph.js
@@ -1,10 +1,10 @@
 import dagre from "dagre";
 import { useVueFlow } from "@vue-flow/core";
 
-const NODE_WIDTH = 260;
-const NODE_HEIGHT = 160;
-const H_GAP = 70; // horizontal gap between ranks (LR) or between main and body column (TB)
-const V_GAP = 80; // vertical gap between nodes
+const NODE_WIDTH = 220;
+const NODE_HEIGHT = 140;
+const H_GAP = 46; // horizontal gap between ranks (LR) or between main and body column (TB)
+const V_GAP = 72; // vertical gap between nodes
 
 export function useRuleGraph() {
 	const { nodes, edges, setNodes, setEdges, fitView } = useVueFlow();
@@ -85,7 +85,7 @@ export function useRuleGraph() {
 		dagreGraph.setGraph({
 			rankdir: direction,
 			nodesep: isHorizontal ? V_GAP : H_GAP,
-			ranksep: isHorizontal ? H_GAP : V_GAP,
+			ranksep: isHorizontal ? H_GAP + 12 : V_GAP,
 			marginx: 40,
 			marginy: 40,
 		});
@@ -130,8 +130,8 @@ export function useRuleGraph() {
 				const afterLastSubtreeIds = bfsReachable(afterLastId, currentEdges);
 				// In LR layout, After Last exits Bottom -> shift Down (+Y)
 				// In TB layout, After Last exits Right -> shift Right (+X)
-				const shiftX = isHorizontal ? 0 : NODE_WIDTH + H_GAP;
-				const shiftY = isHorizontal ? NODE_HEIGHT + V_GAP : 0;
+				const shiftX = isHorizontal ? 0 : NODE_WIDTH + H_GAP + 80;
+				const shiftY = isHorizontal ? NODE_HEIGHT + V_GAP + 80 : 0;
 
 				afterLastSubtreeIds.forEach((id) => {
 					const p = positions.get(id);
@@ -148,9 +148,9 @@ export function useRuleGraph() {
 			let bodyY = loopPos.y;
 
 			if (isHorizontal) {
-				bodyX += NODE_WIDTH + H_GAP;
+				bodyX += NODE_WIDTH + H_GAP + 60;
 			} else {
-				bodyY += NODE_HEIGHT + V_GAP;
+				bodyY += NODE_HEIGHT + V_GAP + 40;
 			}
 
 			// BFS-order the body nodes so they stack nicely
@@ -173,13 +173,13 @@ export function useRuleGraph() {
 			ordered.forEach((id, i) => {
 				if (isHorizontal) {
 					positions.set(id, {
-						x: bodyX + (NODE_WIDTH + H_GAP) * i,
+						x: bodyX + (NODE_WIDTH + H_GAP + 40) * i,
 						y: bodyY,
 					});
 				} else {
 					positions.set(id, {
 						x: bodyX,
-						y: bodyY + (NODE_HEIGHT + V_GAP) * i,
+						y: bodyY + (NODE_HEIGHT + V_GAP + 16) * i,
 					});
 				}
 			});
@@ -220,7 +220,12 @@ export function useRuleGraph() {
 		setNodes(layoutedNodes);
 
 		setTimeout(() => {
-			fitView({ padding: 0.05, duration: 500 });
+			fitView({
+				padding: 0.12,
+				duration: 500,
+				minZoom: isHorizontal ? 0.68 : 0.72,
+				maxZoom: 1,
+			});
 		}, 100);
 	};
 

--- a/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
@@ -294,7 +294,7 @@
 </template>
 
 <script setup>
-import { computed, ref, watch, onBeforeUnmount, nextTick, getCurrentInstance } from "vue";
+import { computed, ref, watch, onBeforeUnmount, nextTick } from "vue";
 import { Editor, EditorContent, VueRenderer, VueNodeViewRenderer } from "@tiptap/vue-3";
 import { StarterKit } from "@tiptap/starter-kit";
 import { Node, mergeAttributes } from "@tiptap/core";
@@ -312,58 +312,6 @@ import MentionList from "./MentionList.vue";
 import ControlFactory from "./ControlFactory.vue";
 import ValueResolverControl from "./ValueResolverControl.vue";
 import ResolverTokenView from "./ResolverTokenView.vue";
-
-const globalSuggestionPopups = [];
-
-function destroySuggestionPopup(popup) {
-	if (!popup) return;
-	if (Array.isArray(popup)) {
-		popup.forEach((p) => destroySuggestionPopup(p));
-		return;
-	}
-	if (typeof popup.destroy === "function") {
-		try {
-			popup.destroy();
-		} catch (e) {
-			// A sibling FlexValueControl may have already destroyed it.
-		}
-	}
-}
-
-function closeAllSuggestionPopups() {
-	[...activeTippyPopups, ...globalSuggestionPopups].forEach(destroySuggestionPopup);
-	activeTippyPopups.length = 0;
-	globalSuggestionPopups.length = 0;
-
-	document.querySelectorAll(".fvc-suggestion-popover").forEach((el) => {
-		if (el._tippy) {
-			destroySuggestionPopup(el._tippy);
-		} else {
-			el.remove();
-		}
-	});
-}
-
-function getSuggestionClientRect(suggestionProps) {
-	const rect = suggestionProps.clientRect?.();
-	if (rect) return rect;
-
-	const from = suggestionProps.range?.from;
-	const view = suggestionProps.editor?.view;
-	if (typeof from === "number" && view?.coordsAtPos) {
-		const coords = view.coordsAtPos(from);
-		return {
-			width: 0,
-			height: coords.bottom - coords.top,
-			top: coords.top,
-			right: coords.right,
-			bottom: coords.bottom,
-			left: coords.left,
-		};
-	}
-
-	return controlRef.value?.getBoundingClientRect?.() || null;
-}
 
 const props = defineProps({
 	modelValue: { type: [Object, String, Number, Boolean], default: null },
@@ -660,13 +608,22 @@ function createSuggestionRenderer() {
 	return {
 		onStart: (props) => {
 			isSuggestionOpen.value = true;
-			closeAllSuggestionPopups();
+			// Destroy any existing popups to prevent duplicates
+			activeTippyPopups.forEach((p) => {
+				if (p) {
+					if (Array.isArray(p)) {
+						p.forEach((pi) => pi?.destroy?.());
+					} else if (typeof p.destroy === "function") {
+						p.destroy();
+					}
+				}
+			});
+			activeTippyPopups.length = 0;
 
 			component = new VueRenderer(MentionList, { props, editor: props.editor });
-			const initialRect = getSuggestionClientRect(props);
-			if (!initialRect) return;
+			if (!props.clientRect) return;
 			popup = tippy(document.createElement("div"), {
-				getReferenceClientRect: () => getSuggestionClientRect(props) || initialRect,
+				getReferenceClientRect: props.clientRect,
 				appendTo: () => document.body,
 				content: component.element,
 				showOnCreate: true,
@@ -674,20 +631,13 @@ function createSuggestionRenderer() {
 				trigger: "manual",
 				placement: "bottom-start",
 				zIndex: 14000,
-				onCreate(instance) {
-					instance.popper.classList.add("fvc-suggestion-popover");
-				},
 			});
 			activeTippyPopups.push(popup);
-			globalSuggestionPopups.push(popup);
 		},
 		onUpdate(props) {
 			component?.updateProps(props);
-			const rect = getSuggestionClientRect(props);
-			if (!rect) return;
-			popup?.setProps({
-				getReferenceClientRect: () => getSuggestionClientRect(props) || rect,
-			});
+			if (!props.clientRect) return;
+			popup?.setProps({ getReferenceClientRect: props.clientRect });
 		},
 		onKeyDown(props) {
 			if (props.event.key === "Escape") {
@@ -702,19 +652,17 @@ function createSuggestionRenderer() {
 		onExit() {
 			isSuggestionOpen.value = false;
 			if (popup) {
-				destroySuggestionPopup(popup);
+				try {
+					popup.destroy();
+				} catch (e) {}
 				const idx = activeTippyPopups.indexOf(popup);
 				if (idx > -1) activeTippyPopups.splice(idx, 1);
-				const globalIdx = globalSuggestionPopups.indexOf(popup);
-				if (globalIdx > -1) globalSuggestionPopups.splice(globalIdx, 1);
 				popup = null;
 			}
 			if (component) {
 				try {
 					component.destroy();
-				} catch (e) {
-					// VueRenderer may already be destroyed with the popup.
-				}
+				} catch (e) {}
 				component = null;
 			}
 		},
@@ -1225,7 +1173,16 @@ watch(
 );
 
 onBeforeUnmount(() => {
-	closeAllSuggestionPopups();
+	activeTippyPopups.forEach((popup) => {
+		if (popup) {
+			if (Array.isArray(popup)) {
+				popup.forEach((p) => p?.destroy?.());
+			} else if (typeof popup.destroy === "function") {
+				popup.destroy();
+			}
+		}
+	});
+	activeTippyPopups.length = 0;
 	editor.destroy();
 });
 </script>
@@ -1358,7 +1315,7 @@ onBeforeUnmount(() => {
 	outline: none;
 	font-size: 13px;
 	min-height: 22px;
-	white-space: nowrap;
+	white-space: pre-wrap;
 }
 
 .fvc-inline-actions {

--- a/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
@@ -313,6 +313,58 @@ import ControlFactory from "./ControlFactory.vue";
 import ValueResolverControl from "./ValueResolverControl.vue";
 import ResolverTokenView from "./ResolverTokenView.vue";
 
+const globalSuggestionPopups = [];
+
+function destroySuggestionPopup(popup) {
+	if (!popup) return;
+	if (Array.isArray(popup)) {
+		popup.forEach((p) => destroySuggestionPopup(p));
+		return;
+	}
+	if (typeof popup.destroy === "function") {
+		try {
+			popup.destroy();
+		} catch (e) {
+			// A sibling FlexValueControl may have already destroyed it.
+		}
+	}
+}
+
+function closeAllSuggestionPopups() {
+	[...activeTippyPopups, ...globalSuggestionPopups].forEach(destroySuggestionPopup);
+	activeTippyPopups.length = 0;
+	globalSuggestionPopups.length = 0;
+
+	document.querySelectorAll(".fvc-suggestion-popover").forEach((el) => {
+		if (el._tippy) {
+			destroySuggestionPopup(el._tippy);
+		} else {
+			el.remove();
+		}
+	});
+}
+
+function getSuggestionClientRect(suggestionProps) {
+	const rect = suggestionProps.clientRect?.();
+	if (rect) return rect;
+
+	const from = suggestionProps.range?.from;
+	const view = suggestionProps.editor?.view;
+	if (typeof from === "number" && view?.coordsAtPos) {
+		const coords = view.coordsAtPos(from);
+		return {
+			width: 0,
+			height: coords.bottom - coords.top,
+			top: coords.top,
+			right: coords.right,
+			bottom: coords.bottom,
+			left: coords.left,
+		};
+	}
+
+	return controlRef.value?.getBoundingClientRect?.() || null;
+}
+
 const props = defineProps({
 	modelValue: { type: [Object, String, Number, Boolean], default: null },
 	variableOptions: { type: Array, default: () => [] },
@@ -360,9 +412,12 @@ const staticValue = ref("");
 
 const fieldType = computed(() => props.context?.df?.fieldtype || "Data");
 const fieldOptions = computed(() => props.context?.df?.options || []);
-const referenceDoctype = computed(
-	() => props.context?.referenceDoctype || props.context?.df?.options || ""
-);
+const referenceDoctype = computed(() => {
+	if (fieldType.value === "Link" && fieldOptions.value) {
+		return fieldOptions.value;
+	}
+	return props.context?.referenceDoctype || fieldOptions.value || "";
+});
 const resolverContext = computed(() => {
 	const df = props.context?.df || {};
 	const fieldname = props.context?.fieldname || df.fieldname || df.value || "";
@@ -605,22 +660,13 @@ function createSuggestionRenderer() {
 	return {
 		onStart: (props) => {
 			isSuggestionOpen.value = true;
-			// Destroy any existing popups to prevent duplicates
-			activeTippyPopups.forEach((p) => {
-				if (p) {
-					if (Array.isArray(p)) {
-						p.forEach((pi) => pi?.destroy?.());
-					} else if (typeof p.destroy === "function") {
-						p.destroy();
-					}
-				}
-			});
-			activeTippyPopups.length = 0;
+			closeAllSuggestionPopups();
 
 			component = new VueRenderer(MentionList, { props, editor: props.editor });
-			if (!props.clientRect) return;
+			const initialRect = getSuggestionClientRect(props);
+			if (!initialRect) return;
 			popup = tippy(document.createElement("div"), {
-				getReferenceClientRect: props.clientRect,
+				getReferenceClientRect: () => getSuggestionClientRect(props) || initialRect,
 				appendTo: () => document.body,
 				content: component.element,
 				showOnCreate: true,
@@ -628,13 +674,20 @@ function createSuggestionRenderer() {
 				trigger: "manual",
 				placement: "bottom-start",
 				zIndex: 14000,
+				onCreate(instance) {
+					instance.popper.classList.add("fvc-suggestion-popover");
+				},
 			});
 			activeTippyPopups.push(popup);
+			globalSuggestionPopups.push(popup);
 		},
 		onUpdate(props) {
 			component?.updateProps(props);
-			if (!props.clientRect) return;
-			popup?.setProps({ getReferenceClientRect: props.clientRect });
+			const rect = getSuggestionClientRect(props);
+			if (!rect) return;
+			popup?.setProps({
+				getReferenceClientRect: () => getSuggestionClientRect(props) || rect,
+			});
 		},
 		onKeyDown(props) {
 			if (props.event.key === "Escape") {
@@ -649,17 +702,19 @@ function createSuggestionRenderer() {
 		onExit() {
 			isSuggestionOpen.value = false;
 			if (popup) {
-				try {
-					popup.destroy();
-				} catch (e) {}
+				destroySuggestionPopup(popup);
 				const idx = activeTippyPopups.indexOf(popup);
 				if (idx > -1) activeTippyPopups.splice(idx, 1);
+				const globalIdx = globalSuggestionPopups.indexOf(popup);
+				if (globalIdx > -1) globalSuggestionPopups.splice(globalIdx, 1);
 				popup = null;
 			}
 			if (component) {
 				try {
 					component.destroy();
-				} catch (e) {}
+				} catch (e) {
+					// VueRenderer may already be destroyed with the popup.
+				}
 				component = null;
 			}
 		},
@@ -1170,16 +1225,7 @@ watch(
 );
 
 onBeforeUnmount(() => {
-	activeTippyPopups.forEach((popup) => {
-		if (popup) {
-			if (Array.isArray(popup)) {
-				popup.forEach((p) => p?.destroy?.());
-			} else if (typeof popup.destroy === "function") {
-				popup.destroy();
-			}
-		}
-	});
-	activeTippyPopups.length = 0;
+	closeAllSuggestionPopups();
 	editor.destroy();
 });
 </script>

--- a/flexirule/public/js/flexirule/rule_builder/controls/MentionList.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/MentionList.vue
@@ -1,10 +1,10 @@
 <template>
 	<div class="tg-mention-list" v-if="items.length">
 		<div class="tg-mention-header" v-if="triggerChar === '@'">
-			<i class="fa fa-at"></i> {{ __("Variables") }}
+			<i class="fa fa-at"></i> {{ t("Variables") }}
 		</div>
 		<div class="tg-mention-header" v-else>
-			<i class="fa fa-terminal"></i> {{ __("Logic Commands") }}
+			<i class="fa fa-terminal"></i> {{ t("Logic Commands") }}
 		</div>
 
 		<div class="tg-mention-scroller v2-scrollbar">
@@ -32,7 +32,7 @@
 		</div>
 	</div>
 	<div v-else class="tg-mention-list tg-mention-empty">
-		{{ __("No results found") }}
+		{{ t("No results found") }}
 	</div>
 </template>
 
@@ -61,6 +61,10 @@ export default {
 		},
 	},
 	methods: {
+		t(message) {
+			const translate = globalThis.__;
+			return typeof translate === "function" ? translate(message) : message;
+		},
 		getIcon(item) {
 			if (item.type === "variable") return "fa fa-cube";
 			if (item.type === "logic") {


### PR DESCRIPTION
- FlexValueControl: Force-closes any existing Tiptap/tippy suggestion popups before opening a new @ or / popup, resolving stale DOM elements and double-position menu bugs.

- Condition Value: Link fields now retain the selected field's Link doctype and remount cleanly on field, operator, or doctype changes.

- Loop Handles: Fixed broken return lines in top-to-bottom layouts by matching return handles to their correct VueFlow side.

- Edge Routing: Stopped treating Condition NO edges as Loop 'After Last' edges, eliminating unexpected routing overlaps.

- Auto Layout: Made layouts more compact while capping maximum zoom-down limits to keep large rules readable and allow off-screen canvas extension.

- Toolbar: Added a hand/pan toggle button to the bottom toolbar. Enabling it switches canvas dragging from node selection to panning and sets scroll panning to free mode.

# Pull Request Template


