### PR TITLE
Fix get_context_value to properly resolve field values on fallback lookups

### DIFF
--- a/flexirule/ruleflow/core/value_resolver.py
+++ b/flexirule/ruleflow/core/value_resolver.py
@@ -45,8 +45,7 @@ def get_context_value(context: dict, path: str | None) -> Any:
 		vars_dict = context.get("vars", {})
 
 		if doc is not None and (
-			(isinstance(doc, dict) and base in doc)
-			or (hasattr(doc, "get") and doc.get(base) is not None)
+			(isinstance(doc, dict) and base in doc) or (hasattr(doc, "get") and doc.get(base) is not None)
 		):
 			current = doc
 		elif isinstance(vars_dict, dict) and base in vars_dict:

--- a/flexirule/ruleflow/core/value_resolver.py
+++ b/flexirule/ruleflow/core/value_resolver.py
@@ -25,26 +25,36 @@ def get_context_value(context: dict, path: str | None) -> Any:
 	base = parts[0]
 	if base == "doc":
 		current = context.get("doc")
+		parts = parts[1:]
 	elif base == "vars":
 		current = context.get("vars", {})
+		parts = parts[1:]
 	elif base == "item":
 		current = context.get("item")
+		parts = parts[1:]
 	elif base == "loop":
 		current = context.get("loop")
+		parts = parts[1:]
 	elif base == "row":
 		current = context.get("row")
+		parts = parts[1:]
 	else:
 		# Fallback context lookup if no explicit scope is declared
-		if context.get("vars") and base in context["vars"]:
-			current = context["vars"]
-			parts = [base, *parts[1:]]
-		elif context.get("doc") and hasattr(context["doc"], "get") and context["doc"].get(base) is not None:
-			current = context["doc"]
-			parts = [base, *parts[1:]]
+		# Prioritize 'doc' then 'vars'
+		doc = context.get("doc")
+		vars_dict = context.get("vars", {})
+
+		if doc is not None and (
+			(isinstance(doc, dict) and base in doc)
+			or (hasattr(doc, "get") and doc.get(base) is not None)
+		):
+			current = doc
+		elif isinstance(vars_dict, dict) and base in vars_dict:
+			current = vars_dict
 		else:
 			return None
 
-	for part in parts[1:]:
+	for part in parts:
 		if current is None:
 			return None
 		if isinstance(current, dict):


### PR DESCRIPTION
The get_context_value function was incorrectly returning the parent container (like the Document object) instead of the specific field value when a path was provided without an explicit scope prefix (e.g., 'posting_date' instead of 'doc.posting_date'). This caused downstream errors in date calculations where the utility expected a date string or object but received a SalesInvoice document object. The fix refactors the resolution logic to correctly handle these fallback scenarios and ensures compatibility with both Frappe Document objects and raw dictionaries.

---
*PR created automatically by Jules for task [9103652073273920156](https://jules.google.com/task/9103652073273920156) started by @Sendipad*