### PR TITLE
Implement Fetch Resolver configuration popover

### DIFF
--- a/flexirule/public/js/flexirule/core/builder_utils.js
+++ b/flexirule/public/js/flexirule/core/builder_utils.js
@@ -112,7 +112,8 @@ export function compileToCode(item, fallbackField = "") {
 
 	if (item.kind === "fetch") {
 		const dt = item.linked_doctype || "";
-		const dtExpr = dt.startsWith("doc.") ? dt : `"${dt}"`;
+		const knownScopes = ["doc.", "vars.", "ctx.", "loop.", "row.", "item.", "caller.", "rule."];
+		const dtExpr = knownScopes.some((s) => String(dt).startsWith(s)) ? dt : `"${dt}"`;
 		const link = item.link_field ? toDocExpression(item.link_field) : "";
 		const field = item.fetch_field || "";
 		return `{frappe.db.get_value(${dtExpr}, ${link}, "${field}")}`;

--- a/flexirule/public/js/flexirule/core/builder_utils.js
+++ b/flexirule/public/js/flexirule/core/builder_utils.js
@@ -112,9 +112,10 @@ export function compileToCode(item, fallbackField = "") {
 
 	if (item.kind === "fetch") {
 		const dt = item.linked_doctype || "";
+		const dtExpr = dt.startsWith("doc.") ? dt : `"${dt}"`;
 		const link = item.link_field ? toDocExpression(item.link_field) : "";
 		const field = item.fetch_field || "";
-		return `{frappe.db.get_value("${dt}", ${link}, "${field}")}`;
+		return `{frappe.db.get_value(${dtExpr}, ${link}, "${field}")}`;
 	}
 
 	if (item.kind === "system_context") {

--- a/flexirule/public/js/flexirule/core/builder_utils.js
+++ b/flexirule/public/js/flexirule/core/builder_utils.js
@@ -110,6 +110,13 @@ export function compileToCode(item, fallbackField = "") {
 		if (item.fmt_op === "format") return `{("${cfg}").format(${f})}`;
 	}
 
+	if (item.kind === "fetch") {
+		const dt = item.linked_doctype || "";
+		const link = item.link_field ? toDocExpression(item.link_field) : "";
+		const field = item.fetch_field || "";
+		return `{frappe.db.get_value("${dt}", ${link}, "${field}")}`;
+	}
+
 	if (item.kind === "system_context") {
 		if (item.sys_token === "role_check") {
 			return `{"${item.sys_role}" in frappe.get_roles(frappe.session.user)}`;
@@ -190,6 +197,13 @@ export function compileToLabel(item) {
 
 	if (item.kind === "format") {
 		return `${__(item.fmt_op)}(${item.fmt_field || "?"})`;
+	}
+
+	if (item.kind === "fetch") {
+		const dt = item.linked_doctype || __("Linked Doc");
+		const field = item.fetch_field || "?";
+		const link = item.link_field || "?";
+		return `${dt}.${field}\n← ${link}`;
 	}
 
 	if (item.kind === "system_context") {

--- a/flexirule/public/js/flexirule/core/formula_registry.js
+++ b/flexirule/public/js/flexirule/core/formula_registry.js
@@ -134,6 +134,13 @@ export const SLASH_COMMANDS = [
 		groups: [FORMULA_GROUPS.SELECT],
 	},
 	{
+		id: "fetch",
+		label: __("Fetch From Link"),
+		type: "logic",
+		icon: "🔗",
+		groups: [FORMULA_GROUPS.LINK, FORMULA_GROUPS.GENERAL],
+	},
+	{
 		id: "boolean",
 		label: __("Toggle"),
 		type: "logic",
@@ -185,7 +192,6 @@ export const FORMULA_REGISTRY = {
 		{ id: "not", label: "not", description: "Negate boolean" },
 	],
 	[FORMULA_GROUPS.LINK]: [
-		{ id: "fetch", label: "fetch", description: "Fetch field from linked document" },
 		{ id: "lookup", label: "lookup", description: "Look up record by filters" },
 	],
 	[FORMULA_GROUPS.TABLE]: [

--- a/flexirule/public/js/flexirule/core/formula_registry.js
+++ b/flexirule/public/js/flexirule/core/formula_registry.js
@@ -220,23 +220,30 @@ export function getFormulasForFieldtype(ft) {
 export function getAllowedBuilderKinds(fieldtype) {
 	if (!fieldtype) return null;
 	if (["Date", "Datetime", "Time"].includes(fieldtype)) {
-		return ["date_formula", "date_diff", "format", "system_context"];
+		return ["date_formula", "date_diff", "fetch", "format", "system_context"];
 	}
 	if (["Int", "Float", "Currency", "Percent", "Duration"].includes(fieldtype)) {
-		return ["math_formula", "child_aggregation", "date_diff", "format", "system_context"];
+		return [
+			"math_formula",
+			"child_aggregation",
+			"date_diff",
+			"fetch",
+			"format",
+			"system_context",
+		];
 	}
 	if (
 		["Data", "Small Text", "Text", "Long Text", "Text Editor", "Code", "Select"].includes(
 			fieldtype
 		)
 	) {
-		return ["normalization", "format", "string_formula", "system_context"];
+		return ["normalization", "format", "fetch", "string_formula", "system_context"];
 	}
 	if (["Check"].includes(fieldtype)) {
-		return ["system_context"];
+		return ["fetch", "system_context"];
 	}
 	if (["Link", "Dynamic Link"].includes(fieldtype)) {
-		return ["string_formula", "format", "system_context"];
+		return ["fetch", "string_formula", "format", "system_context"];
 	}
 	return null;
 }

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
@@ -110,6 +110,7 @@
 									df:
 										targetOptions.find((o) => o.value === assignment.target) ||
 										{},
+									target: assignment.target,
 									operator: assignment.operator,
 									referenceDoctype: getTargetDoctype(assignment.target),
 								}"

--- a/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
@@ -185,7 +185,7 @@
 								<ValueResolverControl
 									viewMode="inline"
 									:modelValue="tokenDraftAttrs.config"
-									:doctype="referenceDoctype"
+									:doctype="triggerDoctype"
 									:context="resolverContext"
 									:variableOptions="availableVariableOptions"
 									:allowedKinds="allowedBuilderKinds"
@@ -392,6 +392,11 @@ const referenceDoctype = computed(() => {
 	}
 	return props.context?.referenceDoctype || fieldOptions.value || "";
 });
+
+const triggerDoctype = computed(() => {
+	return props.doctype || props.engine?.rule_doc?.document_type || "";
+});
+
 const resolverContext = computed(() => {
 	const df = props.context?.df || {};
 	const fieldname = props.context?.fieldname || df.fieldname || df.value || "";
@@ -401,6 +406,7 @@ const resolverContext = computed(() => {
 		fieldname,
 		target: props.context?.target || fieldname,
 		referenceDoctype: referenceDoctype.value,
+		triggerDoctype: triggerDoctype.value,
 	};
 });
 

--- a/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
@@ -187,6 +187,7 @@
 									:modelValue="tokenDraftAttrs.config"
 									:doctype="referenceDoctype"
 									:context="resolverContext"
+									:variableOptions="availableVariableOptions"
 									:allowedKinds="allowedBuilderKinds"
 									@update:modelValue="handleBuilderUpdate"
 								/>

--- a/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
@@ -812,6 +812,7 @@ const editor = new Editor({
 							normalize: "normalization",
 							formatter: "format",
 							resolver: "string_formula",
+							fetch: "fetch",
 						};
 						const allowedKinds = Array.isArray(allowedBuilderKinds.value)
 							? allowedBuilderKinds.value
@@ -1110,6 +1111,7 @@ const activeTokenPresentation = computed(() => {
 		resolver: { title: __("Configure Resolver"), icon: "fa fa-bolt" },
 		normalize: { title: __("Configure Normalization"), icon: "fa fa-refresh" },
 		format: { title: __("Configure Format"), icon: "fa fa-paint-brush" },
+		fetch: { title: __("Fetch From Link"), icon: "fa fa-link" },
 		json: { title: __("JSON Editor"), icon: "fa fa-code" },
 	};
 	return map[activeTokenType.value] || { title: __("Token Configuration"), icon: "fa fa-cog" };
@@ -1129,8 +1131,10 @@ function openTokenEditor(node, pos, typeOverride = null) {
 
 	if (node.type.name === "resolverToken") {
 		const kind = node.attrs.config?.kind;
-		if (["normalization", "format"].includes(kind)) {
-			activeTokenType.value = kind === "normalization" ? "normalize" : "format";
+		if (["normalization", "format", "fetch"].includes(kind)) {
+			if (kind === "normalization") activeTokenType.value = "normalize";
+			else if (kind === "format") activeTokenType.value = "format";
+			else activeTokenType.value = "fetch";
 		} else if (kind?.includes("formula") || kind?.includes("aggregation")) {
 			activeTokenType.value = "formula";
 		} else {

--- a/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
@@ -721,7 +721,10 @@ const resolverFieldname = computed(() => {
 		props.context?.df?.fieldname ||
 		props.context?.df?.value ||
 		"value_resolver";
-	return String(fieldname).replace(/^doc\./, "");
+	// Strip both doc. and vars. prefixes
+	return String(fieldname)
+		.replace(/^doc\./, "")
+		.replace(/^vars\./, "");
 });
 
 // ─── Category Definitions ───
@@ -753,7 +756,9 @@ function getDefaultState(kind = "date_formula") {
 
 	const fieldname = props.context?.fieldname || props.context?.target;
 	if (fieldname) {
-		const raw = fieldname.startsWith("doc.") ? fieldname.slice(4) : fieldname;
+		const raw = String(fieldname)
+			.replace(/^doc\./, "")
+			.replace(/^vars\./, "");
 		if (kind === "date_formula") {
 			baseType = "doc_field";
 			baseField = raw;
@@ -817,7 +822,7 @@ const localState = ref(getDefaultState());
 
 // ─── Field Options ───
 const dateFieldOptions = computed(() => {
-	const dt = props.doctype || store.rule_doc?.document_type;
+	const dt = store.rule_doc?.document_type || props.doctype;
 	if (!dt) return [];
 	const fields = store.doc_meta[dt];
 	if (!fields || !Array.isArray(fields)) return [];
@@ -835,7 +840,7 @@ const dateFieldOptions = computed(() => {
 });
 
 const numericFieldOptions = computed(() => {
-	const dt = props.doctype || store.rule_doc?.document_type;
+	const dt = store.rule_doc?.document_type || props.doctype;
 	if (!dt) return [];
 	const fields = store.doc_meta[dt];
 	if (!fields || !Array.isArray(fields)) return [];
@@ -853,7 +858,7 @@ const numericFieldOptions = computed(() => {
 });
 
 const stringFieldOptions = computed(() => {
-	const dt = props.doctype || store.rule_doc?.document_type;
+	const dt = store.rule_doc?.document_type || props.doctype;
 	if (!dt) return [];
 	const fields = store.doc_meta[dt];
 	if (!fields || !Array.isArray(fields)) return [];
@@ -871,7 +876,7 @@ const stringFieldOptions = computed(() => {
 });
 
 const tableFieldOptions = computed(() => {
-	const dt = props.doctype || store.rule_doc?.document_type;
+	const dt = store.rule_doc?.document_type || props.doctype;
 	if (!dt) return [];
 	const fields = store.doc_meta[dt];
 	if (!fields || !Array.isArray(fields)) return [];
@@ -918,7 +923,7 @@ const sourceLinkOptions = computed(() => {
 });
 
 const prioritizedFieldOptions = computed(() => {
-	const dt = props.doctype || store.rule_doc?.document_type;
+	const dt = store.rule_doc?.document_type || props.doctype;
 	if (!dt) return [];
 	const fields = store.doc_meta[dt];
 	if (!fields || !Array.isArray(fields)) return [];

--- a/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
@@ -543,58 +543,55 @@
 					<template v-else-if="localState.kind === 'fetch'">
 						<div class="d-flex flex-column fxr-gap-1">
 							<label class="fxr-label-sm">{{ __("Source Link Field") }}</label>
-							<select
-								class="fxr-select"
-								v-model="localState.link_field"
-								:disabled="readOnly"
-							>
-								<option value="">{{ __("Select link field...") }}</option>
-								<option
-									v-for="opt in linkFieldOptions"
-									:key="opt.value"
-									:value="opt.value"
-								>
-									{{ opt.label }}
-								</option>
-							</select>
-						</div>
-						<div class="d-flex flex-column fxr-gap-1 mt-2">
-							<label class="fxr-label-sm">{{ __("Fetch Field") }}</label>
-							<div class="position-relative">
+							<div class="d-flex fxr-gap-2">
 								<select
-									class="fxr-select w-100"
-									v-model="localState.fetch_field"
-									:disabled="
-										readOnly || !localState.link_field || fetchMetaLoading
-									"
+									class="fxr-select flex-1"
+									v-model="localState.link_source_type"
+									:disabled="readOnly"
 								>
-									<option value="">
-										{{
-											fetchMetaLoading
-												? __("Loading...")
-												: __("Select field to fetch...")
-										}}
-									</option>
+									<option value="doc_field">{{ __("Document Field") }}</option>
+								</select>
+								<select
+									class="fxr-select flex-1"
+									v-model="localState.link_field"
+									:disabled="readOnly"
+								>
+									<option value="">{{ __("Select link field...") }}</option>
 									<option
-										v-for="opt in fetchFieldOptions"
+										v-for="opt in linkFieldOptions"
 										:key="opt.value"
 										:value="opt.value"
 									>
 										{{ opt.label }}
 									</option>
 								</select>
-								<div
-									v-if="fetchMetaLoading"
-									class="position-absolute"
-									style="right: 25px; top: 50%; transform: translateY(-50%)"
-								>
-									<i class="fa fa-spinner fa-spin text-muted"></i>
-								</div>
 							</div>
+						</div>
+						<div class="d-flex flex-column fxr-gap-1 mt-2">
+							<label class="fxr-label-sm">{{ __("Fetch Field") }}</label>
+							<ComboBoxControl
+								v-model="localState.fetch_field"
+								:options="fetchFieldOptions"
+								:read_only="readOnly || !localState.link_field"
+								:loading="fetchMetaLoading"
+								:placeholder="
+									fetchMetaLoading
+										? __('Loading...')
+										: __('Select field to fetch...')
+								"
+								:allow-custom-value="true"
+								hide-label
+							/>
 						</div>
 						<div class="mt-1" v-if="localState.linked_doctype">
 							<span class="fxr-text-xs text-muted">
-								{{ __("Fetching from {0}", [localState.linked_doctype]) }}
+								{{
+									localState.linked_doctype.startsWith("doc.")
+										? __("Fetching from {0} (Dynamic)", [
+												localState.linked_doctype,
+										  ])
+										: __("Fetching from {0}", [localState.linked_doctype])
+								}}
 							</span>
 						</div>
 					</template>
@@ -640,6 +637,7 @@
 <script setup>
 import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from "vue";
 import { useStore } from "../stores";
+import ComboBoxControl from "./ComboBoxControl.vue";
 import { compileToCode, compileToLabel } from "../../core/builder_utils.js";
 import { useFloatingDropdown } from "../composables/useFloatingDropdown";
 
@@ -748,6 +746,7 @@ function getDefaultState(kind = "date_formula") {
 	return {
 		kind,
 		// Fetch Resolver fields
+		link_source_type: "doc_field",
 		link_field: "",
 		fetch_field: "",
 		linked_doctype: "",
@@ -890,11 +889,12 @@ const linkFieldOptions = computed(() => {
 	const fields = store.doc_meta[dt];
 	if (!fields || !Array.isArray(fields)) return [];
 	return fields
-		.filter((f) => f.fieldtype === "Link")
+		.filter((f) => ["Link", "Dynamic Link"].includes(f.fieldtype))
 		.map((f) => ({
 			label: `${f.label || f.fieldname} (${f.fieldname})`,
 			value: f.fieldname,
 			options: f.options,
+			fieldtype: f.fieldtype,
 		}));
 });
 
@@ -916,16 +916,45 @@ watch(
 			return;
 		}
 		const opt = linkFieldOptions.value.find((o) => o.value === newVal);
-		if (opt && opt.options) {
-			localState.value.linked_doctype = opt.options;
+		if (opt && (opt.options || opt.fieldtype === "Dynamic Link")) {
+			// For Dynamic Link, options is usually the fieldname that holds the doctype
+			let linkedDt = opt.options;
+			if (opt.fieldtype === "Dynamic Link") {
+				linkedDt = `doc.${opt.options}`;
+			}
+
+			localState.value.linked_doctype = linkedDt;
+
 			if (newVal !== oldVal) {
 				localState.value.fetch_field = "";
 			}
-			fetchMetaLoading.value = true;
-			try {
-				await store.fetch_metadata(opt.options);
-			} finally {
-				fetchMetaLoading.value = false;
+
+			// Try to auto-default even for Dynamic Link or before metadata is loaded
+			if (!localState.value.fetch_field && resolverFieldname.value) {
+				localState.value.fetch_field = resolverFieldname.value;
+			}
+
+			if (opt.fieldtype === "Link" && linkedDt) {
+				fetchMetaLoading.value = true;
+				try {
+					await store.fetch_metadata(linkedDt);
+
+					// If we auto-defaulted, but it turns out the field doesn't exist, clear it
+					// unless it was manually changed (though that's hard to track here)
+					if (
+						localState.value.fetch_field === resolverFieldname.value &&
+						fetchFieldOptions.value.length > 0
+					) {
+						const match = fetchFieldOptions.value.find(
+							(f) => f.value === resolverFieldname.value
+						);
+						if (!match) {
+							localState.value.fetch_field = "";
+						}
+					}
+				} finally {
+					fetchMetaLoading.value = false;
+				}
 			}
 		} else {
 			localState.value.linked_doctype = "";
@@ -999,6 +1028,7 @@ const syncFromProps = () => {
 		next.fmt_field = val.fmt_field || "";
 		next.fmt_config = val.fmt_config || "";
 	} else if (kind === "fetch") {
+		next.link_source_type = val.link_source_type || "doc_field";
 		next.link_field = val.link_field || "";
 		next.fetch_field = val.fetch_field || "";
 		next.linked_doctype = val.linked_doctype || "";
@@ -1094,6 +1124,7 @@ watch(
 			});
 		} else if (newVal.kind === "fetch") {
 			Object.assign(config, {
+				link_source_type: newVal.link_source_type,
 				link_field: newVal.link_field,
 				fetch_field: newVal.fetch_field,
 				linked_doctype: newVal.linked_doctype,

--- a/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
@@ -548,23 +548,24 @@
 									class="fxr-select flex-1"
 									v-model="localState.link_source_type"
 									:disabled="readOnly"
+									@change="localState.link_field = ''"
 								>
 									<option value="doc_field">{{ __("Document Field") }}</option>
+									<option value="variable">{{ __("Workflow Variable") }}</option>
 								</select>
-								<select
-									class="fxr-select flex-1"
+								<ComboBoxControl
+									class="flex-1 min-w-0"
 									v-model="localState.link_field"
-									:disabled="readOnly"
-								>
-									<option value="">{{ __("Select link field...") }}</option>
-									<option
-										v-for="opt in linkFieldOptions"
-										:key="opt.value"
-										:value="opt.value"
-									>
-										{{ opt.label }}
-									</option>
-								</select>
+									:options="sourceLinkOptions"
+									:read_only="readOnly"
+									:placeholder="
+										localState.link_source_type === 'variable'
+											? __('Search variable...')
+											: __('Select link field...')
+									"
+									:allow-custom-value="localState.link_source_type === 'variable'"
+									hide-label
+								/>
 							</div>
 						</div>
 						<div class="d-flex flex-column fxr-gap-1 mt-2">
@@ -653,6 +654,10 @@ const props = defineProps({
 	context: {
 		type: Object,
 		default: () => ({}),
+	},
+	variableOptions: {
+		type: Array,
+		default: () => [],
 	},
 	readOnly: {
 		type: Boolean,
@@ -883,6 +888,20 @@ const aggFieldOptions = computed(() => {
 		}));
 });
 
+const sourceLinkOptions = computed(() => {
+	if (localState.value.link_source_type === "variable") {
+		return (props.variableOptions || [])
+			.filter((v) => v.fieldtype === "Link" || v.fieldtype === "Dynamic Link")
+			.map((v) => ({
+				label: `${v.label || v.value} (vars.${v.value})`,
+				value: `vars.${v.value}`,
+				options: v.options,
+				fieldtype: v.fieldtype,
+			}));
+	}
+	return linkFieldOptions.value;
+});
+
 const linkFieldOptions = computed(() => {
 	const dt = props.doctype || store.rule_doc?.document_type;
 	if (!dt) return [];
@@ -915,7 +934,7 @@ watch(
 			localState.value.fetch_field = "";
 			return;
 		}
-		const opt = linkFieldOptions.value.find((o) => o.value === newVal);
+		const opt = sourceLinkOptions.value.find((o) => o.value === newVal);
 		if (opt && (opt.options || opt.fieldtype === "Dynamic Link")) {
 			// For Dynamic Link, options is usually the fieldname that holds the doctype
 			let linkedDt = opt.options;
@@ -934,7 +953,7 @@ watch(
 				localState.value.fetch_field = resolverFieldname.value;
 			}
 
-			if (opt.fieldtype === "Link" && linkedDt) {
+			if (linkedDt && !linkedDt.startsWith("doc.")) {
 				fetchMetaLoading.value = true;
 				try {
 					await store.fetch_metadata(linkedDt);

--- a/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
@@ -539,6 +539,64 @@
 						</div>
 					</template>
 
+					<!-- ═══════════ Fetch Resolver ═══════════ -->
+					<template v-else-if="localState.kind === 'fetch'">
+						<div class="d-flex flex-column fxr-gap-1">
+							<label class="fxr-label-sm">{{ __("Source Link Field") }}</label>
+							<select
+								class="fxr-select"
+								v-model="localState.link_field"
+								:disabled="readOnly"
+							>
+								<option value="">{{ __("Select link field...") }}</option>
+								<option
+									v-for="opt in linkFieldOptions"
+									:key="opt.value"
+									:value="opt.value"
+								>
+									{{ opt.label }}
+								</option>
+							</select>
+						</div>
+						<div class="d-flex flex-column fxr-gap-1 mt-2">
+							<label class="fxr-label-sm">{{ __("Fetch Field") }}</label>
+							<div class="position-relative">
+								<select
+									class="fxr-select w-100"
+									v-model="localState.fetch_field"
+									:disabled="readOnly || !localState.link_field || fetchMetaLoading"
+								>
+									<option value="">
+										{{
+											fetchMetaLoading
+												? __("Loading...")
+												: __("Select field to fetch...")
+										}}
+									</option>
+									<option
+										v-for="opt in fetchFieldOptions"
+										:key="opt.value"
+										:value="opt.value"
+									>
+										{{ opt.label }}
+									</option>
+								</select>
+								<div
+									v-if="fetchMetaLoading"
+									class="position-absolute"
+									style="right: 25px; top: 50%; transform: translateY(-50%)"
+								>
+									<i class="fa fa-spinner fa-spin text-muted"></i>
+								</div>
+							</div>
+						</div>
+						<div class="mt-1" v-if="localState.linked_doctype">
+							<span class="fxr-text-xs text-muted">
+								{{ __("Fetching from {0}", [localState.linked_doctype]) }}
+							</span>
+						</div>
+					</template>
+
 					<!-- ═══════════ System Context ═══════════ -->
 					<template v-else-if="localState.kind === 'system_context'">
 						<div class="d-flex flex-column fxr-gap-1">
@@ -654,6 +712,7 @@ const ALL_CATEGORIES = [
 	{ value: "string_formula", label: __("String Manipulation"), icon: "fa fa-font" },
 	{ value: "normalization", label: __("Normalization"), icon: "fa fa-refresh" },
 	{ value: "format", label: __("Format"), icon: "fa fa-paint-brush" },
+	{ value: "fetch", label: __("Fetch From Link"), icon: "fa fa-link" },
 	{ value: "system_context", label: __("System Context"), icon: "fa fa-globe" },
 ];
 
@@ -686,6 +745,10 @@ function getDefaultState(kind = "date_formula") {
 
 	return {
 		kind,
+		// Fetch Resolver fields
+		link_field: "",
+		fetch_field: "",
+		linked_doctype: "",
 		// Date Formula fields
 		base_type: baseType,
 		base_field: baseField,
@@ -819,6 +882,56 @@ const aggFieldOptions = computed(() => {
 		}));
 });
 
+const linkFieldOptions = computed(() => {
+	const dt = props.doctype || store.rule_doc?.document_type;
+	if (!dt) return [];
+	const fields = store.doc_meta[dt];
+	if (!fields || !Array.isArray(fields)) return [];
+	return fields
+		.filter((f) => f.fieldtype === "Link")
+		.map((f) => ({
+			label: `${f.label || f.fieldname} (${f.fieldname})`,
+			value: f.fieldname,
+			options: f.options,
+		}));
+});
+
+const fetchFieldOptions = computed(() => {
+	const linkedDt = localState.value.linked_doctype;
+	if (!linkedDt) return [];
+	return store.get_fields_for_doctype(linkedDt, { valueMode: "fieldname" });
+});
+
+const fetchMetaLoading = ref(false);
+
+watch(
+	() => localState.value.link_field,
+	async (newVal, oldVal) => {
+		if (_syncing) return;
+		if (!newVal) {
+			localState.value.linked_doctype = "";
+			localState.value.fetch_field = "";
+			return;
+		}
+		const opt = linkFieldOptions.value.find((o) => o.value === newVal);
+		if (opt && opt.options) {
+			localState.value.linked_doctype = opt.options;
+			if (newVal !== oldVal) {
+				localState.value.fetch_field = "";
+			}
+			fetchMetaLoading.value = true;
+			try {
+				await store.fetch_metadata(opt.options);
+			} finally {
+				fetchMetaLoading.value = false;
+			}
+		} else {
+			localState.value.linked_doctype = "";
+			localState.value.fetch_field = "";
+		}
+	}
+);
+
 // ─── Sync from Props (Hydration) ───
 const syncFromProps = () => {
 	let val = props.modelValue || {};
@@ -883,6 +996,10 @@ const syncFromProps = () => {
 		next.fmt_op = val.fmt_op || "format_date";
 		next.fmt_field = val.fmt_field || "";
 		next.fmt_config = val.fmt_config || "";
+	} else if (kind === "fetch") {
+		next.link_field = val.link_field || "";
+		next.fetch_field = val.fetch_field || "";
+		next.linked_doctype = val.linked_doctype || "";
 	} else if (kind === "system_context") {
 		next.sys_token = val.sys_token || "user";
 		next.sys_role = val.sys_role || "";
@@ -972,6 +1089,12 @@ watch(
 				fmt_op: newVal.fmt_op,
 				fmt_field: newVal.fmt_field,
 				fmt_config: newVal.fmt_config,
+			});
+		} else if (newVal.kind === "fetch") {
+			Object.assign(config, {
+				link_field: newVal.link_field,
+				fetch_field: newVal.fetch_field,
+				linked_doctype: newVal.linked_doctype,
 			});
 		} else if (newVal.kind === "system_context") {
 			Object.assign(config, {

--- a/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
@@ -564,7 +564,9 @@
 								<select
 									class="fxr-select w-100"
 									v-model="localState.fetch_field"
-									:disabled="readOnly || !localState.link_field || fetchMetaLoading"
+									:disabled="
+										readOnly || !localState.link_field || fetchMetaLoading
+									"
 								>
 									<option value="">
 										{{

--- a/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
@@ -1206,14 +1206,23 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
 	document.removeEventListener("mousedown", handleClickOutside);
-	window.removeEventListener("keydown", handleGlobalKeydown, { capture: true });
+	window.removeEventListener("keydown", handleGlobalKeydown);
 	cleanupFloatingDropdown();
 });
 
 const handleClickOutside = (e) => {
 	if (!showPopover.value) return;
-	if (controlRef.value && controlRef.value.contains(e.target)) return;
-	if (popoverRef.value && popoverRef.value.contains(e.target)) return;
+
+	// Ignore clicks inside the control or the popover itself
+	if (controlRef.value?.contains(e.target)) return;
+	if (popoverRef.value?.contains(e.target)) return;
+
+	// CRITICAL: Ignore clicks on teleported overlays (like ComboBox dropdowns)
+	// These are usually children of <body> and outside the popover DOM tree.
+	const target = e.target;
+	if (target.closest(".fxr-dropdown") || target.closest(".tippy-box")) {
+		return;
+	}
 
 	closePopover();
 };
@@ -1276,13 +1285,13 @@ const open = async () => {
 		kindSelectRef.value.focus();
 	}
 
-	window.addEventListener("keydown", handleGlobalKeydown, { capture: true });
+	window.addEventListener("keydown", handleGlobalKeydown);
 };
 
 const closePopover = () => {
 	if (!showPopover.value) return;
 	closeDropdown();
-	window.removeEventListener("keydown", handleGlobalKeydown, { capture: true });
+	window.removeEventListener("keydown", handleGlobalKeydown);
 
 	// Return focus to trigger
 	nextTick(() => {

--- a/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
@@ -541,19 +541,36 @@
 
 					<!-- ═══════════ Fetch Resolver ═══════════ -->
 					<template v-else-if="localState.kind === 'fetch'">
+						<!-- Step 1: Source DocType -->
 						<div class="d-flex flex-column fxr-gap-1">
-							<label class="fxr-label-sm">{{ __("Source Link Field") }}</label>
+							<label class="fxr-label-sm">{{ __("1. Source DocType") }}</label>
+							<ComboBoxControl
+								v-model="localState.linked_doctype"
+								doctype="DocType"
+								:read_only="readOnly"
+								:placeholder="__('Select Source DocType...')"
+								hide-label
+								allow-custom-value
+							/>
+						</div>
+
+						<!-- Step 2: Source Document -->
+						<div class="d-flex flex-column fxr-gap-1 mt-2">
+							<label class="fxr-label-sm">{{ __("2. Source Document") }}</label>
 							<div class="d-flex fxr-gap-2">
 								<select
-									class="fxr-select flex-1"
+									class="fxr-select"
+									style="width: 100px"
 									v-model="localState.link_source_type"
 									:disabled="readOnly"
 									@change="localState.link_field = ''"
 								>
-									<option value="doc_field">{{ __("Document Field") }}</option>
-									<option value="variable">{{ __("Workflow Variable") }}</option>
+									<option value="doc_field">{{ __("Field") }}</option>
+									<option value="variable">{{ __("Var") }}</option>
+									<option value="expression">{{ __("Expr") }}</option>
 								</select>
 								<ComboBoxControl
+									v-if="localState.link_source_type !== 'expression'"
 									class="flex-1 min-w-0"
 									v-model="localState.link_field"
 									:options="sourceLinkOptions"
@@ -561,19 +578,29 @@
 									:placeholder="
 										localState.link_source_type === 'variable'
 											? __('Search variable...')
-											: __('Select link field...')
+											: __('Select field...')
 									"
 									:allow-custom-value="localState.link_source_type === 'variable'"
 									hide-label
 								/>
+								<input
+									v-else
+									type="text"
+									class="fxr-input flex-1"
+									v-model="localState.link_field"
+									:disabled="readOnly"
+									:placeholder="__('e.g. doc.party')"
+								/>
 							</div>
 						</div>
+
+						<!-- Step 3: Fetch Field -->
 						<div class="d-flex flex-column fxr-gap-1 mt-2">
-							<label class="fxr-label-sm">{{ __("Fetch Field") }}</label>
+							<label class="fxr-label-sm">{{ __("3. Fetch Field") }}</label>
 							<ComboBoxControl
 								v-model="localState.fetch_field"
 								:options="fetchFieldOptions"
-								:read_only="readOnly || !localState.link_field"
+								:read_only="readOnly || !localState.linked_doctype"
 								:loading="fetchMetaLoading"
 								:placeholder="
 									fetchMetaLoading
@@ -583,17 +610,6 @@
 								:allow-custom-value="true"
 								hide-label
 							/>
-						</div>
-						<div class="mt-1" v-if="localState.linked_doctype">
-							<span class="fxr-text-xs text-muted">
-								{{
-									localState.linked_doctype.startsWith("doc.")
-										? __("Fetching from {0} (Dynamic)", [
-												localState.linked_doctype,
-										  ])
-										: __("Fetching from {0}", [localState.linked_doctype])
-								}}
-							</span>
 						</div>
 					</template>
 
@@ -890,30 +906,41 @@ const aggFieldOptions = computed(() => {
 
 const sourceLinkOptions = computed(() => {
 	if (localState.value.link_source_type === "variable") {
-		return (props.variableOptions || [])
-			.filter((v) => v.fieldtype === "Link" || v.fieldtype === "Dynamic Link")
-			.map((v) => ({
-				label: `${v.label || v.value} (vars.${v.value})`,
-				value: `vars.${v.value}`,
-				options: v.options,
-				fieldtype: v.fieldtype,
-			}));
+		const vars = props.variableOptions || [];
+		return vars.map((v) => ({
+			label: `${v.label || v.value} (vars.${v.value})`,
+			value: `vars.${v.value}`,
+			options: v.options,
+			fieldtype: v.fieldtype,
+		}));
 	}
-	return linkFieldOptions.value;
+	return prioritizedFieldOptions.value;
 });
 
-const linkFieldOptions = computed(() => {
+const prioritizedFieldOptions = computed(() => {
 	const dt = props.doctype || store.rule_doc?.document_type;
 	if (!dt) return [];
 	const fields = store.doc_meta[dt];
 	if (!fields || !Array.isArray(fields)) return [];
-	return fields
-		.filter((f) => ["Link", "Dynamic Link"].includes(f.fieldtype))
+
+	const prioritizedTypes = ["Link", "Dynamic Link", "Data", "Select"];
+
+	return [...fields]
+		.sort((a, b) => {
+			const aPrio = prioritizedTypes.indexOf(a.fieldtype);
+			const bPrio = prioritizedTypes.indexOf(b.fieldtype);
+
+			if (aPrio !== -1 && bPrio !== -1) return aPrio - bPrio;
+			if (aPrio !== -1) return -1;
+			if (bPrio !== -1) return 1;
+			return 0;
+		})
 		.map((f) => ({
 			label: `${f.label || f.fieldname} (${f.fieldname})`,
 			value: f.fieldname,
 			options: f.options,
 			fieldtype: f.fieldtype,
+			icon: ["Link", "Dynamic Link"].includes(f.fieldtype) ? "fa fa-link" : "fa fa-columns",
 		}));
 });
 
@@ -928,56 +955,60 @@ const fetchMetaLoading = ref(false);
 watch(
 	() => localState.value.link_field,
 	async (newVal, oldVal) => {
-		if (_syncing) return;
-		if (!newVal) {
-			localState.value.linked_doctype = "";
-			localState.value.fetch_field = "";
-			return;
-		}
+		if (_syncing || !newVal) return;
+
 		const opt = sourceLinkOptions.value.find((o) => o.value === newVal);
 		if (opt && (opt.options || opt.fieldtype === "Dynamic Link")) {
-			// For Dynamic Link, options is usually the fieldname that holds the doctype
 			let linkedDt = opt.options;
 			if (opt.fieldtype === "Dynamic Link") {
 				linkedDt = `doc.${opt.options}`;
 			}
 
-			localState.value.linked_doctype = linkedDt;
-
-			if (newVal !== oldVal) {
-				localState.value.fetch_field = "";
+			// Auto-populate Source DocType if it's empty
+			if (linkedDt && !localState.value.linked_doctype) {
+				localState.value.linked_doctype = linkedDt;
 			}
+		}
+	}
+);
 
-			// Try to auto-default even for Dynamic Link or before metadata is loaded
+watch(
+	() => localState.value.linked_doctype,
+	async (newVal, oldVal) => {
+		if (_syncing) return;
+		if (!newVal) {
+			localState.value.fetch_field = "";
+			return;
+		}
+
+		if (newVal !== oldVal) {
+			// Auto-default fetch field to target field name if it's empty
 			if (!localState.value.fetch_field && resolverFieldname.value) {
 				localState.value.fetch_field = resolverFieldname.value;
 			}
+		}
 
-			if (linkedDt && !linkedDt.startsWith("doc.")) {
-				fetchMetaLoading.value = true;
-				try {
-					await store.fetch_metadata(linkedDt);
+		if (newVal && !newVal.startsWith("doc.") && !newVal.startsWith("vars.")) {
+			fetchMetaLoading.value = true;
+			try {
+				await store.fetch_metadata(newVal);
 
-					// If we auto-defaulted, but it turns out the field doesn't exist, clear it
-					// unless it was manually changed (though that's hard to track here)
-					if (
-						localState.value.fetch_field === resolverFieldname.value &&
-						fetchFieldOptions.value.length > 0
-					) {
-						const match = fetchFieldOptions.value.find(
-							(f) => f.value === resolverFieldname.value
-						);
-						if (!match) {
-							localState.value.fetch_field = "";
-						}
+				// Re-verify auto-defaulted field exists in metadata
+				if (
+					localState.value.fetch_field === resolverFieldname.value &&
+					fetchFieldOptions.value.length > 0
+				) {
+					const match = fetchFieldOptions.value.find(
+						(f) => f.value === resolverFieldname.value
+					);
+					if (!match) {
+						// Don't clear if it was manually typed, but here it's likely our auto-default
+						// We'll keep it for now as per user request "default fieldname could hold the same fieldname in target"
 					}
-				} finally {
-					fetchMetaLoading.value = false;
 				}
+			} finally {
+				fetchMetaLoading.value = false;
 			}
-		} else {
-			localState.value.linked_doctype = "";
-			localState.value.fetch_field = "";
 		}
 	}
 );

--- a/flexirule/ruleflow/core/value_resolver.py
+++ b/flexirule/ruleflow/core/value_resolver.py
@@ -324,6 +324,29 @@ class SystemContextResolver(CompiledResolver):
 		return None
 
 
+class FetchResolver(CompiledResolver):
+	def __init__(self, link_field: str | None, fetch_field: str | None, linked_doctype: str | None):
+		self.link_field = link_field
+		self.fetch_field = fetch_field
+		self.linked_doctype = linked_doctype
+
+	def resolve(self, context: dict) -> Any:
+		if not self.link_field or not self.fetch_field or not self.linked_doctype:
+			return None
+
+		# Ensure link_field has a scope, default to doc.
+		path = self.link_field
+		known_scopes = ("doc.", "vars.", "ctx.", "loop.", "row.", "item.", "caller.", "rule.")
+		if not any(path.startswith(s) for s in known_scopes):
+			path = f"doc.{path}"
+
+		link_value = get_context_value(context, path)
+		if not link_value:
+			return None
+
+		return frappe.db.get_value(self.linked_doctype, link_value, self.fetch_field)
+
+
 class JinjaResolver(CompiledResolver):
 	"""Fallback resolver that compiles and renders standard Jinja templates."""
 
@@ -488,6 +511,12 @@ class ValueResolver:
 				fmt_op=config.get("fmt_op", "format_date"),
 				fmt_field=config.get("fmt_field"),
 				fmt_config=config.get("fmt_config", ""),
+			)
+		if kind == "fetch":
+			return FetchResolver(
+				link_field=config.get("link_field"),
+				fetch_field=config.get("fetch_field"),
+				linked_doctype=config.get("linked_doctype"),
 			)
 		if kind == "system_context":
 			return SystemContextResolver(

--- a/flexirule/ruleflow/tests/test_fetch_resolver.py
+++ b/flexirule/ruleflow/tests/test_fetch_resolver.py
@@ -1,7 +1,10 @@
 import unittest
 from unittest.mock import patch
+
 import frappe
+
 from flexirule.ruleflow.core.value_resolver import ValueResolver
+
 
 class TestFetchResolver(unittest.TestCase):
 	def setUp(self):
@@ -40,7 +43,7 @@ class TestFetchResolver(unittest.TestCase):
 			"mode": "resolver",
 			"config": {
 				"kind": "fetch",
-				"link_field": "customer", # No doc. prefix
+				"link_field": "customer",  # No doc. prefix
 				"fetch_field": "party_master",
 				"linked_doctype": "Customer",
 			},

--- a/flexirule/ruleflow/tests/test_fetch_resolver.py
+++ b/flexirule/ruleflow/tests/test_fetch_resolver.py
@@ -1,0 +1,84 @@
+import unittest
+from unittest.mock import patch
+import frappe
+from flexirule.ruleflow.core.value_resolver import ValueResolver
+
+class TestFetchResolver(unittest.TestCase):
+	def setUp(self):
+		self.doc = frappe._dict(
+			{
+				"doctype": "User",
+				"customer": "CUST-0001",
+			}
+		)
+		self.context = {"doc": self.doc, "vars": {}}
+
+	@patch("frappe.db.get_value")
+	def test_fetch_resolver_with_prefix(self, mock_get_value):
+		mock_get_value.return_value = "PM-0005"
+
+		val = {
+			"mode": "resolver",
+			"config": {
+				"kind": "fetch",
+				"link_field": "doc.customer",
+				"fetch_field": "party_master",
+				"linked_doctype": "Customer",
+			},
+		}
+		resolver = ValueResolver.compile(val)
+		result = resolver.resolve(self.context)
+
+		mock_get_value.assert_called_once_with("Customer", "CUST-0001", "party_master")
+		self.assertEqual(result, "PM-0005")
+
+	@patch("frappe.db.get_value")
+	def test_fetch_resolver_without_prefix(self, mock_get_value):
+		mock_get_value.return_value = "PM-0005"
+
+		val = {
+			"mode": "resolver",
+			"config": {
+				"kind": "fetch",
+				"link_field": "customer", # No doc. prefix
+				"fetch_field": "party_master",
+				"linked_doctype": "Customer",
+			},
+		}
+		resolver = ValueResolver.compile(val)
+		result = resolver.resolve(self.context)
+
+		# Should still resolve correctly by prepending doc.
+		mock_get_value.assert_called_once_with("Customer", "CUST-0001", "party_master")
+		self.assertEqual(result, "PM-0005")
+
+	def test_fetch_resolver_missing_config(self):
+		val = {
+			"mode": "resolver",
+			"config": {
+				"kind": "fetch",
+				"link_field": "doc.customer",
+				# fetch_field missing
+				"linked_doctype": "Customer",
+			},
+		}
+		resolver = ValueResolver.compile(val)
+		result = resolver.resolve(self.context)
+		self.assertIsNone(result)
+
+	@patch("frappe.db.get_value")
+	def test_fetch_resolver_no_link_value(self, mock_get_value):
+		self.doc.customer = None
+		val = {
+			"mode": "resolver",
+			"config": {
+				"kind": "fetch",
+				"link_field": "doc.customer",
+				"fetch_field": "party_master",
+				"linked_doctype": "Customer",
+			},
+		}
+		resolver = ValueResolver.compile(val)
+		result = resolver.resolve(self.context)
+		self.assertIsNone(result)
+		mock_get_value.assert_not_called()


### PR DESCRIPTION
This PR implements a proper configuration popover for the Fetch Resolver in the FlexiRule Rule Builder. It allows users to explicitly select a Link field from the current DocType and then pick a field from the linked DocType to fetch. This replaces the previous placeholder implementation and aligns with the ERPNext "Fetch From" pattern.

Key changes:
- UI in `ValueResolverControl.vue` for configuring 'fetch' with live metadata loading.
- Human-readable summary labels like `Customer.party_master ← customer`.
- Backend `FetchResolver` implementation using `frappe.db.get_value`.
- Robust path handling in Python to ensure compatibility with UI-saved fieldnames.

---
*PR created automatically by Jules for task [18388941931249135645](https://jules.google.com/task/18388941931249135645) started by @Sendipad*