### PR TITLE
Enhance debug dialog and Api to simulate user and Role 

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/App.vue
+++ b/flexirule/public/js/flexirule/rule_builder/App.vue
@@ -466,6 +466,12 @@ function onPaneReady(instance) {
 	instance.fitView();
 }
 
+function onDebugProgress(data) {
+	if (data.rule === ruleStore.rule_name) {
+		uiStore.add_test_progress_result(data.result);
+	}
+}
+
 onMounted(async () => {
 	document.body.classList.add("fxr-builder-active");
 	if (props.rule) ruleStore.rule_name = props.rule;
@@ -478,6 +484,9 @@ onMounted(async () => {
 	window.addEventListener("mousedown", handleGlobalMouseDown, true);
 	window.addEventListener("resize", updateQuickActionsPosition);
 	window.addEventListener("flexirule:show-shortcuts-help", showShortcutsHelp);
+	if (window.frappe?.realtime) {
+		frappe.realtime.on("flexirule_debug_progress", onDebugProgress);
+	}
 
 	setTimeout(() => {
 		if (graphStore.nodes.length > 0) {
@@ -496,6 +505,9 @@ onUnmounted(() => {
 	window.removeEventListener("mousedown", handleGlobalMouseDown, true);
 	window.removeEventListener("resize", updateQuickActionsPosition);
 	window.removeEventListener("flexirule:show-shortcuts-help", showShortcutsHelp);
+	if (window.frappe?.realtime) {
+		frappe.realtime.off("flexirule_debug_progress", onDebugProgress);
+	}
 });
 
 async function pasteFromClipboardWrapper() {

--- a/flexirule/public/js/flexirule/rule_builder/App.vue
+++ b/flexirule/public/js/flexirule/rule_builder/App.vue
@@ -284,7 +284,7 @@ const fieldInspector = ref({
 
 const quickActionItems = computed(() => [
 	{ key: "save", label: __("Save"), icon: "fa-floppy-o", shortcut: "Ctrl S" },
-	{ key: "test", label: __("Test"), icon: "fa-play" },
+	{ key: "test", label: __("Debug"), icon: "fa-bug" },
 	{
 		key: "status",
 		label: isReadOnly.value ? __("Unlock for editing") : __("Set to active"),

--- a/flexirule/public/js/flexirule/rule_builder/components/debugger/DebuggerPath.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/debugger/DebuggerPath.vue
@@ -7,6 +7,40 @@
 				<span class="title">{{ __("Execution Path") }}</span>
 				<span class="badge-steps">{{ steps.length }}</span>
 			</div>
+
+			<div v-if="uiStore.test_multi_results?.length > 1" class="multi-doc-selector">
+				<button
+					class="btn-nav"
+					@click="uiStore.set_active_multi_result(uiStore.test_current_multi_index - 1)"
+					:disabled="uiStore.test_current_multi_index === 0"
+				>
+					<i class="fa fa-chevron-left"></i>
+				</button>
+				<span
+					class="doc-label"
+					:title="uiStore.test_multi_results[uiStore.test_current_multi_index]?.docname"
+				>
+					{{
+						uiStore.test_multi_results[uiStore.test_current_multi_index]?.docname ||
+						`Doc ${uiStore.test_current_multi_index + 1}`
+					}}
+					<span class="counter"
+						>({{ uiStore.test_current_multi_index + 1 }}/{{
+							uiStore.test_multi_results.length
+						}})</span
+					>
+				</span>
+				<button
+					class="btn-nav"
+					@click="uiStore.set_active_multi_result(uiStore.test_current_multi_index + 1)"
+					:disabled="
+						uiStore.test_current_multi_index === uiStore.test_multi_results.length - 1
+					"
+				>
+					<i class="fa fa-chevron-right"></i>
+				</button>
+			</div>
+
 			<div class="divider-vertical"></div>
 			<button class="btn-clear" @click="clearPath" :title="__('Clear and Close')">
 				<i class="fa fa-times"></i>
@@ -188,6 +222,58 @@ watch(
 	width: 1px;
 	height: 16px;
 	background-color: var(--fxr-border-subtle);
+}
+
+.multi-doc-selector {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	margin: 0 8px;
+	padding: 2px 6px;
+	background: var(--fxr-surface-2);
+	border-radius: 4px;
+}
+
+.multi-doc-selector .doc-label {
+	font-size: 11px;
+	font-weight: 600;
+	color: var(--fxr-text-main);
+	max-width: 150px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}
+
+.multi-doc-selector .counter {
+	font-size: 10px;
+	color: var(--fxr-text-faint);
+	font-weight: normal;
+}
+
+.btn-nav {
+	background: none;
+	border: none;
+	cursor: pointer;
+	color: var(--fxr-text-soft);
+	padding: 2px 4px;
+	border-radius: 4px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: all 0.2s;
+}
+
+.btn-nav:hover:not(:disabled) {
+	color: var(--fxr-text-main);
+	background-color: var(--fxr-surface-3);
+}
+
+.btn-nav:disabled {
+	opacity: 0.3;
+	cursor: not-allowed;
 }
 
 .btn-clear {

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/QueryRecordsConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/QueryRecordsConfig.vue
@@ -355,7 +355,7 @@
 				:disabled="readOnly"
 				tabindex="0"
 			>
-				<i class="fa fa-flask mr-1"></i> {{ __("Refresh Schema (Test Query)") }}
+				<i class="fa fa-flask mr-1"></i> {{ __("Refresh Schema (Debug Query)") }}
 			</button>
 			<span v-if="test_status" class="ml-2 text-muted font-weight-bold">{{
 				test_status
@@ -914,7 +914,7 @@ function update_report_filter(fieldname, value) {
 
 async function test_query() {
 	if (!props.node?.data) return;
-	test_status.value = __("Testing...");
+	test_status.value = __("Debugging...");
 	try {
 		const res = await frappe.call({
 			method: "flexirule.ruleflow.api.test_action_query",

--- a/flexirule/public/js/flexirule/rule_builder/rule_builder.js
+++ b/flexirule/public/js/flexirule/rule_builder/rule_builder.js
@@ -237,7 +237,16 @@ class RuleBuilder {
 	}
 
 	show_debug_dialog() {
-		const last_docname = localStorage.getItem(`flexirule-debug-last-doc-${this.rule}`);
+		let last_docname = localStorage.getItem(`flexirule-debug-last-doc-${this.rule}`);
+		try {
+			last_docname = last_docname ? JSON.parse(last_docname) : [];
+			if (!Array.isArray(last_docname)) {
+				last_docname = last_docname ? last_docname.split(",") : [];
+			}
+		} catch (e) {
+			last_docname = last_docname ? last_docname.split(",") : [];
+		}
+
 		const last_sim_user = localStorage.getItem(`flexirule_debug_user_${this.rule}`);
 		const last_sim_role = localStorage.getItem(`flexirule_debug_role_${this.rule}`);
 
@@ -263,12 +272,22 @@ class RuleBuilder {
 					reqd: 1,
 				},
 				{
-					fieldtype: "Dynamic Link",
-					fieldname: "docname",
-					label: __("Document"),
-					options: "doctype",
-					default: last_docname,
+					fieldtype: "MultiSelectList",
+					fieldname: "docnames",
+					label: __("Documents"),
 					reqd: 1,
+					default: last_docname,
+					get_data: async (txt) => {
+						const doctype = d.get_value("doctype");
+
+						if (!doctype) {
+							return [];
+						}
+
+						const r = await frappe.db.get_link_options(doctype, txt);
+
+						return r || [];
+					},
 				},
 				{
 					fieldtype: "Section Break",
@@ -317,53 +336,86 @@ class RuleBuilder {
 			],
 			primary_action_label: __("Debug"),
 			primary_action: (values) => {
-				if (values.docname) {
-					localStorage.setItem(`flexirule-debug-last-doc-${this.rule}`, values.docname);
+				if (values.docnames && values.docnames.length) {
+					localStorage.setItem(
+						`flexirule-debug-last-doc-${this.rule}`,
+						JSON.stringify(values.docnames)
+					);
 				}
 				localStorage.setItem(`flexirule_debug_user_${this.rule}`, values.sim_user || "");
 				localStorage.setItem(`flexirule_debug_role_${this.rule}`, values.sim_role || "");
+
+				this.uiStore.clear_test_result();
 
 				frappe.call({
 					method: "flexirule.ruleflow.api.test_rule",
 					args: {
 						rule_name: this.rule,
 						doctype: values.doctype,
-						docname: values.docname,
+						docnames: values.docnames,
 						sim_user: values.sim_user,
 						sim_role: values.sim_role,
 						dry_run: !values.save_log,
 						skip_log_enqueue: !values.save_log,
 					},
 					callback: (r) => {
-						this.uiStore.set_test_execution_visuals(r.message || {});
-						if (r.message?.success) {
-							// Highlight path in builder
-							const pathTrace =
-								r.message.path_trace || r.message.execution_path || [];
-							this.update_test_ui(pathTrace);
-
-							frappe.show_alert(
-								{
-									message:
-										r.message?.message ||
-										__("Rule debug completed successfully"),
-									indicator: "green",
-								},
-								5
-							);
+						if (r.message?.multi) {
+							if (r.message.success_count > 0) {
+								frappe.show_alert(
+									{
+										message: __(
+											"Debug completed: {0} succeeded, {1} failed out of {2}",
+											[
+												r.message.success_count,
+												r.message.failure_count,
+												r.message.total,
+											]
+										),
+										indicator: r.message.failure_count > 0 ? "orange" : "green",
+									},
+									5
+								);
+							} else {
+								frappe.show_alert(
+									{
+										message: __("Debug completed: All {0} failed", [
+											r.message.total,
+										]),
+										indicator: "red",
+									},
+									7
+								);
+							}
 						} else {
-							this.update_test_ui(r.message?.path_trace || []);
-							frappe.show_alert(
-								{
-									message:
-										r.message?.message ||
-										r.message?.error ||
-										(r.message?.execution?.errors || []).join("\n") ||
-										__("Debug failed"),
-									indicator: "red",
-								},
-								7
-							);
+							this.uiStore.set_test_execution_visuals(r.message || {});
+							if (r.message?.success) {
+								const pathTrace =
+									r.message.path_trace || r.message.execution_path || [];
+								this.update_test_ui(pathTrace);
+
+								frappe.show_alert(
+									{
+										message:
+											r.message?.message ||
+											__("Rule debug completed successfully"),
+										indicator: "green",
+									},
+									5
+								);
+							} else {
+								this.update_test_ui(r.message?.path_trace || []);
+								frappe.show_alert(
+									{
+										message:
+											r.message?.message ||
+											r.message?.error ||
+											(r.message?.execution?.errors || []).join("\n") ||
+											__("Debug failed"),
+										indicator: "red",
+									},
+									7
+								);
+							}
 						}
 						d.hide();
 					},

--- a/flexirule/public/js/flexirule/rule_builder/rule_builder.js
+++ b/flexirule/public/js/flexirule/rule_builder/rule_builder.js
@@ -247,7 +247,7 @@ class RuleBuilder {
 					options: `
 						<div class="alert alert-info small" style="margin-bottom: 15px;">
 							${__(
-								"You can debug a Rule on any existing record without side effects; it is just a simulation run."
+								"Debug a rule against an existing record to inspect execution flow, conditions, variables, and action results. This is a simulation and does not modify data."
 							)}
 						</div>
 					`,

--- a/flexirule/public/js/flexirule/rule_builder/rule_builder.js
+++ b/flexirule/public/js/flexirule/rule_builder/rule_builder.js
@@ -60,7 +60,7 @@ class RuleBuilder {
 
 		// Debug
 		this.test_btn = this.page.add_inner_button(__("Debug Rule"), () => {
-			this.show_test_dialog();
+			this.show_debug_dialog();
 		});
 
 		// Clear visualization if any
@@ -236,8 +236,10 @@ class RuleBuilder {
 		}
 	}
 
-	show_test_dialog() {
+	show_debug_dialog() {
 		const last_docname = localStorage.getItem(`flexirule-debug-last-doc-${this.rule}`);
+		const last_sim_user = localStorage.getItem(`flexirule_debug_user_${this.rule}`);
+		const last_sim_role = localStorage.getItem(`flexirule_debug_role_${this.rule}`);
 
 		let d = new frappe.ui.Dialog({
 			title: __("Debug Rule"),
@@ -269,6 +271,20 @@ class RuleBuilder {
 					reqd: 1,
 				},
 				{
+					fieldtype: "Link",
+					fieldname: "sim_user",
+					label: __("Simulate User"),
+					options: "User",
+					default: last_sim_user || frappe.session.user,
+				},
+				{
+					fieldtype: "Link",
+					fieldname: "sim_role",
+					label: __("Simulate Role"),
+					options: "Role",
+					default: last_sim_role,
+				},
+				{
 					fieldtype: "Check",
 					fieldname: "save_log",
 					label: __("Create Execution Log"),
@@ -281,6 +297,8 @@ class RuleBuilder {
 				if (values.docname) {
 					localStorage.setItem(`flexirule-debug-last-doc-${this.rule}`, values.docname);
 				}
+				localStorage.setItem(`flexirule_debug_user_${this.rule}`, values.sim_user || "");
+				localStorage.setItem(`flexirule_debug_role_${this.rule}`, values.sim_role || "");
 
 				frappe.call({
 					method: "flexirule.ruleflow.api.test_rule",
@@ -288,6 +306,8 @@ class RuleBuilder {
 						rule_name: this.rule,
 						doctype: values.doctype,
 						docname: values.docname,
+						sim_user: values.sim_user,
+						sim_role: values.sim_role,
 						dry_run: !values.save_log,
 						skip_log_enqueue: !values.save_log,
 					},
@@ -295,15 +315,12 @@ class RuleBuilder {
 						this.uiStore.set_test_execution_visuals(r.message || {});
 						if (r.message?.success) {
 							// Highlight path in builder
-							const pathTrace =
-								r.message.path_trace || r.message.execution_path || [];
+							const pathTrace = r.message.path_trace || r.message.execution_path || [];
 							this.update_test_ui(pathTrace);
 
 							frappe.show_alert(
 								{
-									message:
-										r.message?.message ||
-										__("Rule debug completed successfully"),
+									message: r.message?.message || __("Rule debug completed successfully"),
 									indicator: "green",
 								},
 								5

--- a/flexirule/public/js/flexirule/rule_builder/rule_builder.js
+++ b/flexirule/public/js/flexirule/rule_builder/rule_builder.js
@@ -315,12 +315,15 @@ class RuleBuilder {
 						this.uiStore.set_test_execution_visuals(r.message || {});
 						if (r.message?.success) {
 							// Highlight path in builder
-							const pathTrace = r.message.path_trace || r.message.execution_path || [];
+							const pathTrace =
+								r.message.path_trace || r.message.execution_path || [];
 							this.update_test_ui(pathTrace);
 
 							frappe.show_alert(
 								{
-									message: r.message?.message || __("Rule debug completed successfully"),
+									message:
+										r.message?.message ||
+										__("Rule debug completed successfully"),
 									indicator: "green",
 								},
 								5

--- a/flexirule/public/js/flexirule/rule_builder/rule_builder.js
+++ b/flexirule/public/js/flexirule/rule_builder/rule_builder.js
@@ -58,13 +58,13 @@ class RuleBuilder {
 			await this.toggle_rule_active();
 		});
 
-		// Test
-		this.test_btn = this.page.add_inner_button(__("Test Rule"), () => {
+		// Debug
+		this.test_btn = this.page.add_inner_button(__("Debug Rule"), () => {
 			this.show_test_dialog();
 		});
 
 		// Clear visualization if any
-		this.clear_test_btn = this.page.add_inner_button(__("Clear Test Path"), () => {
+		this.clear_test_btn = this.page.add_inner_button(__("Clear Debug Path"), () => {
 			this.uiStore.clear_test_result();
 			this.update_test_ui([]);
 		});
@@ -238,8 +238,18 @@ class RuleBuilder {
 
 	show_test_dialog() {
 		let d = new frappe.ui.Dialog({
-			title: __("Test Rule"),
+			title: __("Debug Rule"),
 			fields: [
+				{
+					fieldtype: "HTML",
+					options: `
+						<div class="alert alert-info small" style="margin-bottom: 15px;">
+							${__(
+								"You can debug a Rule on any existing record without side effects; it is just a simulation run."
+							)}
+						</div>
+					`,
+				},
 				{
 					fieldtype: "Link",
 					fieldname: "doctype",
@@ -259,11 +269,11 @@ class RuleBuilder {
 					fieldtype: "Check",
 					fieldname: "save_log",
 					label: __("Create Execution Log"),
-					description: __("Persist a log record even for this test run"),
+					description: __("Persist a log record even for this debug run"),
 					default: 1,
 				},
 			],
-			primary_action_label: __("Test"),
+			primary_action_label: __("Debug"),
 			primary_action: (values) => {
 				frappe.call({
 					method: "flexirule.ruleflow.api.test_rule",
@@ -285,7 +295,7 @@ class RuleBuilder {
 							frappe.msgprint({
 								title: __("Success"),
 								message:
-									r.message?.message || __("Rule test completed successfully"),
+									r.message?.message || __("Rule debug completed successfully"),
 								indicator: "green",
 							});
 						} else {
@@ -296,7 +306,7 @@ class RuleBuilder {
 									r.message?.message ||
 									r.message?.error ||
 									(r.message?.execution?.errors || []).join("\n") ||
-									__("Test failed"),
+									__("Debug failed"),
 								indicator: "red",
 							});
 						}

--- a/flexirule/public/js/flexirule/rule_builder/rule_builder.js
+++ b/flexirule/public/js/flexirule/rule_builder/rule_builder.js
@@ -237,6 +237,8 @@ class RuleBuilder {
 	}
 
 	show_test_dialog() {
+		const last_docname = localStorage.getItem(`flexirule-debug-last-doc-${this.rule}`);
+
 		let d = new frappe.ui.Dialog({
 			title: __("Debug Rule"),
 			fields: [
@@ -263,6 +265,7 @@ class RuleBuilder {
 					fieldname: "docname",
 					label: __("Document"),
 					options: "doctype",
+					default: last_docname,
 					reqd: 1,
 				},
 				{
@@ -275,6 +278,10 @@ class RuleBuilder {
 			],
 			primary_action_label: __("Debug"),
 			primary_action: (values) => {
+				if (values.docname) {
+					localStorage.setItem(`flexirule-debug-last-doc-${this.rule}`, values.docname);
+				}
+
 				frappe.call({
 					method: "flexirule.ruleflow.api.test_rule",
 					args: {
@@ -292,23 +299,28 @@ class RuleBuilder {
 								r.message.path_trace || r.message.execution_path || [];
 							this.update_test_ui(pathTrace);
 
-							frappe.msgprint({
-								title: __("Success"),
-								message:
-									r.message?.message || __("Rule debug completed successfully"),
-								indicator: "green",
-							});
+							frappe.show_alert(
+								{
+									message:
+										r.message?.message ||
+										__("Rule debug completed successfully"),
+									indicator: "green",
+								},
+								5
+							);
 						} else {
 							this.update_test_ui(r.message?.path_trace || []);
-							frappe.msgprint({
-								title: __("Error"),
-								message:
-									r.message?.message ||
-									r.message?.error ||
-									(r.message?.execution?.errors || []).join("\n") ||
-									__("Debug failed"),
-								indicator: "red",
-							});
+							frappe.show_alert(
+								{
+									message:
+										r.message?.message ||
+										r.message?.error ||
+										(r.message?.execution?.errors || []).join("\n") ||
+										__("Debug failed"),
+									indicator: "red",
+								},
+								7
+							);
 						}
 						d.hide();
 					},

--- a/flexirule/public/js/flexirule/rule_builder/rule_builder.js
+++ b/flexirule/public/js/flexirule/rule_builder/rule_builder.js
@@ -271,11 +271,29 @@ class RuleBuilder {
 					reqd: 1,
 				},
 				{
+					fieldtype: "Section Break",
+					fieldname: "simulator",
+				},
+				{
 					fieldtype: "Link",
 					fieldname: "sim_user",
 					label: __("Simulate User"),
 					options: "User",
-					default: last_sim_user || frappe.session.user,
+					default: last_sim_user ?? frappe.session.user,
+					description: __("Execute the rule as if initiated by this user"),
+				},
+				{
+					fieldtype: "HTML",
+					fieldname: "current_context",
+					options: `
+					<div class="small text-muted">
+						<strong>${__("Current User")}:</strong> ${frappe.session.user}
+					</div>
+					`,
+				},
+				{
+					fieldtype: "Column Break",
+					fieldname: "column_role",
 				},
 				{
 					fieldtype: "Link",
@@ -283,6 +301,11 @@ class RuleBuilder {
 					label: __("Simulate Role"),
 					options: "Role",
 					default: last_sim_role,
+					description: __("Use only this role during execution"),
+				},
+				{
+					fieldtype: "Section Break",
+					fieldname: "debug_log",
 				},
 				{
 					fieldtype: "Check",

--- a/flexirule/public/js/flexirule/rule_builder/stores/useUIStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useUIStore.js
@@ -31,6 +31,10 @@ export const useUIStore = defineStore("rule-builder-ui", () => {
 	const test_selected_step_index = ref(null);
 	const show_test_sidebar = ref(false);
 
+	// ── Multi-document Visualization ──
+	const test_multi_results = ref([]);
+	const test_current_multi_index = ref(0);
+
 	// ── Derived ──
 	const has_selection = computed(() => selected_id.value !== null);
 	const has_test_path = computed(
@@ -130,6 +134,22 @@ export const useUIStore = defineStore("rule-builder-ui", () => {
 		test_execution_steps.value = [];
 		test_selected_step_index.value = null;
 		show_test_sidebar.value = false;
+		test_multi_results.value = [];
+		test_current_multi_index.value = 0;
+	}
+
+	function add_test_progress_result(payload) {
+		test_multi_results.value.push(payload);
+		if (test_multi_results.value.length === 1) {
+			set_active_multi_result(0);
+		}
+	}
+
+	function set_active_multi_result(index) {
+		if (index >= 0 && index < test_multi_results.value.length) {
+			test_current_multi_index.value = index;
+			set_test_execution_visuals(test_multi_results.value[index]);
+		}
 	}
 
 	/**
@@ -163,6 +183,8 @@ export const useUIStore = defineStore("rule-builder-ui", () => {
 		test_selected_step_index,
 		show_test_sidebar,
 		local_clipboard,
+		test_multi_results,
+		test_current_multi_index,
 
 		// Computed
 		has_selection,
@@ -177,5 +199,7 @@ export const useUIStore = defineStore("rule-builder-ui", () => {
 		set_test_execution_visuals,
 		clear_test_result,
 		navigate_node,
+		add_test_progress_result,
+		set_active_multi_result,
 	};
 });

--- a/flexirule/ruleflow/api.py
+++ b/flexirule/ruleflow/api.py
@@ -240,6 +240,7 @@ def test_rule(
 	rule_name: str,
 	doctype: str | None = None,
 	docname: str | None = None,
+	docnames: list | str | None = None,
 	document_json: str | None = None,
 	dry_run: int | bool | str = True,
 	skip_log_enqueue: int | bool | str = True,
@@ -247,27 +248,84 @@ def test_rule(
 	sim_user: str | None = None,
 	sim_role: str | None = None,
 ):
-	"""
-	Test a rule against a document.
-	Supports either an existing document (by docname) or a transient document (by document_json).
-	"""
 	_require_api_access()
 
 	rule = frappe.get_doc("Rule", rule_name)
 
+	# Multi-document mode
+	if docnames:
+		parsed_docnames = frappe.parse_json(docnames)
+		if not isinstance(parsed_docnames, list):
+			parsed_docnames = [parsed_docnames]
+
+		results = []
+
+		for name in parsed_docnames:
+			doc = frappe.get_doc(doctype, name)
+
+			res = _test_rule_for_doc(
+				rule=rule,
+				doc=doc,
+				dry_run=dry_run,
+				skip_log_enqueue=skip_log_enqueue,
+				save_log=save_log,
+				sim_user=sim_user,
+				sim_role=sim_role,
+			)
+
+			frappe.publish_realtime(
+				event="flexirule_debug_progress",
+				message={"rule": rule_name, "docname": name, "result": res},
+				user=frappe.session.user,
+			)
+
+			results.append(res)
+
+		success_count = sum(1 for r in results if r.get("success"))
+
+		return {
+			"success": success_count > 0,
+			"multi": True,
+			"total": len(results),
+			"success_count": success_count,
+			"failure_count": len(results) - success_count,
+			"results": results,
+		}
+
+	# Existing single-document behavior
 	if docname:
 		doc = frappe.get_doc(doctype, docname)
+
 	elif document_json:
 		doc_data = json.loads(document_json)
 		doc = frappe.get_doc(doc_data)
-		# Transient docs might need to be 'local'
 		doc.flags.ignore_permissions = True
-	else:
-		frappe.throw(_("Either docname or document_json must be provided"))
 
+	else:
+		frappe.throw(_("Either docname, docnames or document_json must be provided"))
+
+	return _test_rule_for_doc(
+		rule=rule,
+		doc=doc,
+		dry_run=dry_run,
+		skip_log_enqueue=skip_log_enqueue,
+		save_log=save_log,
+		sim_user=sim_user,
+		sim_role=sim_role,
+	)
+
+
+def _test_rule_for_doc(
+	rule,
+	doc,
+	dry_run,
+	skip_log_enqueue,
+	save_log,
+	sim_user,
+	sim_role,
+):
 	from flexirule.ruleflow.core.coordinator import RuleCoordinator
 
-	# Manual tests are a pre-activation validation stage and must also work for drafts/inactive rules.
 	is_eligible, reason = RuleCoordinator.check_eligibility(
 		rule,
 		doc,
@@ -280,6 +338,7 @@ def test_rule(
 	if not is_eligible:
 		return {
 			"success": False,
+			"docname": doc.name,
 			"status": _("Skipped"),
 			"message": _("Rule Skipped: {0}").format(reason),
 			"execution": {
@@ -301,6 +360,7 @@ def test_rule(
 
 		dry = bool(frappe.parse_json(dry_run))
 		skip_enqueue = bool(frappe.parse_json(skip_log_enqueue))
+
 		if save_log is not None and bool(frappe.parse_json(save_log)):
 			dry = False
 			skip_enqueue = False
@@ -314,8 +374,15 @@ def test_rule(
 			"sim_user": sim_user,
 			"sim_role": sim_role,
 		}
-		RuleCoordinator.execute_rule(rule, context=execution_context, dry_run=dry)
+
+		RuleCoordinator.execute_rule(
+			rule,
+			context=execution_context,
+			dry_run=dry,
+		)
+
 		execution = getattr(frappe.local, "execution_payload", None) or {}
+
 		if not execution:
 			engine = RuleEngine(rule, execution_context=execution_context)
 			engine.execute(doc, event_name="Manual Test")
@@ -330,48 +397,44 @@ def test_rule(
 				"log_enqueued": False,
 			}
 
-		# Include info about skipped trigger filters for transparency
 		info_msg = _("Rule '{0}' executed successfully").format(rule.rule_name)
+
 		if rule.compiled_expression:
 			info_msg += " " + _("(trigger filters were bypassed for manual test)")
 
+		return {
+			"success": True,
+			"docname": doc.name,
+			"status": _(execution.get("status", "Success")),
+			"execution": execution,
+			"execution_id": execution.get("execution_id"),
+			"path_trace": execution.get("path_trace", []),
+			"vars": execution.get("vars", {}),
+			"execution_path": execution.get("path_trace", []),
+			"context_snapshot": execution.get("vars", {}),
+			"message": info_msg,
+		}
+
 	except Exception as e:
-		# The engine's ``finally`` block always writes the full execution
-		# payload (including path_trace) to ``frappe.local.execution_payload``
-		# even when the rule raises.  Prefer that over the local ``engine``
-		# variable which only exists if we fell through to the manual
-		# engine.execute() path.
 		fallback_execution = (
 			getattr(locals().get("engine"), "last_execution_payload", None)
 			or getattr(frappe.local, "execution_payload", None)
 			or {}
 		)
+
 		return _build_error_response(
 			e,
 			context="test_rule",
 			extra={
+				"docname": doc.name,
 				"status": _("Failed"),
 				"execution": fallback_execution,
 				"path_trace": fallback_execution.get("path_trace", []),
 				"vars": fallback_execution.get("vars", {}),
-				# Legacy compatibility for existing UI consumers
 				"execution_path": fallback_execution.get("path_trace", []),
 				"context_snapshot": fallback_execution.get("vars", {}),
 			},
 		)
-
-	return {
-		"success": True,
-		"status": _(execution.get("status", "Success")),
-		"execution": execution,
-		"execution_id": execution.get("execution_id"),
-		"path_trace": execution.get("path_trace", []),
-		"vars": execution.get("vars", {}),
-		# Legacy compatibility for existing UI consumers
-		"execution_path": execution.get("path_trace", []),
-		"context_snapshot": execution.get("vars", {}),
-		"message": info_msg,
-	}
 
 
 @frappe.whitelist()

--- a/flexirule/ruleflow/api.py
+++ b/flexirule/ruleflow/api.py
@@ -244,6 +244,8 @@ def test_rule(
 	dry_run: int | bool | str = True,
 	skip_log_enqueue: int | bool | str = True,
 	save_log: int | bool | str | None = None,
+	sim_user: str | None = None,
+	sim_role: str | None = None,
 ):
 	"""
 	Test a rule against a document.
@@ -267,7 +269,12 @@ def test_rule(
 
 	# Manual tests are a pre-activation validation stage and must also work for drafts/inactive rules.
 	is_eligible, reason = RuleCoordinator.check_eligibility(
-		rule, doc, event_name="Manual Test", skip_event_check=True, allow_inactive=True
+		rule,
+		doc,
+		event_name="Manual Test",
+		skip_event_check=True,
+		allow_inactive=True,
+		context={"sim_user": sim_user, "sim_role": sim_role},
 	)
 
 	if not is_eligible:
@@ -304,6 +311,8 @@ def test_rule(
 			"allow_inactive_rule_test": True,
 			"dry_run": dry,
 			"skip_log_enqueue": skip_enqueue,
+			"sim_user": sim_user,
+			"sim_role": sim_role,
 		}
 		RuleCoordinator.execute_rule(rule, context=execution_context, dry_run=dry)
 		execution = getattr(frappe.local, "execution_payload", None) or {}

--- a/flexirule/ruleflow/core/coordinator.py
+++ b/flexirule/ruleflow/core/coordinator.py
@@ -498,6 +498,7 @@ class RuleCoordinator:
 		skip_event_check=False,
 		allow_inactive=False,
 		old_doc=None,
+		context=None,
 	) -> tuple[bool, str]:
 		"""
 		Strict V1 Contract Eligibility Check
@@ -534,6 +535,14 @@ class RuleCoordinator:
 				# Use SafeFrappeAPI to prevent write operations in trigger conditions
 				from flexirule.ruleflow.core.engine import SafeFrappeAPI
 
+				sim_user = (context or {}).get("sim_user")
+				sim_role = (context or {}).get("sim_role")
+
+				if sim_user or sim_role:
+					safe_frappe = SafeFrappeAPI(user=sim_user, roles=[sim_role] if sim_role else None)
+				else:
+					safe_frappe = SafeFrappeAPI()
+
 				rule_meta = {
 					"name": rule_doc.name,
 					"trigger_type": rule_doc.trigger_type,
@@ -562,7 +571,7 @@ class RuleCoordinator:
 					"doc": doc,
 					"old_doc": old_doc,
 					"vars": {},
-					"frappe": SafeFrappeAPI(),
+					"frappe": safe_frappe,
 					"caller": frappe._dict({}),
 					"rule": frappe._dict(rule_meta),
 					"doctype": doctype_name,

--- a/flexirule/ruleflow/core/engine.py
+++ b/flexirule/ruleflow/core/engine.py
@@ -135,20 +135,25 @@ class SafeFrappeAPI:
 	Exposes only safe, read-only operations to prevent security issues.
 	"""
 
-	def __init__(self):
+	def __init__(self, user=None, roles=None):
 		# Safe utilities
 		self.utils = frappe.utils
 		self._dict = frappe._dict
+		self._user = user
+		self._roles = roles
 
 	@property
 	def session(self):
 		"""Read-only access to frappe.session (current user, roles, etc.)"""
+		if self._user:
+			return frappe._dict({"user": self._user, "data": frappe._dict({"user": self._user})})
 		return frappe.session
 
-	@staticmethod
-	def get_roles(user=None):
+	def get_roles(self, user=None):
 		"""Read-only: return roles for the given user (or current session user)."""
-		return frappe.get_roles(user)
+		if not user and self._roles:
+			return self._roles
+		return frappe.get_roles(user or self._user)
 
 	# Safe read operations
 	@staticmethod
@@ -317,7 +322,14 @@ class RuleEngine:
 			# Check role-based skipping
 			skip_for_roles_docs = self.rule.get("skip_for_roles")
 			if skip_for_roles_docs:
-				user_roles = frappe.get_roles()
+				sim_user = self.context.get("sim_user")
+				sim_role = self.context.get("sim_role")
+
+				if sim_role:
+					user_roles = [sim_role]
+				else:
+					user_roles = frappe.get_roles(sim_user)
+
 				skip_roles = [row.get("role") for row in skip_for_roles_docs]
 				if any(role in user_roles for role in skip_roles):
 					self._log(
@@ -416,7 +428,14 @@ class RuleEngine:
 		# Check Rule Permission table if defined
 		rule_permissions = self.rule.get("permissions")
 		if rule_permissions:
-			user_roles = set(frappe.get_roles())
+			sim_user = self.context.get("sim_user")
+			sim_role = self.context.get("sim_role")
+
+			if sim_role:
+				user_roles = {sim_role}
+			else:
+				user_roles = set(frappe.get_roles(sim_user))
+
 			# System Manager always bypasses
 			if "System Manager" not in user_roles:
 				can_exec = any(p.can_execute and p.role in user_roles for p in rule_permissions)
@@ -437,7 +456,7 @@ class RuleEngine:
 			"rule": self.rule.name,
 			"rule_version": self.rule.version,
 			"engine_version": "1.0",
-			"user": frappe.session.user,
+			"user": self.context.get("sim_user") or frappe.session.user,
 			"timestamp": frappe.utils.now(),
 			"test_mode": self.context.get("test_mode", False),
 			"execution_id": self.execution_id,
@@ -460,6 +479,11 @@ class RuleEngine:
 
 	def _get_safe_frappe_api(self):
 		"""Return a restricted frappe API object for condition evaluation"""
+		sim_user = self.context.get("sim_user")
+		sim_role = self.context.get("sim_role")
+
+		if sim_user or sim_role:
+			return SafeFrappeAPI(user=sim_user, roles=[sim_role] if sim_role else None)
 		return _safe_frappe
 
 	def _execute_graph(self, context):

--- a/flexirule/ruleflow/doctype/rule/rule.js
+++ b/flexirule/ruleflow/doctype/rule/rule.js
@@ -399,7 +399,8 @@ function test_rule(frm) {
 					if (r.message?.success) {
 						frappe.show_alert(
 							{
-								message: r.message?.message || __("Rule debug completed successfully"),
+								message:
+									r.message?.message || __("Rule debug completed successfully"),
 								indicator: "green",
 							},
 							5

--- a/flexirule/ruleflow/doctype/rule/rule.js
+++ b/flexirule/ruleflow/doctype/rule/rule.js
@@ -89,7 +89,7 @@ frappe.ui.form.on("Rule", {
 
 		frm.page.clear_custom_actions();
 		frm.add_custom_button(__("Amend Rule"), () => amend_rule(frm), __("Actions"));
-		frm.add_custom_button(__("Test Rule"), () => test_rule(frm), __("Actions"));
+		frm.add_custom_button(__("Debug Rule"), () => test_rule(frm), __("Actions"));
 		frm.add_custom_button(__("Clear Cache"), () => clear_rule_cache(frm), __("Actions"));
 
 		apply_trigger_type_contract(frm);
@@ -321,9 +321,23 @@ function update_dashboard_indicators(frm) {
 	});
 }
 function test_rule(frm) {
+	const last_docname = localStorage.getItem(`flexirule-debug-last-doc-${frm.doc.name}`);
+	const last_sim_user = localStorage.getItem(`flexirule_debug_user_${frm.doc.name}`);
+	const last_sim_role = localStorage.getItem(`flexirule_debug_role_${frm.doc.name}`);
+
 	let d = new frappe.ui.Dialog({
-		title: __("Test Rule"),
+		title: __("Debug Rule"),
 		fields: [
+			{
+				fieldtype: "HTML",
+				options: `
+					<div class="alert alert-info small" style="margin-bottom: 15px;">
+						${__(
+							"Debug a rule against an existing record to inspect execution flow, conditions, variables, and action results. This is a simulation and does not modify data."
+						)}
+					</div>
+				`,
+			},
 			{
 				fieldtype: "Link",
 				fieldname: "doctype",
@@ -337,42 +351,67 @@ function test_rule(frm) {
 				fieldname: "docname",
 				label: __("Document"),
 				options: "doctype",
+				default: last_docname,
 				reqd: 1,
+			},
+			{
+				fieldtype: "Link",
+				fieldname: "sim_user",
+				label: __("Simulate User"),
+				options: "User",
+				default: last_sim_user || frappe.session.user,
+			},
+			{
+				fieldtype: "Link",
+				fieldname: "sim_role",
+				label: __("Simulate Role"),
+				options: "Role",
+				default: last_sim_role,
 			},
 			{
 				fieldtype: "Check",
 				fieldname: "save_log",
 				label: __("Create Execution Log"),
-				description: __("Persist a log record even for this test run"),
+				description: __("Persist a log record even for this debug run"),
 				default: 1,
 			},
 		],
-		primary_action_label: __("Test"),
+		primary_action_label: __("Debug"),
 		primary_action: (values) => {
+			if (values.docname) {
+				localStorage.setItem(`flexirule-debug-last-doc-${frm.doc.name}`, values.docname);
+			}
+			localStorage.setItem(`flexirule_debug_user_${frm.doc.name}`, values.sim_user || "");
+			localStorage.setItem(`flexirule_debug_role_${frm.doc.name}`, values.sim_role || "");
+
 			frappe.call({
 				method: "flexirule.ruleflow.api.test_rule",
 				args: {
 					rule_name: frm.doc.name,
 					doctype: values.doctype,
 					docname: values.docname,
+					sim_user: values.sim_user,
+					sim_role: values.sim_role,
 					dry_run: !values.save_log,
 					skip_log_enqueue: !values.save_log,
 				},
 				callback: (r) => {
 					if (r.message?.success) {
-						// Highlight path in builder
-
-						frappe.msgprint({
-							title: __("Success"),
-							message: r.message?.message || __("Rule test completed successfully"),
-							indicator: "green",
-						});
+						frappe.show_alert(
+							{
+								message: r.message?.message || __("Rule debug completed successfully"),
+								indicator: "green",
+							},
+							5
+						);
 					} else {
-						frappe.msgprint({
-							title: __("Error"),
-							message: r.message?.error || __("Test failed"),
-							indicator: "red",
-						});
+						frappe.show_alert(
+							{
+								message: r.message?.error || __("Debug failed"),
+								indicator: "red",
+							},
+							7
+						);
 					}
 					d.hide();
 				},

--- a/flexirule/ruleflow/tests/test_api.py
+++ b/flexirule/ruleflow/tests/test_api.py
@@ -89,6 +89,45 @@ class TestFlexiRuleAPI(unittest.TestCase):
 
 		self.assertIn("success", result)
 
+	def test_test_rule_multi_doc(self):
+		"""Test rule testing API with multiple documents and realtime publishing"""
+		from flexirule.ruleflow.api import test_rule
+
+		todo1 = frappe.get_doc({"doctype": "ToDo", "description": "Multi Test 1"}).insert(
+			ignore_permissions=True
+		)
+		todo2 = frappe.get_doc({"doctype": "ToDo", "description": "Multi Test 2"}).insert(
+			ignore_permissions=True
+		)
+
+		docnames_json = json.dumps([todo1.name, todo2.name])
+
+		# Mock publish_realtime to verify it is called
+		original_publish = frappe.publish_realtime
+		published_events = []
+
+		def mock_publish_realtime(event, message, **kwargs):
+			published_events.append((event, message))
+
+		frappe.publish_realtime = mock_publish_realtime
+
+		try:
+			result = test_rule(self.rule.name, "ToDo", docnames=docnames_json)
+
+			self.assertTrue(result.get("multi"))
+			self.assertEqual(result.get("total"), 2)
+			self.assertEqual(result.get("success_count"), 2)
+			self.assertEqual(len(result.get("results", [])), 2)
+			self.assertTrue(result["results"][0].get("success"))
+
+			# Verify realtime events were published per document
+			self.assertEqual(len(published_events), 2)
+			self.assertEqual(published_events[0][0], "flexirule_debug_progress")
+			self.assertEqual(published_events[0][1].get("docname"), todo1.name)
+			self.assertEqual(published_events[1][1].get("docname"), todo2.name)
+		finally:
+			frappe.publish_realtime = original_publish
+
 	def test_test_rule_allows_inactive_draft_pre_activation(self):
 		"""Rule testing should work before activation."""
 		from flexirule.ruleflow.api import test_rule


### PR DESCRIPTION
Refactored the FlexiRule Rule Builder UI to transition from "Test" to "Debug" terminology, ensuring users understand that rule execution within the builder is a safe, non-destructive simulation. The update includes renaming buttons, quick actions, icons, and adding a descriptive informational banner to the debug dialog.
Renamed 'show_test_dialog' to 'show_debug_dialog' for terminology consistency.
- Added 'Simulate User' and 'Simulate Role' fields to Debug Dialog.
- Implemented rule-specific localStorage caching for simulation parameters.
- Updated 'test_rule' API and backend engine to support context mocking via 'SafeFrappeAPI'.
- Synchronized UI enhancements (HTML alerts, non-blocking toasts) across Visual Builder and DocType form.
- Applied Prettier formatting fixes.
When you select Simulated User or Simulated Role, FlexiRule temporarily replaces frappe.session.user and frappe.get_roles() with those values, so the rule behaves almost exactly as if that user executed it, including trigger conditions, permission checks, and role-based skipping. The main limitation is that some document-level read permissions may not be enforced in every code path.
