### PR TITLE
Expand Debug Dialog with User and Role Simulation

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/rule_builder.js
+++ b/flexirule/public/js/flexirule/rule_builder/rule_builder.js
@@ -60,7 +60,7 @@ class RuleBuilder {
 
 		// Debug
 		this.test_btn = this.page.add_inner_button(__("Debug Rule"), () => {
-			this.show_test_dialog();
+			this.show_debug_dialog();
 		});
 
 		// Clear visualization if any
@@ -236,8 +236,10 @@ class RuleBuilder {
 		}
 	}
 
-	show_test_dialog() {
+	show_debug_dialog() {
 		const last_docname = localStorage.getItem(`flexirule-debug-last-doc-${this.rule}`);
+		const last_sim_user = localStorage.getItem(`flexirule_debug_user_${this.rule}`);
+		const last_sim_role = localStorage.getItem(`flexirule_debug_role_${this.rule}`);
 
 		let d = new frappe.ui.Dialog({
 			title: __("Debug Rule"),
@@ -269,6 +271,20 @@ class RuleBuilder {
 					reqd: 1,
 				},
 				{
+					fieldtype: "Link",
+					fieldname: "sim_user",
+					label: __("Simulate User"),
+					options: "User",
+					default: last_sim_user || frappe.session.user,
+				},
+				{
+					fieldtype: "Link",
+					fieldname: "sim_role",
+					label: __("Simulate Role"),
+					options: "Role",
+					default: last_sim_role,
+				},
+				{
 					fieldtype: "Check",
 					fieldname: "save_log",
 					label: __("Create Execution Log"),
@@ -281,6 +297,8 @@ class RuleBuilder {
 				if (values.docname) {
 					localStorage.setItem(`flexirule-debug-last-doc-${this.rule}`, values.docname);
 				}
+				localStorage.setItem(`flexirule_debug_user_${this.rule}`, values.sim_user || "");
+				localStorage.setItem(`flexirule_debug_role_${this.rule}`, values.sim_role || "");
 
 				frappe.call({
 					method: "flexirule.ruleflow.api.test_rule",
@@ -288,6 +306,8 @@ class RuleBuilder {
 						rule_name: this.rule,
 						doctype: values.doctype,
 						docname: values.docname,
+						sim_user: values.sim_user,
+						sim_role: values.sim_role,
 						dry_run: !values.save_log,
 						skip_log_enqueue: !values.save_log,
 					},
@@ -295,15 +315,12 @@ class RuleBuilder {
 						this.uiStore.set_test_execution_visuals(r.message || {});
 						if (r.message?.success) {
 							// Highlight path in builder
-							const pathTrace =
-								r.message.path_trace || r.message.execution_path || [];
+							const pathTrace = r.message.path_trace || r.message.execution_path || [];
 							this.update_test_ui(pathTrace);
 
 							frappe.show_alert(
 								{
-									message:
-										r.message?.message ||
-										__("Rule debug completed successfully"),
+									message: r.message?.message || __("Rule debug completed successfully"),
 									indicator: "green",
 								},
 								5

--- a/flexirule/public/js/flexirule/rule_builder/rule_builder.js
+++ b/flexirule/public/js/flexirule/rule_builder/rule_builder.js
@@ -315,12 +315,15 @@ class RuleBuilder {
 						this.uiStore.set_test_execution_visuals(r.message || {});
 						if (r.message?.success) {
 							// Highlight path in builder
-							const pathTrace = r.message.path_trace || r.message.execution_path || [];
+							const pathTrace =
+								r.message.path_trace || r.message.execution_path || [];
 							this.update_test_ui(pathTrace);
 
 							frappe.show_alert(
 								{
-									message: r.message?.message || __("Rule debug completed successfully"),
+									message:
+										r.message?.message ||
+										__("Rule debug completed successfully"),
 									indicator: "green",
 								},
 								5

--- a/flexirule/ruleflow/api.py
+++ b/flexirule/ruleflow/api.py
@@ -244,6 +244,8 @@ def test_rule(
 	dry_run: int | bool | str = True,
 	skip_log_enqueue: int | bool | str = True,
 	save_log: int | bool | str | None = None,
+	sim_user: str | None = None,
+	sim_role: str | None = None,
 ):
 	"""
 	Test a rule against a document.
@@ -267,7 +269,12 @@ def test_rule(
 
 	# Manual tests are a pre-activation validation stage and must also work for drafts/inactive rules.
 	is_eligible, reason = RuleCoordinator.check_eligibility(
-		rule, doc, event_name="Manual Test", skip_event_check=True, allow_inactive=True
+		rule,
+		doc,
+		event_name="Manual Test",
+		skip_event_check=True,
+		allow_inactive=True,
+		context={"sim_user": sim_user, "sim_role": sim_role},
 	)
 
 	if not is_eligible:
@@ -304,6 +311,8 @@ def test_rule(
 			"allow_inactive_rule_test": True,
 			"dry_run": dry,
 			"skip_log_enqueue": skip_enqueue,
+			"sim_user": sim_user,
+			"sim_role": sim_role,
 		}
 		RuleCoordinator.execute_rule(rule, context=execution_context, dry_run=dry)
 		execution = getattr(frappe.local, "execution_payload", None) or {}

--- a/flexirule/ruleflow/core/coordinator.py
+++ b/flexirule/ruleflow/core/coordinator.py
@@ -498,6 +498,7 @@ class RuleCoordinator:
 		skip_event_check=False,
 		allow_inactive=False,
 		old_doc=None,
+		context=None,
 	) -> tuple[bool, str]:
 		"""
 		Strict V1 Contract Eligibility Check
@@ -534,6 +535,14 @@ class RuleCoordinator:
 				# Use SafeFrappeAPI to prevent write operations in trigger conditions
 				from flexirule.ruleflow.core.engine import SafeFrappeAPI
 
+				sim_user = (context or {}).get("sim_user")
+				sim_role = (context or {}).get("sim_role")
+
+				if sim_user or sim_role:
+					safe_frappe = SafeFrappeAPI(user=sim_user, roles=[sim_role] if sim_role else None)
+				else:
+					safe_frappe = SafeFrappeAPI()
+
 				rule_meta = {
 					"name": rule_doc.name,
 					"trigger_type": rule_doc.trigger_type,
@@ -562,7 +571,7 @@ class RuleCoordinator:
 					"doc": doc,
 					"old_doc": old_doc,
 					"vars": {},
-					"frappe": SafeFrappeAPI(),
+					"frappe": safe_frappe,
 					"caller": frappe._dict({}),
 					"rule": frappe._dict(rule_meta),
 					"doctype": doctype_name,

--- a/flexirule/ruleflow/core/engine.py
+++ b/flexirule/ruleflow/core/engine.py
@@ -135,20 +135,25 @@ class SafeFrappeAPI:
 	Exposes only safe, read-only operations to prevent security issues.
 	"""
 
-	def __init__(self):
+	def __init__(self, user=None, roles=None):
 		# Safe utilities
 		self.utils = frappe.utils
 		self._dict = frappe._dict
+		self._user = user
+		self._roles = roles
 
 	@property
 	def session(self):
 		"""Read-only access to frappe.session (current user, roles, etc.)"""
+		if self._user:
+			return frappe._dict({"user": self._user, "data": frappe._dict({"user": self._user})})
 		return frappe.session
 
-	@staticmethod
-	def get_roles(user=None):
+	def get_roles(self, user=None):
 		"""Read-only: return roles for the given user (or current session user)."""
-		return frappe.get_roles(user)
+		if not user and self._roles:
+			return self._roles
+		return frappe.get_roles(user or self._user)
 
 	# Safe read operations
 	@staticmethod
@@ -317,7 +322,14 @@ class RuleEngine:
 			# Check role-based skipping
 			skip_for_roles_docs = self.rule.get("skip_for_roles")
 			if skip_for_roles_docs:
-				user_roles = frappe.get_roles()
+				sim_user = self.context.get("sim_user")
+				sim_role = self.context.get("sim_role")
+
+				if sim_role:
+					user_roles = [sim_role]
+				else:
+					user_roles = frappe.get_roles(sim_user)
+
 				skip_roles = [row.get("role") for row in skip_for_roles_docs]
 				if any(role in user_roles for role in skip_roles):
 					self._log(
@@ -416,7 +428,14 @@ class RuleEngine:
 		# Check Rule Permission table if defined
 		rule_permissions = self.rule.get("permissions")
 		if rule_permissions:
-			user_roles = set(frappe.get_roles())
+			sim_user = self.context.get("sim_user")
+			sim_role = self.context.get("sim_role")
+
+			if sim_role:
+				user_roles = {sim_role}
+			else:
+				user_roles = set(frappe.get_roles(sim_user))
+
 			# System Manager always bypasses
 			if "System Manager" not in user_roles:
 				can_exec = any(p.can_execute and p.role in user_roles for p in rule_permissions)
@@ -437,7 +456,7 @@ class RuleEngine:
 			"rule": self.rule.name,
 			"rule_version": self.rule.version,
 			"engine_version": "1.0",
-			"user": frappe.session.user,
+			"user": self.context.get("sim_user") or frappe.session.user,
 			"timestamp": frappe.utils.now(),
 			"test_mode": self.context.get("test_mode", False),
 			"execution_id": self.execution_id,
@@ -460,6 +479,11 @@ class RuleEngine:
 
 	def _get_safe_frappe_api(self):
 		"""Return a restricted frappe API object for condition evaluation"""
+		sim_user = self.context.get("sim_user")
+		sim_role = self.context.get("sim_role")
+
+		if sim_user or sim_role:
+			return SafeFrappeAPI(user=sim_user, roles=[sim_role] if sim_role else None)
 		return _safe_frappe
 
 	def _execute_graph(self, context):

--- a/flexirule/ruleflow/doctype/rule/rule.js
+++ b/flexirule/ruleflow/doctype/rule/rule.js
@@ -399,7 +399,8 @@ function test_rule(frm) {
 					if (r.message?.success) {
 						frappe.show_alert(
 							{
-								message: r.message?.message || __("Rule debug completed successfully"),
+								message:
+									r.message?.message || __("Rule debug completed successfully"),
 								indicator: "green",
 							},
 							5

--- a/flexirule/ruleflow/doctype/rule/rule.js
+++ b/flexirule/ruleflow/doctype/rule/rule.js
@@ -89,7 +89,7 @@ frappe.ui.form.on("Rule", {
 
 		frm.page.clear_custom_actions();
 		frm.add_custom_button(__("Amend Rule"), () => amend_rule(frm), __("Actions"));
-		frm.add_custom_button(__("Test Rule"), () => test_rule(frm), __("Actions"));
+		frm.add_custom_button(__("Debug Rule"), () => test_rule(frm), __("Actions"));
 		frm.add_custom_button(__("Clear Cache"), () => clear_rule_cache(frm), __("Actions"));
 
 		apply_trigger_type_contract(frm);
@@ -321,9 +321,23 @@ function update_dashboard_indicators(frm) {
 	});
 }
 function test_rule(frm) {
+	const last_docname = localStorage.getItem(`flexirule-debug-last-doc-${frm.doc.name}`);
+	const last_sim_user = localStorage.getItem(`flexirule_debug_user_${frm.doc.name}`);
+	const last_sim_role = localStorage.getItem(`flexirule_debug_role_${frm.doc.name}`);
+
 	let d = new frappe.ui.Dialog({
-		title: __("Test Rule"),
+		title: __("Debug Rule"),
 		fields: [
+			{
+				fieldtype: "HTML",
+				options: `
+					<div class="alert alert-info small" style="margin-bottom: 15px;">
+						${__(
+							"Debug a rule against an existing record to inspect execution flow, conditions, variables, and action results. This is a simulation and does not modify data."
+						)}
+					</div>
+				`,
+			},
 			{
 				fieldtype: "Link",
 				fieldname: "doctype",
@@ -337,42 +351,67 @@ function test_rule(frm) {
 				fieldname: "docname",
 				label: __("Document"),
 				options: "doctype",
+				default: last_docname,
 				reqd: 1,
+			},
+			{
+				fieldtype: "Link",
+				fieldname: "sim_user",
+				label: __("Simulate User"),
+				options: "User",
+				default: last_sim_user || frappe.session.user,
+			},
+			{
+				fieldtype: "Link",
+				fieldname: "sim_role",
+				label: __("Simulate Role"),
+				options: "Role",
+				default: last_sim_role,
 			},
 			{
 				fieldtype: "Check",
 				fieldname: "save_log",
 				label: __("Create Execution Log"),
-				description: __("Persist a log record even for this test run"),
+				description: __("Persist a log record even for this debug run"),
 				default: 1,
 			},
 		],
-		primary_action_label: __("Test"),
+		primary_action_label: __("Debug"),
 		primary_action: (values) => {
+			if (values.docname) {
+				localStorage.setItem(`flexirule-debug-last-doc-${frm.doc.name}`, values.docname);
+			}
+			localStorage.setItem(`flexirule_debug_user_${frm.doc.name}`, values.sim_user || "");
+			localStorage.setItem(`flexirule_debug_role_${frm.doc.name}`, values.sim_role || "");
+
 			frappe.call({
 				method: "flexirule.ruleflow.api.test_rule",
 				args: {
 					rule_name: frm.doc.name,
 					doctype: values.doctype,
 					docname: values.docname,
+					sim_user: values.sim_user,
+					sim_role: values.sim_role,
 					dry_run: !values.save_log,
 					skip_log_enqueue: !values.save_log,
 				},
 				callback: (r) => {
 					if (r.message?.success) {
-						// Highlight path in builder
-
-						frappe.msgprint({
-							title: __("Success"),
-							message: r.message?.message || __("Rule test completed successfully"),
-							indicator: "green",
-						});
+						frappe.show_alert(
+							{
+								message: r.message?.message || __("Rule debug completed successfully"),
+								indicator: "green",
+							},
+							5
+						);
 					} else {
-						frappe.msgprint({
-							title: __("Error"),
-							message: r.message?.error || __("Test failed"),
-							indicator: "red",
-						});
+						frappe.show_alert(
+							{
+								message: r.message?.error || __("Debug failed"),
+								indicator: "red",
+							},
+							7
+						);
 					}
 					d.hide();
 				},


### PR DESCRIPTION
This PR introduces the ability to simulate specific users and roles during Rule debugging. 

Key changes:
- Frontend: The Debug dialog now includes "Simulate User" and "Simulate Role" fields. These values are cached in localStorage uniquely for each rule to improve developer experience.
- Backend: The 'test_rule' API now accepts 'sim_user' and 'sim_role'. The Rule Engine's 'SafeFrappeAPI' has been enhanced to mock the session user and roles based on these parameters, allowing for accurate simulation of permission-based logic and role-based skipping.
- Consistency: Unified the "Debug Rule" terminology and UI across both the Visual Builder and the standard Frappe DocType form.
- Robustness: Fixed a potential crash in the Coordinator and ensured simulation parameters are correctly retrieved from the execution context.

---
*PR created automatically by Jules for task [14377949981919168610](https://jules.google.com/task/14377949981919168610) started by @Sendipad*