### PR TITLE
Optimize GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,73 @@ on:
             - "landing-page/**"
             - "architecture/**"
             - "*.md"
+    workflow_dispatch:
 
 concurrency:
     group: develop-flexirule-${{ github.event.number }}
     cancel-in-progress: true
 
 jobs:
+    build:
+        runs-on: ubuntu-latest
+        name: Frontend
+
+        steps:
+            - name: Clone
+              uses: actions/checkout@v3
+
+            - name: Setup Python
+              uses: actions/setup-python@v4
+              with:
+                  python-version: "3.10"
+
+            - name: Setup Node
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 18
+                  check-latest: true
+
+            - name: Cache pip
+              uses: actions/cache@v4
+              with:
+                  path: ~/.cache/pip
+                  key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml', '**/setup.py', '**/setup.cfg') }}
+                  restore-keys: |
+                      ${{ runner.os }}-pip-
+                      ${{ runner.os }}-
+
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: 'echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT'
+
+            - uses: actions/cache@v4
+              id: yarn-cache
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
+
+            - name: Setup Bench
+              run: |
+                  pip install frappe-bench
+                  bench init --frappe-branch version-15 --skip-redis-config-generation --skip-assets --python "$(which python)" ~/frappe-bench
+
+            - name: Install App
+              working-directory: /home/runner/frappe-bench
+              run: |
+                  bench get-app flexirule $GITHUB_WORKSPACE
+                  bench setup requirements --dev
+              env:
+                  CI: "Yes"
+
+            - name: Build
+              working-directory: /home/runner/frappe-bench
+              run: |
+                  bench build --app flexirule --production
+              env:
+                  CI: "Yes"
+
     tests:
         runs-on: ubuntu-latest
         strategy:
@@ -104,7 +165,6 @@ jobs:
                   bench setup requirements --dev
                   bench new-site --db-root-password root --admin-password admin test_site
                   bench --site test_site install-app flexirule
-                  bench build
               env:
                   CI: "Yes"
 


### PR DESCRIPTION
This change optimizes the GitHub Actions CI workflow for the flexirule app. It splits the workflow into two parallel jobs: 'Frontend' (build) and 'Server' (tests). The 'Frontend' job handles asset compilation with the --production flag, while the 'Server' job focuses exclusively on running backend tests. Caching for dependencies has been implemented in both jobs to further reduce execution time. Additionally, the workflow can now be manually triggered via the GitHub UI.

---
*PR created automatically by Jules for task [7312191292122849862](https://jules.google.com/task/7312191292122849862) started by @ruzaqiarkan-eng*