### PR TITLE
Remove 'doc.' prefix from Query Records field selections

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/components/condition_builder/CollectionUI.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/condition_builder/CollectionUI.vue
@@ -73,7 +73,10 @@ const scopedVariableOptions = computed(() => {
 			const childDoctype = fieldMeta.options;
 			const childFields =
 				typeof store.get_fields_for_doctype === "function"
-					? store.get_fields_for_doctype(childDoctype, alias)
+					? store.get_fields_for_doctype(childDoctype, {
+							alias,
+							valueMode: "expression",
+					  })
 					: [];
 
 			childFields.forEach((f) => {
@@ -223,7 +226,10 @@ function fetchChildMeta() {
 		const childDoctype = fieldMeta.options;
 		const getAliasFields = () =>
 			typeof store.get_fields_for_doctype === "function"
-				? store.get_fields_for_doctype(childDoctype, alias)
+				? store.get_fields_for_doctype(childDoctype, {
+						alias,
+						valueMode: "expression",
+				  })
 				: [];
 		const parentFields = props.docFields.filter((f) => f.fieldtype !== "Table");
 		const mergeFields = (aliasFields) => {
@@ -239,7 +245,7 @@ function fetchChildMeta() {
 		};
 
 		const childFields = getAliasFields();
-		if (childFields.length > 0) {
+		if (childFields && childFields.length > 0) {
 			mergeFields(childFields);
 			return;
 		}

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/FilterGroup.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/FilterGroup.vue
@@ -586,7 +586,7 @@ const getFieldsForDoctype = (dt) => {
 	const mapped = [];
 
 	// Fetch unified fields (including standard ones like modified_by) from the meta store
-	const parentFields = store.get_fields_for_doctype(dt, "");
+	const parentFields = store.get_fields_for_doctype(dt, { valueMode: "fieldname" });
 	for (const df of parentFields) {
 		if (!shouldIncludeFilterField(df, dt)) continue;
 		if (frappe.model.table_fields.includes(df.fieldtype)) continue;

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/ConditionStep.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/ConditionStep.vue
@@ -163,7 +163,10 @@ const docFields = computed(() => {
 		const metaStore = store;
 		const doctype = store.rule_doc?.document_type;
 		if (doctype) {
-			const oldFields = metaStore.get_fields_for_doctype(doctype, "old_doc");
+			const oldFields = metaStore.get_fields_for_doctype(doctype, {
+				alias: "old_doc",
+				valueMode: "expression",
+			});
 			fields = [...fields, ...oldFields];
 		}
 	}

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/QueryRecordsConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/QueryRecordsConfig.vue
@@ -396,7 +396,9 @@ const {
 	is_field_valid,
 	refresh_variables,
 	update_action_field,
-} = useActionConfig(props);
+} = useActionConfig(props, {
+	fieldValueMode: "fieldname",
+});
 const { getPolicyField } = useNodeConfigPolicy({
 	actionType: () => props.node?.data?.action_type || "Query Records",
 	operation: mode,

--- a/flexirule/public/js/flexirule/rule_builder/composables/useActionConfig.js
+++ b/flexirule/public/js/flexirule/rule_builder/composables/useActionConfig.js
@@ -1,7 +1,7 @@
 import { reactive, ref, computed, watch, onMounted, provide } from "vue";
 import { useStore } from "../stores";
 
-export function useActionConfig(props) {
+export function useActionConfig(props, options = {}) {
 	const store = useStore();
 	const config = reactive({});
 	const docMeta = ref(null);
@@ -67,7 +67,14 @@ export function useActionConfig(props) {
 			loading.value = true;
 			const metaStore = store;
 			await metaStore.fetch_metadata(doctype);
-			doctype_fields.value = metaStore.get_fields_for_doctype(doctype, "doc");
+
+			// Merge defaults with caller-provided options
+			const fieldOptions = {
+				alias: options.fieldAlias || "doc",
+				valueMode: options.fieldValueMode || "expression",
+			};
+
+			doctype_fields.value = metaStore.get_fields_for_doctype(doctype, fieldOptions);
 		} catch (e) {
 			console.error("FlexiRule: Failed to load doctype fields", e);
 			doctype_fields.value = [];

--- a/flexirule/public/js/flexirule/rule_builder/stores/useMetaStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useMetaStore.js
@@ -113,23 +113,39 @@ export const useMetaStore = defineStore("rule-builder-meta", () => {
 	}
 
 	/**
-	 * Get fields for a DocType with an optional alias prefix.
+	 * Get fields for a DocType with configurable value and label formatting.
 	 * Returns standardized objects ready for FieldPicker and ComboBoxControl.
 	 *
 	 * @param {string} doctype
-	 * @param {string} alias - Variable prefix (default "doc")
+	 * @param {string|Object} options - Alias string (legacy) or configuration object
+	 * @param {string} [options.alias="doc"] - Prefix for expression mode
+	 * @param {string} [options.valueMode="expression"] - "expression" (doc.field) or "fieldname" (field)
 	 * @returns {Array}
 	 */
-	function get_fields_for_doctype(doctype, alias = "doc") {
+	function get_fields_for_doctype(doctype, options = "doc") {
 		if (!doctype || !doc_meta[doctype]) return [];
+
+		// Handle legacy string alias or new options object
+		const config = typeof options === "string" ? { alias: options } : options || {};
+		const alias = config.alias !== undefined ? config.alias : "doc";
+		const valueMode = config.valueMode || "expression";
 
 		return doc_meta[doctype].map((f) => {
 			const isSpecial = f.fieldname === "docstatus" || f.fieldname === "name" || f.is_std;
 			const prefix = alias ? `${alias}.` : "";
+
+			let value = f.fieldname;
+			let labelSuffix = f.fieldname;
+
+			if (valueMode === "expression") {
+				value = `${prefix}${f.fieldname}`;
+				labelSuffix = `${prefix}${f.fieldname}`;
+			}
+
 			return {
 				...f,
-				label: `${f.original_label || f.fieldname} (${prefix}${f.fieldname})`,
-				value: `${prefix}${f.fieldname}`,
+				label: `${f.original_label || f.fieldname} (${labelSuffix})`,
+				value: value,
 				icon: isSpecial ? "fa fa-asterisk" : "fa fa-columns",
 			};
 		});

--- a/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
@@ -46,7 +46,7 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 		const metaStore = useMetaStore();
 		const doctype = rule_doc.value?.document_type;
 		if (!doctype || !metaStore.doc_meta[doctype]) return [];
-		return metaStore.get_fields_for_doctype(doctype, "doc");
+		return metaStore.get_fields_for_doctype(doctype, { alias: "doc", valueMode: "expression" });
 	});
 
 	const raw_meta = computed(() => {


### PR DESCRIPTION
Identify the source of the 'doc.' prefix in Query Records field selections and refactor the shared metadata provider to allow consumers to choose between raw fieldnames and expression paths.

Changes:
- Enhanced `get_fields_for_doctype` in `useMetaStore.js` to support `valueMode: 'fieldname' | 'expression'`.
- Updated `useActionConfig.js` to allow passing field formatting options.
- Refactored `QueryRecordsConfig.vue` to use raw fieldnames for field selections, order by, and group by.
- Updated `FilterGroup.vue`, `useRuleStore.js`, `CollectionUI.vue`, and `ConditionStep.vue` to explicitly use `expression` mode where appropriate to maintain existing behavior.
- Verified backend compatibility with raw fieldnames in Query Records action handlers.

---
*PR created automatically by Jules for task [10851765990438934756](https://jules.google.com/task/10851765990438934756) started by @Sendipad*