### PR TITLE
Refactor ValueResolver child components to standardized UI controls

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/controls/value_resolver/components/AggregationResolver.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/value_resolver/components/AggregationResolver.vue
@@ -1,29 +1,27 @@
 <template>
 	<div class="d-flex flex-column fxr-gap-1">
-		<label class="fxr-label-sm">{{ __("Child Table") }}</label>
-		<select class="fxr-select" v-model="modelValue.agg_table" :disabled="readOnly">
-			<option value="">{{ __("Select child table...") }}</option>
-			<option v-for="opt in tableFieldOptions" :key="opt.value" :value="opt.value">
-				{{ opt.label }}
-			</option>
-		</select>
+		<ComboBoxControl
+			v-model="modelValue.agg_table"
+			:options="tableFieldOptions"
+			:read_only="readOnly"
+			:df="{ label: __('Child Table') }"
+		/>
 	</div>
 	<div class="d-flex flex-column fxr-gap-1 mt-2" v-if="modelValue.agg_op !== 'count'">
-		<label class="fxr-label-sm">{{ __("Numeric Field") }}</label>
-		<select class="fxr-select" v-model="modelValue.agg_field" :disabled="readOnly">
-			<option value="">{{ __("Select field...") }}</option>
-			<option v-for="opt in aggFieldOptions" :key="opt.value" :value="opt.value">
-				{{ opt.label }}
-			</option>
-		</select>
+		<ComboBoxControl
+			v-model="modelValue.agg_field"
+			:options="aggFieldOptions"
+			:read_only="readOnly"
+			:df="{ label: __('Numeric Field') }"
+		/>
 	</div>
 	<div class="d-flex flex-column fxr-gap-1 mt-2">
-		<label class="fxr-label-sm">{{ __("Operation") }}</label>
-		<select class="fxr-select" v-model="modelValue.agg_op" :disabled="readOnly">
-			<option value="sum">{{ __("Sum") }}</option>
-			<option value="avg">{{ __("Average") }}</option>
-			<option value="count">{{ __("Count Rows") }}</option>
-		</select>
+		<SelectControl
+			v-model="modelValue.agg_op"
+			:options="opOptions"
+			:read_only="readOnly"
+			:df="{ label: __('Operation') }"
+		/>
 	</div>
 </template>
 
@@ -31,6 +29,8 @@
 import { computed } from "vue";
 import { useStore } from "../../../stores";
 import { __ } from "../utils";
+import ComboBoxControl from "../../ComboBoxControl.vue";
+import SelectControl from "../../SelectControl.vue";
 
 const props = defineProps({
 	modelValue: Object,
@@ -39,6 +39,12 @@ const props = defineProps({
 });
 
 const store = useStore();
+
+const opOptions = [
+	{ value: "sum", label: __("Sum") },
+	{ value: "avg", label: __("Average") },
+	{ value: "count", label: __("Count Rows") },
+];
 
 const tableFieldOptions = computed(() => {
 	const dt = store.rule_doc?.document_type || props.doctype;

--- a/flexirule/public/js/flexirule/rule_builder/controls/value_resolver/components/DateDiffResolver.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/value_resolver/components/DateDiffResolver.vue
@@ -2,56 +2,52 @@
 	<div class="d-flex flex-column fxr-gap-1">
 		<label class="fxr-label-sm">{{ __("Start Date") }}</label>
 		<div class="d-flex fxr-gap-2">
-			<select
-				class="fxr-select flex-1"
+			<SelectControl
+				class="flex-1"
 				v-model="modelValue.diff_start_type"
-				:disabled="readOnly"
-			>
-				<option value="today">{{ __("Today") }}</option>
-				<option value="doc_field">{{ __("Document Field") }}</option>
-			</select>
-			<select
+				:options="typeOptions"
+				:read_only="readOnly"
+				no-label
+			/>
+			<ComboBoxControl
 				v-if="modelValue.diff_start_type === 'doc_field'"
-				class="fxr-select flex-1"
+				class="flex-1"
 				v-model="modelValue.diff_start_field"
-				:disabled="readOnly"
-			>
-				<option v-for="opt in dateFieldOptions" :key="opt.value" :value="opt.value">
-					{{ opt.label }}
-				</option>
-			</select>
+				:options="dateFieldOptions"
+				:read_only="readOnly"
+				no-label
+				:placeholder="__('Select field...')"
+			/>
 		</div>
 	</div>
 	<div class="d-flex flex-column fxr-gap-1 mt-2">
 		<label class="fxr-label-sm">{{ __("End Date") }}</label>
 		<div class="d-flex fxr-gap-2">
-			<select
-				class="fxr-select flex-1"
+			<SelectControl
+				class="flex-1"
 				v-model="modelValue.diff_end_type"
-				:disabled="readOnly"
-			>
-				<option value="today">{{ __("Today") }}</option>
-				<option value="doc_field">{{ __("Document Field") }}</option>
-			</select>
-			<select
+				:options="typeOptions"
+				:read_only="readOnly"
+				no-label
+			/>
+			<ComboBoxControl
 				v-if="modelValue.diff_end_type === 'doc_field'"
-				class="fxr-select flex-1"
+				class="flex-1"
 				v-model="modelValue.diff_end_field"
-				:disabled="readOnly"
-			>
-				<option v-for="opt in dateFieldOptions" :key="opt.value" :value="opt.value">
-					{{ opt.label }}
-				</option>
-			</select>
+				:options="dateFieldOptions"
+				:read_only="readOnly"
+				no-label
+				:placeholder="__('Select field...')"
+			/>
 		</div>
 	</div>
 	<div class="d-flex flex-column fxr-gap-1 mt-2">
-		<label class="fxr-label-sm">{{ __("Result Unit") }}</label>
-		<select class="fxr-select" v-model="modelValue.diff_unit" :disabled="readOnly">
-			<option value="days">{{ __("Days") }}</option>
-			<option value="months">{{ __("Months") }}</option>
-			<option value="years">{{ __("Years") }}</option>
-		</select>
+		<SelectControl
+			v-model="modelValue.diff_unit"
+			:options="unitOptions"
+			:read_only="readOnly"
+			:df="{ label: __('Result Unit') }"
+		/>
 	</div>
 </template>
 
@@ -59,6 +55,8 @@
 import { computed } from "vue";
 import { useStore } from "../../../stores";
 import { __ } from "../utils";
+import SelectControl from "../../SelectControl.vue";
+import ComboBoxControl from "../../ComboBoxControl.vue";
 
 const props = defineProps({
 	modelValue: Object,
@@ -67,6 +65,17 @@ const props = defineProps({
 });
 
 const store = useStore();
+
+const typeOptions = [
+	{ value: "today", label: __("Today") },
+	{ value: "doc_field", label: __("Document Field") },
+];
+
+const unitOptions = [
+	{ value: "days", label: __("Days") },
+	{ value: "months", label: __("Months") },
+	{ value: "years", label: __("Years") },
+];
 
 const dateFieldOptions = computed(() => {
 	const dt = store.rule_doc?.document_type || props.doctype;

--- a/flexirule/public/js/flexirule/rule_builder/controls/value_resolver/components/DateFormulaResolver.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/value_resolver/components/DateFormulaResolver.vue
@@ -2,21 +2,22 @@
 	<div class="d-flex flex-column fxr-gap-1">
 		<label class="fxr-label-sm">{{ __("Base Date") }}</label>
 		<div class="d-flex fxr-gap-2">
-			<select class="fxr-select flex-1" v-model="modelValue.base_type" :disabled="readOnly">
-				<option value="today">{{ __("Today") }}</option>
-				<option value="doc_field">{{ __("Document Field") }}</option>
-			</select>
-			<select
+			<SelectControl
+				class="flex-1"
+				v-model="modelValue.base_type"
+				:options="baseTypeOptions"
+				:read_only="readOnly"
+				no-label
+			/>
+			<ComboBoxControl
 				v-if="modelValue.base_type === 'doc_field'"
-				class="fxr-select flex-1"
+				class="flex-1"
 				v-model="modelValue.base_field"
-				:disabled="readOnly"
-				:class="{ 'is-invalid': !isBaseFieldValid }"
-			>
-				<option v-for="opt in dateFieldOptions" :key="opt.value" :value="opt.value">
-					{{ opt.label }}
-				</option>
-			</select>
+				:options="dateFieldOptions"
+				:read_only="readOnly"
+				no-label
+				:placeholder="__('Select field...')"
+			/>
 		</div>
 		<div v-if="!isBaseFieldValid" class="fxr-text-xs text-danger mt-1">
 			<i class="fa fa-exclamation-circle mr-1"></i>
@@ -31,30 +32,27 @@
 	<div class="d-flex flex-column fxr-gap-1 mt-2">
 		<label class="fxr-label-sm">{{ __("Offset") }}</label>
 		<div class="d-flex align-items-center fxr-gap-2">
-			<select
-				class="fxr-select"
-				v-model="modelValue.offset_sign"
+			<SelectControl
 				style="width: 70px"
-				:disabled="readOnly"
-			>
-				<option value="+">+</option>
-				<option value="-">-</option>
-			</select>
-			<input
-				type="number"
-				class="fxr-input"
-				style="width: 80px"
-				v-model.number="modelValue.offset_value"
-				min="0"
-				:disabled="readOnly"
+				v-model="modelValue.offset_sign"
+				:options="signOptions"
+				:read_only="readOnly"
+				no-label
 			/>
-			<select class="fxr-select flex-1" v-model="modelValue.offset_unit" :disabled="readOnly">
-				<option value="days">{{ __("Days") }}</option>
-				<option value="weeks">{{ __("Weeks") }}</option>
-				<option value="months">{{ __("Months") }}</option>
-				<option value="years">{{ __("Years") }}</option>
-				<option value="hours">{{ __("Hours") }}</option>
-			</select>
+			<DataControl
+				style="width: 80px"
+				v-model="modelValue.offset_value"
+				:df="{ fieldtype: 'Int' }"
+				:read_only="readOnly"
+				no-label
+			/>
+			<SelectControl
+				class="flex-1"
+				v-model="modelValue.offset_unit"
+				:options="unitOptions"
+				:read_only="readOnly"
+				no-label
+			/>
 		</div>
 	</div>
 </template>
@@ -63,6 +61,9 @@
 import { computed } from "vue";
 import { useStore } from "../../../stores";
 import { __, validateField } from "../utils";
+import SelectControl from "../../SelectControl.vue";
+import ComboBoxControl from "../../ComboBoxControl.vue";
+import DataControl from "../../DataControl.vue";
 
 const props = defineProps({
 	modelValue: Object,
@@ -71,6 +72,24 @@ const props = defineProps({
 });
 
 const store = useStore();
+
+const baseTypeOptions = [
+	{ value: "today", label: __("Today") },
+	{ value: "doc_field", label: __("Document Field") },
+];
+
+const signOptions = [
+	{ value: "+", label: "+" },
+	{ value: "-", label: "-" },
+];
+
+const unitOptions = [
+	{ value: "days", label: __("Days") },
+	{ value: "weeks", label: __("Weeks") },
+	{ value: "months", label: __("Months") },
+	{ value: "years", label: __("Years") },
+	{ value: "hours", label: __("Hours") },
+];
 
 const dateFieldOptions = computed(() => {
 	const dt = store.rule_doc?.document_type || props.doctype;

--- a/flexirule/public/js/flexirule/rule_builder/controls/value_resolver/components/FetchResolver.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/value_resolver/components/FetchResolver.vue
@@ -34,17 +34,14 @@
 				</span>
 			</template>
 			<div class="d-flex fxr-gap-2">
-				<select
-					class="fxr-select"
+				<SelectControl
 					style="width: 80px"
 					v-model="modelValue.link_source_type"
-					:disabled="readOnly"
+					:options="sourceTypeOptions"
+					:read_only="readOnly"
+					no-label
 					@change="modelValue.link_field = ''"
-				>
-					<option value="doc_field">{{ __("Field") }}</option>
-					<option value="variable">{{ __("Var") }}</option>
-					<option value="expression">{{ __("Expr") }}</option>
-				</select>
+				/>
 				<ComboBoxControl
 					v-if="modelValue.link_source_type !== 'expression'"
 					class="flex-1 min-w-0"
@@ -59,13 +56,13 @@
 					:allow-custom-value="modelValue.link_source_type === 'variable'"
 					hide-label
 				/>
-				<input
+				<DataControl
 					v-else
-					type="text"
-					class="fxr-input flex-1"
+					class="flex-1"
 					v-model="modelValue.link_field"
-					:disabled="readOnly"
+					:read_only="readOnly"
 					:placeholder="__('e.g. doc.party')"
+					no-label
 				/>
 			</div>
 		</CollapsibleSection>
@@ -99,6 +96,8 @@
 import { ref, computed, watch } from "vue";
 import { useStore } from "../../../stores";
 import ComboBoxControl from "../../ComboBoxControl.vue";
+import SelectControl from "../../SelectControl.vue";
+import DataControl from "../../DataControl.vue";
 import CollapsibleSection from "../../CollapsibleSection.vue";
 import { __ } from "../utils";
 
@@ -115,6 +114,12 @@ const props = defineProps({
 
 const store = useStore();
 const fetchMetaLoading = ref(false);
+
+const sourceTypeOptions = [
+	{ value: "doc_field", label: __("Field") },
+	{ value: "variable", label: __("Var") },
+	{ value: "expression", label: __("Expr") },
+];
 
 const resolverFieldname = computed(() => {
 	const fieldname =

--- a/flexirule/public/js/flexirule/rule_builder/controls/value_resolver/components/FormatResolver.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/value_resolver/components/FormatResolver.vue
@@ -1,43 +1,28 @@
 <template>
 	<div class="d-flex flex-column fxr-gap-1">
-		<label class="fxr-label-sm">{{ __("Format Type") }}</label>
-		<select class="fxr-select" v-model="modelValue.fmt_op" :disabled="readOnly">
-			<option value="format_date">{{ __("Date/Time Format") }}</option>
-			<option value="fmt_money">{{ __("Currency Format") }}</option>
-			<option value="format">{{ __("String Template") }}</option>
-		</select>
+		<SelectControl
+			v-model="modelValue.fmt_op"
+			:options="formatOptions"
+			:read_only="readOnly"
+			:df="{ label: __('Format Type') }"
+		/>
 	</div>
 	<div class="d-flex flex-column fxr-gap-1 mt-2">
-		<label class="fxr-label-sm">{{ __("Field") }}</label>
-		<select class="fxr-select" v-model="modelValue.fmt_field" :disabled="readOnly">
-			<option value="">{{ __("Select field...") }}</option>
-			<option
-				v-for="opt in modelValue.fmt_op === 'fmt_money'
-					? numericFieldOptions
-					: modelValue.fmt_op === 'format_date'
-					? dateFieldOptions
-					: stringFieldOptions"
-				:key="opt.value"
-				:value="opt.value"
-			>
-				{{ opt.label }}
-			</option>
-		</select>
+		<ComboBoxControl
+			v-model="modelValue.fmt_field"
+			:options="activeFieldOptions"
+			:read_only="readOnly"
+			:df="{ label: __('Field') }"
+		/>
 	</div>
 	<div class="d-flex flex-column fxr-gap-1 mt-2">
-		<label class="fxr-label-sm">{{
-			modelValue.fmt_op === "fmt_money"
-				? __("Currency (Field or Code)")
-				: modelValue.fmt_op === "format_date"
-				? __("Date Format (e.g. YYYY-MM-DD)")
-				: __("Template")
-		}}</label>
-		<input
-			type="text"
-			class="fxr-input"
+		<DataControl
 			v-model="modelValue.fmt_config"
-			:disabled="readOnly"
-			:placeholder="modelValue.fmt_op === 'format_date' ? 'YYYY-MM-DD' : ''"
+			:read_only="readOnly"
+			:df="{
+				label: configLabel,
+				placeholder: modelValue.fmt_op === 'format_date' ? 'YYYY-MM-DD' : '',
+			}"
 		/>
 	</div>
 </template>
@@ -46,6 +31,9 @@
 import { computed } from "vue";
 import { useStore } from "../../../stores";
 import { __ } from "../utils";
+import SelectControl from "../../SelectControl.vue";
+import ComboBoxControl from "../../ComboBoxControl.vue";
+import DataControl from "../../DataControl.vue";
 
 const props = defineProps({
 	modelValue: Object,
@@ -54,6 +42,24 @@ const props = defineProps({
 });
 
 const store = useStore();
+
+const formatOptions = [
+	{ value: "format_date", label: __("Date/Time Format") },
+	{ value: "fmt_money", label: __("Currency Format") },
+	{ value: "format", label: __("String Template") },
+];
+
+const configLabel = computed(() => {
+	if (props.modelValue.fmt_op === "fmt_money") return __("Currency (Field or Code)");
+	if (props.modelValue.fmt_op === "format_date") return __("Date Format (e.g. YYYY-MM-DD)");
+	return __("Template");
+});
+
+const activeFieldOptions = computed(() => {
+	if (props.modelValue.fmt_op === "fmt_money") return numericFieldOptions.value;
+	if (props.modelValue.fmt_op === "format_date") return dateFieldOptions.value;
+	return stringFieldOptions.value;
+});
 
 const dateFieldOptions = computed(() => {
 	const dt = store.rule_doc?.document_type || props.doctype;

--- a/flexirule/public/js/flexirule/rule_builder/controls/value_resolver/components/MathFormulaResolver.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/value_resolver/components/MathFormulaResolver.vue
@@ -1,57 +1,48 @@
 <template>
 	<div class="d-flex flex-column fxr-gap-1">
-		<label class="fxr-label-sm">{{ __("Field A") }}</label>
-		<select
-			class="fxr-select"
+		<ComboBoxControl
 			v-model="modelValue.field_a"
-			:disabled="readOnly"
+			:options="numericFieldOptions"
+			:read_only="readOnly"
+			:df="{ label: __('Field A') }"
 			:class="{ 'is-invalid': !isFieldAValid }"
-		>
-			<option value="">{{ __("Select field...") }}</option>
-			<option v-for="opt in numericFieldOptions" :key="opt.value" :value="opt.value">
-				{{ opt.label }}
-			</option>
-		</select>
+		/>
 	</div>
 	<div class="d-flex flex-column fxr-gap-1 mt-2">
-		<label class="fxr-label-sm">{{ __("Operator") }}</label>
-		<select class="fxr-select" v-model="modelValue.math_op" :disabled="readOnly">
-			<option value="+">{{ __("Add (+)") }}</option>
-			<option value="-">{{ __("Subtract (-)") }}</option>
-			<option value="*">{{ __("Multiply (×)") }}</option>
-			<option value="/">{{ __("Divide (÷)") }}</option>
-		</select>
+		<SelectControl
+			v-model="modelValue.math_op"
+			:options="mathOpOptions"
+			:read_only="readOnly"
+			:df="{ label: __('Operator') }"
+		/>
 	</div>
 	<div class="d-flex flex-column fxr-gap-1 mt-2">
 		<label class="fxr-label-sm">{{ __("Field B / Value") }}</label>
 		<div class="d-flex fxr-gap-2">
-			<select
-				class="fxr-select flex-1"
+			<SelectControl
+				class="flex-1"
 				v-model="modelValue.field_b_type"
-				:disabled="readOnly"
-			>
-				<option value="field">{{ __("Document Field") }}</option>
-				<option value="constant">{{ __("Fixed Value") }}</option>
-			</select>
-			<select
+				:options="fieldBTypeOptions"
+				:read_only="readOnly"
+				no-label
+			/>
+			<ComboBoxControl
 				v-if="modelValue.field_b_type === 'field'"
-				class="fxr-select flex-1"
+				class="flex-1"
 				v-model="modelValue.field_b"
-				:disabled="readOnly"
+				:options="numericFieldOptions"
+				:read_only="readOnly"
+				no-label
 				:class="{ 'is-invalid': !isFieldBValid }"
-			>
-				<option value="">{{ __("Select field...") }}</option>
-				<option v-for="opt in numericFieldOptions" :key="opt.value" :value="opt.value">
-					{{ opt.label }}
-				</option>
-			</select>
-			<input
+				:placeholder="__('Select field...')"
+			/>
+			<DataControl
 				v-else
-				type="number"
-				step="any"
-				class="fxr-input flex-1"
-				v-model.number="modelValue.constant_b"
-				:disabled="readOnly"
+				class="flex-1"
+				v-model="modelValue.constant_b"
+				:df="{ fieldtype: 'Float' }"
+				:read_only="readOnly"
+				no-label
 				:placeholder="__('Enter value')"
 			/>
 		</div>
@@ -59,14 +50,12 @@
 	<div class="d-flex flex-column fxr-gap-1 mt-2">
 		<label class="fxr-label-sm">{{ __("Round To") }}</label>
 		<div class="d-flex align-items-center fxr-gap-2">
-			<input
-				type="number"
-				class="fxr-input"
+			<DataControl
 				style="width: 80px"
-				v-model.number="modelValue.precision"
-				min="0"
-				max="9"
-				:disabled="readOnly"
+				v-model="modelValue.precision"
+				:df="{ fieldtype: 'Int' }"
+				:read_only="readOnly"
+				no-label
 			/>
 			<span class="text-muted fxr-text-xs">{{ __("decimal places") }}</span>
 		</div>
@@ -77,6 +66,9 @@
 import { computed } from "vue";
 import { useStore } from "../../../stores";
 import { __ } from "../utils";
+import SelectControl from "../../SelectControl.vue";
+import ComboBoxControl from "../../ComboBoxControl.vue";
+import DataControl from "../../DataControl.vue";
 
 const props = defineProps({
 	modelValue: Object,
@@ -85,6 +77,18 @@ const props = defineProps({
 });
 
 const store = useStore();
+
+const mathOpOptions = [
+	{ value: "+", label: __("Add (+)") },
+	{ value: "-", label: __("Subtract (-)") },
+	{ value: "*", label: __("Multiply (×)") },
+	{ value: "/", label: __("Divide (÷)") },
+];
+
+const fieldBTypeOptions = [
+	{ value: "field", label: __("Document Field") },
+	{ value: "constant", label: __("Fixed Value") },
+];
 
 const numericFieldOptions = computed(() => {
 	const dt = store.rule_doc?.document_type || props.doctype;

--- a/flexirule/public/js/flexirule/rule_builder/controls/value_resolver/components/NormalizationResolver.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/value_resolver/components/NormalizationResolver.vue
@@ -1,22 +1,20 @@
 <template>
 	<div class="d-flex flex-column fxr-gap-1">
-		<label class="fxr-label-sm">{{ __("Target Field") }}</label>
-		<select class="fxr-select" v-model="modelValue.norm_field" :disabled="readOnly">
-			<option value="">{{ __("Select field...") }}</option>
-			<option v-for="opt in stringFieldOptions" :key="opt.value" :value="opt.value">
-				{{ opt.label }}
-			</option>
-		</select>
+		<ComboBoxControl
+			v-model="modelValue.norm_field"
+			:options="stringFieldOptions"
+			:read_only="readOnly"
+			:df="{ label: __('Target Field') }"
+		/>
 	</div>
 
 	<div class="d-flex flex-column fxr-gap-1 mt-3">
-		<label class="fxr-label-sm">{{ __("Normalization Profile") }}</label>
-		<select class="fxr-select" v-model="modelValue.norm_profile" :disabled="readOnly">
-			<option value="Custom">{{ __("Custom Pipeline") }}</option>
-			<option v-for="profile in availableProfiles" :key="profile" :value="profile">
-				{{ profile }}
-			</option>
-		</select>
+		<SelectControl
+			v-model="modelValue.norm_profile"
+			:options="profileOptions"
+			:read_only="readOnly"
+			:df="{ label: __('Normalization Profile') }"
+		/>
 	</div>
 
 	<div class="d-flex flex-column fxr-gap-1 mt-3">
@@ -50,11 +48,9 @@
 
 		<div v-if="showDemo" class="mt-2">
 			<div class="d-flex flex-column fxr-gap-1">
-				<label class="fxr-label-xs text-muted">{{ __("Example Text") }}</label>
-				<input
-					type="text"
+				<DataControl
 					v-model="demoInput"
-					class="fxr-input fxr-input--sm"
+					:df="{ label: __('Example Text') }"
 					:placeholder="__('Type something to test...')"
 				/>
 			</div>
@@ -109,6 +105,9 @@ import { ref, computed, watch, onMounted } from "vue";
 import { useStore } from "../../../stores";
 import { __ } from "../utils";
 import MultiSelectList from "../../MultiSelectList.vue";
+import ComboBoxControl from "../../ComboBoxControl.vue";
+import SelectControl from "../../SelectControl.vue";
+import DataControl from "../../DataControl.vue";
 
 const props = defineProps({
 	modelValue: Object,
@@ -125,6 +124,14 @@ const availableOperations = ref([]);
 const availableProfiles = ref([]);
 
 const isCustomProfile = computed(() => props.modelValue.norm_profile === "Custom");
+
+const profileOptions = computed(() => {
+	const opts = [{ value: "Custom", label: __("Custom Pipeline") }];
+	availableProfiles.value.forEach((p) => {
+		opts.push({ value: p, label: p });
+	});
+	return opts;
+});
 
 const formatOpLabel = (op) => {
 	if (!op) return "";

--- a/flexirule/public/js/flexirule/rule_builder/controls/value_resolver/components/StringFormulaResolver.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/value_resolver/components/StringFormulaResolver.vue
@@ -1,45 +1,37 @@
 <template>
 	<div class="d-flex flex-column fxr-gap-1">
-		<label class="fxr-label-sm">{{ __("Operation") }}</label>
-		<select class="fxr-select" v-model="modelValue.str_op" :disabled="readOnly">
-			<option value="concat">{{ __("Concatenate") }}</option>
-			<option value="fmt_money">{{ __("Format Currency") }}</option>
-			<option value="uppercase">{{ __("Uppercase") }}</option>
-			<option value="lowercase">{{ __("Lowercase") }}</option>
-		</select>
+		<SelectControl
+			v-model="modelValue.str_op"
+			:options="operationOptions"
+			:read_only="readOnly"
+			:df="{ label: __('Operation') }"
+		/>
 	</div>
 	<div class="d-flex flex-column fxr-gap-1 mt-2">
-		<label class="fxr-label-sm">{{
-			modelValue.str_op === "fmt_money" ? __("Numeric Field") : __("Value A")
-		}}</label>
+		<label class="fxr-label-sm">{{ labelA }}</label>
 		<div class="d-flex gap-2">
-			<select class="fxr-select flex-1" v-model="modelValue.str_a_type" :disabled="readOnly">
-				<option value="field">{{ __("Document Field") }}</option>
-				<option value="constant">{{ __("Fixed Text") }}</option>
-			</select>
-			<select
+			<SelectControl
+				class="flex-1"
+				v-model="modelValue.str_a_type"
+				:options="typeOptions"
+				:read_only="readOnly"
+				no-label
+			/>
+			<ComboBoxControl
 				v-if="modelValue.str_a_type === 'field'"
-				class="fxr-select flex-1"
+				class="flex-1"
 				v-model="modelValue.str_a"
-				:disabled="readOnly"
-			>
-				<option value="">{{ __("Select field...") }}</option>
-				<option
-					v-for="opt in modelValue.str_op === 'fmt_money'
-						? numericFieldOptions
-						: stringFieldOptions"
-					:key="opt.value"
-					:value="opt.value"
-				>
-					{{ opt.label }}
-				</option>
-			</select>
-			<input
+				:options="optionsA"
+				:read_only="readOnly"
+				no-label
+				:placeholder="__('Select field...')"
+			/>
+			<DataControl
 				v-else
-				type="text"
-				class="fxr-input flex-1"
+				class="flex-1"
 				v-model="modelValue.str_a"
-				:disabled="readOnly"
+				:read_only="readOnly"
+				no-label
 				:placeholder="__('Enter text')"
 			/>
 		</div>
@@ -48,35 +40,30 @@
 		class="d-flex flex-column fxr-gap-1 mt-2"
 		v-if="['concat', 'fmt_money'].includes(modelValue.str_op)"
 	>
-		<label class="fxr-label-sm">{{
-			modelValue.str_op === "fmt_money" ? __("Currency") : __("Value B")
-		}}</label>
+		<label class="fxr-label-sm">{{ labelB }}</label>
 		<div class="d-flex gap-2">
-			<select class="fxr-select flex-1" v-model="modelValue.str_b_type" :disabled="readOnly">
-				<option value="field">{{ __("Document Field") }}</option>
-				<option value="constant">
-					{{
-						modelValue.str_op === "fmt_money" ? __("Fixed Currency") : __("Fixed Text")
-					}}
-				</option>
-			</select>
-			<select
+			<SelectControl
+				class="flex-1"
+				v-model="modelValue.str_b_type"
+				:options="typeBOptions"
+				:read_only="readOnly"
+				no-label
+			/>
+			<ComboBoxControl
 				v-if="modelValue.str_b_type === 'field'"
-				class="fxr-select flex-1"
+				class="flex-1"
 				v-model="modelValue.str_b"
-				:disabled="readOnly"
-			>
-				<option value="">{{ __("Select field...") }}</option>
-				<option v-for="opt in stringFieldOptions" :key="opt.value" :value="opt.value">
-					{{ opt.label }}
-				</option>
-			</select>
-			<input
+				:options="stringFieldOptions"
+				:read_only="readOnly"
+				no-label
+				:placeholder="__('Select field...')"
+			/>
+			<DataControl
 				v-else
-				type="text"
-				class="fxr-input flex-1"
+				class="flex-1"
 				v-model="modelValue.str_b"
-				:disabled="readOnly"
+				:read_only="readOnly"
+				no-label
 				:placeholder="modelValue.str_op === 'fmt_money' ? __('e.g. USD') : __('Enter text')"
 			/>
 		</div>
@@ -87,6 +74,9 @@
 import { computed } from "vue";
 import { useStore } from "../../../stores";
 import { __ } from "../utils";
+import SelectControl from "../../SelectControl.vue";
+import ComboBoxControl from "../../ComboBoxControl.vue";
+import DataControl from "../../DataControl.vue";
 
 const props = defineProps({
 	modelValue: Object,
@@ -95,6 +85,41 @@ const props = defineProps({
 });
 
 const store = useStore();
+
+const operationOptions = [
+	{ value: "concat", label: __("Concatenate") },
+	{ value: "fmt_money", label: __("Format Currency") },
+	{ value: "uppercase", label: __("Uppercase") },
+	{ value: "lowercase", label: __("Lowercase") },
+];
+
+const typeOptions = [
+	{ value: "field", label: __("Document Field") },
+	{ value: "constant", label: __("Fixed Text") },
+];
+
+const typeBOptions = computed(() => {
+	const fixedLabel =
+		props.modelValue.str_op === "fmt_money" ? __("Fixed Currency") : __("Fixed Text");
+	return [
+		{ value: "field", label: __("Document Field") },
+		{ value: "constant", label: fixedLabel },
+	];
+});
+
+const labelA = computed(() => {
+	return props.modelValue.str_op === "fmt_money" ? __("Numeric Field") : __("Value A");
+});
+
+const labelB = computed(() => {
+	return props.modelValue.str_op === "fmt_money" ? __("Currency") : __("Value B");
+});
+
+const optionsA = computed(() => {
+	return props.modelValue.str_op === "fmt_money"
+		? numericFieldOptions.value
+		: stringFieldOptions.value;
+});
 
 const numericFieldOptions = computed(() => {
 	const dt = store.rule_doc?.document_type || props.doctype;

--- a/flexirule/public/js/flexirule/rule_builder/controls/value_resolver/components/SystemContextResolver.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/value_resolver/components/SystemContextResolver.vue
@@ -1,18 +1,18 @@
 <template>
 	<div class="d-flex flex-column fxr-gap-1">
-		<label class="fxr-label-sm">{{ __("System Token") }}</label>
-		<select class="fxr-select" v-model="modelValue.sys_token" :disabled="readOnly">
-			<option value="user">{{ __("Current User") }}</option>
-			<option value="role_check">{{ __("Has Role?") }}</option>
-		</select>
+		<SelectControl
+			v-model="modelValue.sys_token"
+			:options="tokenOptions"
+			:read_only="readOnly"
+			:df="{ label: __('System Token') }"
+		/>
 	</div>
 	<div class="d-flex flex-column fxr-gap-1 mt-2" v-if="modelValue.sys_token === 'role_check'">
-		<label class="fxr-label-sm">{{ __("Role Name") }}</label>
-		<input
-			type="text"
-			class="fxr-input"
+		<ComboBoxControl
 			v-model="modelValue.sys_role"
-			:disabled="readOnly"
+			doctype="Role"
+			:read_only="readOnly"
+			:df="{ label: __('Role Name') }"
 			:placeholder="__('e.g. System Manager')"
 		/>
 	</div>
@@ -20,6 +20,13 @@
 
 <script setup>
 import { __ } from "../utils";
+import SelectControl from "../../SelectControl.vue";
+import ComboBoxControl from "../../ComboBoxControl.vue";
+
+const tokenOptions = [
+	{ value: "user", label: __("Current User") },
+	{ value: "role_check", label: __("Has Role?") },
+];
 
 defineProps({
 	modelValue: Object,


### PR DESCRIPTION
This change refactors all child components of `ValueResolverControl` to use the standardized UI controls provided by the rule builder. 

Key changes:
- Replaced raw `<select>` elements with `SelectControl` or `ComboBoxControl`.
- Replaced raw `<input>` elements with `DataControl`.
- Standardized option handling and labels across all resolver components.
- Improved layout consistency and followed design system tokens.
- Ensured proper imports of standardized components in each modified file.

Components refactored:
- `AggregationResolver.vue`
- `DateDiffResolver.vue`
- `DateFormulaResolver.vue`
- `FetchResolver.vue`
- `FormatResolver.vue`
- `MathFormulaResolver.vue`
- `NormalizationResolver.vue`
- `StringFormulaResolver.vue`
- `SystemContextResolver.vue`

---
*PR created automatically by Jules for task [7835161795243476373](https://jules.google.com/task/7835161795243476373) started by @ruzaqiarkan-eng*