### PR TITLE
fix: Resolve generator scope NameErrors and recover execution path traces

### DIFF
--- a/flexirule/ruleflow/api.py
+++ b/flexirule/ruleflow/api.py
@@ -327,7 +327,16 @@ def test_rule(
 			info_msg += _(" (trigger filters were bypassed for manual test)")
 
 	except Exception as e:
-		fallback_execution = getattr(locals().get("engine"), "last_execution_payload", None) or {}
+		# The engine's ``finally`` block always writes the full execution
+		# payload (including path_trace) to ``frappe.local.execution_payload``
+		# even when the rule raises.  Prefer that over the local ``engine``
+		# variable which only exists if we fell through to the manual
+		# engine.execute() path.
+		fallback_execution = (
+			getattr(locals().get("engine"), "last_execution_payload", None)
+			or getattr(frappe.local, "execution_payload", None)
+			or {}
+		)
 		return _build_error_response(
 			e,
 			context="test_rule",
@@ -336,6 +345,9 @@ def test_rule(
 				"execution": fallback_execution,
 				"path_trace": fallback_execution.get("path_trace", []),
 				"vars": fallback_execution.get("vars", {}),
+				# Legacy compatibility for existing UI consumers
+				"execution_path": fallback_execution.get("path_trace", []),
+				"context_snapshot": fallback_execution.get("vars", {}),
 			},
 		)
 

--- a/flexirule/ruleflow/core/coordinator.py
+++ b/flexirule/ruleflow/core/coordinator.py
@@ -558,7 +558,7 @@ class RuleCoordinator:
 					meta = _get_meta(doctype)
 					return bool(meta and fieldname and meta.has_field(fieldname))
 
-				eval_globals = {
+				eval_locals = {
 					"doc": doc,
 					"old_doc": old_doc,
 					"vars": {},
@@ -571,12 +571,21 @@ class RuleCoordinator:
 					"get_meta": _get_meta,
 					"resolve": FieldResolver.resolve,
 					"check_link_match": check_link_match,
+					"any": any,
+					"all": all,
 					"True": True,
 					"False": False,
 					"None": None,
 				}
+				# Python 3 generator/comprehension expressions create their own
+				# scope and resolve free variables through the *globals* dict,
+				# not the locals dict passed to eval().  Promote eval_locals
+				# into eval_globals so helpers like check_link_match are visible
+				# inside any(…)/all(…) patterns.
+				eval_globals: dict = {"__builtins__": {}}
+				eval_globals.update(eval_locals)
 
-				if not frappe.safe_eval(rule_doc.get("compiled_expression"), None, eval_globals):
+				if not frappe.safe_eval(rule_doc.get("compiled_expression"), eval_globals, eval_locals):
 					return False, _("Trigger Conditions failed")
 
 			except Exception as e:

--- a/flexirule/ruleflow/core/engine.py
+++ b/flexirule/ruleflow/core/engine.py
@@ -800,7 +800,12 @@ class RuleEngine:
 		}
 
 	def _evaluate_python_condition(self, expression, context):
-		"""Evaluate Python expression safely and coerce to bool."""
+		"""Evaluate Python expression safely and coerce to bool.
+
+		``NameError`` is always re-raised so that missing helper functions
+		or undefined variables surface as visible failures rather than
+		silently returning False.
+		"""
 		if not expression:
 			return True
 
@@ -808,12 +813,21 @@ class RuleEngine:
 
 		try:
 			return eval_condition_bool(expression, safe_locals, default=False)
+		except NameError:
+			self._log(
+				"ERROR", f"Condition evaluation failed — undefined name in expression: {expression[:200]}"
+			)
+			raise
 		except Exception as e:
 			self._log("ERROR", f"Condition evaluation failed: {e}")
 			return False
 
 	def _evaluate_python_value(self, expression, context, default=None):
-		"""Evaluate Python expression safely and return raw value."""
+		"""Evaluate Python expression safely and return raw value.
+
+		``NameError`` is always re-raised so that missing helper functions
+		or undefined variables surface as visible failures.
+		"""
 		if not expression:
 			return default
 
@@ -821,6 +835,9 @@ class RuleEngine:
 
 		try:
 			return eval_value(expression, safe_locals, default=default)
+		except NameError:
+			self._log("ERROR", f"Value evaluation failed — undefined name in expression: {expression[:200]}")
+			raise
 		except Exception as e:
 			self._log("ERROR", f"Value evaluation failed: {e}")
 			return default

--- a/flexirule/ruleflow/core/runtime_eval.py
+++ b/flexirule/ruleflow/core/runtime_eval.py
@@ -12,6 +12,15 @@ and the application logger so operators can diagnose silent rule divergence.
 A caught exception here means the rule's condition/value *did not* evaluate
 as intended — callers receive a safe default, but the failure is always
 recorded for forensic analysis.
+
+NOTE on Python 3 eval() scoping:
+    Generator/comprehension expressions create their own scope in Python 3.
+    Free variables inside the generator body (e.g. ``check_link_match``,
+    ``resolve``) are resolved through the **globals** dict, NOT the locals
+    dict passed to ``eval()``. To ensure utility functions are visible inside
+    ``any(f(x) for x in items)`` patterns, we pass ``safe_locals`` as BOTH
+    ``eval_globals`` (merged with ``{"__builtins__": {}}``) and
+    ``eval_locals``.
 """
 
 from __future__ import annotations
@@ -19,17 +28,46 @@ from __future__ import annotations
 import frappe
 
 
+def _build_eval_globals(safe_locals: dict) -> dict:
+	"""Build a globals dict that includes safe_locals for generator scoping.
+
+	Python 3 generator/comprehension expressions create an implicit nested
+	scope.  Free variables used inside that scope are resolved via the
+	**globals** dict of the enclosing ``eval()`` call, not the locals dict.
+
+	By promoting ``safe_locals`` into the globals dict (alongside a locked-
+	down ``__builtins__``), every name the compiled expression references
+	— including helper functions like ``check_link_match`` — becomes
+	visible inside ``any(…)``, ``all(…)``, list comprehensions, etc.
+	"""
+	eval_globals: dict = {"__builtins__": {}}
+	eval_globals.update(safe_locals)
+	return eval_globals
+
+
 def eval_condition_bool(expression: str, safe_locals: dict, default: bool = False) -> bool:
 	"""Evaluate expression and coerce to bool.
 
 	On failure, logs the expression and exception details to both
 	``frappe.logger`` and the Error Log DocType, then returns *default*.
+
+	``NameError`` is **never** silently swallowed — it is always re-raised
+	so that misconfigured expressions surface immediately rather than
+	producing quietly wrong results.
 	"""
 	if not expression:
 		return True
 
+	eval_globals = _build_eval_globals(safe_locals)
+
 	try:
-		return bool(frappe.safe_eval(expression, None, safe_locals))
+		return bool(frappe.safe_eval(expression, eval_globals, safe_locals))
+	except NameError as exc:
+		# NameError means a variable/function the expression references
+		# does not exist.  This is always a configuration or compilation
+		# bug and must NEVER be swallowed silently.
+		_log_eval_failure("eval_condition_bool", expression, exc)
+		raise
 	except Exception as exc:
 		_log_eval_failure("eval_condition_bool", expression, exc)
 		return default
@@ -40,12 +78,19 @@ def eval_value(expression: str, safe_locals: dict, default=None):
 
 	On failure, logs the expression and exception details to both
 	``frappe.logger`` and the Error Log DocType, then returns *default*.
+
+	``NameError`` is **never** silently swallowed — it is always re-raised.
 	"""
 	if not expression:
 		return default
 
+	eval_globals = _build_eval_globals(safe_locals)
+
 	try:
-		return frappe.safe_eval(expression, None, safe_locals)
+		return frappe.safe_eval(expression, eval_globals, safe_locals)
+	except NameError as exc:
+		_log_eval_failure("eval_value", expression, exc)
+		raise
 	except Exception as exc:
 		_log_eval_failure("eval_value", expression, exc)
 		return default

--- a/scratch.py
+++ b/scratch.py
@@ -1,0 +1,13 @@
+import frappe
+
+from flexirule.ruleflow.core.evaluator import check_link_match
+
+doc = frappe._dict({"items": [frappe._dict({"t_warehouse": "_Test Warehouse - _TC"})]})
+
+safe_locals = {"doc": doc, "check_link_match": check_link_match, "any": any}
+
+expr = "((any((check_link_match(i.get('t_warehouse'), ['Warehouse', ['_Test Warehouse - _TC']], 'in')) for i in (doc.get('items') or []))))"
+try:
+	print("Result:", frappe.safe_eval(expr, None, safe_locals))
+except Exception as e:
+	print("Error:", e)


### PR DESCRIPTION
Fixes silent evaluation bugs and test dialog path tracking in FlexiRule.

- **Generator Scoping:** Update eval_condition_bool and eval_value in runtime_eval.py and trigger evaluation in coordinator.py. Passes safe locals as both globals and locals to ensure utility functions (e.g., check_link_match) are visible inside Python 3 generator scopes.
- **Execution Trace:** Update test_rule API error handler to check frappe.local.execution_payload as a fallback, ensuring the Raise Error branch accurately returns the execution path to the test dialog.