### PR TITLE
Fix invisible edge lines on rule canvas

### DIFF
--- a/flexirule/public/css/theme-overrides.css
+++ b/flexirule/public/css/theme-overrides.css
@@ -4,11 +4,6 @@
  */
 
 /* Vue Flow Overrides */
-.vue-flow__container {
-	background-color: var(--fxr-bg-page);
-	background-image: radial-gradient(var(--fxr-border-subtle) 1px, transparent 1px);
-	background-size: 15px 15px;
-}
 
 .vue-flow__node {
 	background: var(--fxr-bg-card);


### PR DESCRIPTION
This PR fixes a rendering bug where edge lines connecting nodes became invisible in a rectangular region at the center of the canvas. 

The issue was caused by a CSS override in `theme-overrides.css` that applied a background color and grid dots to `.vue-flow__container`. Since Vue Flow uses this class for multiple overlapping internal containers (including the nodes and edges layers), the nodes layer was rendering a solid background on top of the edges, making them disappear.

I have removed these redundant styles from `theme-overrides.css`. The main canvas background and grid dots continue to render correctly as they are handled by the `.canvas-container` wrapper and the built-in `<Background />` component in `App.vue`.

---
*PR created automatically by Jules for task [8210635670132772177](https://jules.google.com/task/8210635670132772177) started by @Sendipad*