### PR TITLE
Refactor Assignment Run Condition to Popover

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
@@ -209,22 +209,22 @@
 					:style="whenDropdownStyle"
 					@mousedown.stop
 				>
-					<div class="popover-header d-flex align-items-center justify-content-between">
+					<div class="popover-header">
 						<div class="d-flex flex-column">
-							<h6 class="mb-0 fw-bold fxr-text-sm">
+							<div class="fw-bold" style="font-size: 11px; line-height: 1.2">
 								{{ __("Execution Condition") }}
-							</h6>
-							<span class="text-muted" style="font-size: 10px; line-height: 1.3">
+							</div>
+							<div class="text-muted" style="font-size: 9px; line-height: 1.2">
 								{{
 									__(
 										"This assignment will only run if the conditions below are met. If left empty, it will always run."
 									)
 								}}
-							</span>
+							</div>
 						</div>
 					</div>
 
-					<div class="condition-builder-wrap mt-3">
+					<div class="condition-builder-wrap">
 						<ConditionBuilder
 							:modelValue="whenEditor.draft"
 							:docFields="whenConditionDocFields"
@@ -632,8 +632,22 @@ function handleKeydown(e) {
 
 function handleClickOutside(e) {
 	if (!isWhenOpen.value) return;
-	if (whenDropdownRef.value?.contains(e.target)) return;
-	if (triggerRef.value?.contains(e.target)) return;
+	const target = e.target;
+
+	// Ignore clicks inside the popover or on the trigger button
+	if (whenDropdownRef.value?.contains(target)) return;
+	if (triggerRef.value?.contains(target)) return;
+
+	// Ignore clicks inside teleported elements (dropdowns, tooltips, modals)
+	if (
+		target.closest(".fxr-dropdown") ||
+		target.closest(".tippy-box") ||
+		target.closest(".fxr-token-modal-overlay") ||
+		target.closest(".awesomplete")
+	) {
+		return;
+	}
+
 	closeWhenConditionEditor();
 }
 
@@ -829,9 +843,9 @@ defineExpose({ validate });
 .when-condition-popover {
 	background-color: var(--fxr-surface-elevated);
 	border: 1px solid var(--fxr-border-strong);
-	border-radius: var(--fxr-radius-lg);
+	border-radius: var(--fxr-radius-md);
 	box-shadow: var(--fxr-shadow-xl);
-	padding: 16px;
+	padding: 10px;
 	display: flex;
 	flex-direction: column;
 	z-index: 15000;
@@ -839,18 +853,16 @@ defineExpose({ validate });
 }
 
 .popover-header {
-	padding-bottom: 0;
+	padding-bottom: 8px;
+	border-bottom: 1px solid var(--fxr-border-subtle);
 }
 
 .condition-builder-wrap {
 	overflow-y: auto;
 	overflow-x: hidden;
-	border: 1px solid var(--fxr-border-subtle);
-	border-radius: 12px;
-	padding: 8px;
-	background-color: var(--fxr-surface-soft);
 	flex: 1;
 	min-height: 0;
+	padding: 8px 0;
 }
 
 /* Value mode toggle + control wrapper */

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
@@ -48,7 +48,7 @@
 							class="fxr-btn fxr-btn--sm w-100 when-toggle-btn"
 							:class="hasWhenCondition(assignment) ? 'is-active' : 'is-default'"
 							:disabled="isReadOnly"
-							@click="openWhenConditionEditor(index)"
+							@click="openWhenConditionEditor(index, $event)"
 						>
 							<i
 								:class="
@@ -200,22 +200,28 @@
 		</button>
 
 		<Teleport to="body">
-			<div
-				v-if="whenEditor.open"
-				class="fxr-modal-overlay"
-				@click.self="closeWhenConditionEditor"
-			>
-				<div class="fxr-modal-card">
-					<div class="d-flex align-items-center justify-content-between mb-2">
-						<h5 class="mb-0">{{ __("Assignment Run Condition") }}</h5>
-						<button
-							class="fxr-btn fxr-btn--icon fxr-btn--sm fxr-btn--ghost"
-							@click="closeWhenConditionEditor"
-						>
-							<i class="fa fa-times"></i>
-						</button>
+			<transition name="dropdown-fade">
+				<div
+					v-if="isWhenOpen"
+					ref="whenDropdownRef"
+					class="fxr-dropdown when-condition-popover"
+					:style="whenDropdownStyle"
+					@mousedown.stop
+				>
+					<div class="popover-header d-flex align-items-center justify-content-between">
+						<div class="d-flex flex-column">
+							<h6 class="mb-0 fw-bold">{{ __("Execution Condition") }}</h6>
+							<span class="text-muted fxr-text-xs">
+								{{
+									__(
+										"This assignment will only run if the conditions below are met. If left empty, it will always run."
+									)
+								}}
+							</span>
+						</div>
 					</div>
-					<div class="condition-builder-wrap">
+
+					<div class="condition-builder-wrap mt-3">
 						<ConditionBuilder
 							:modelValue="whenEditor.draft"
 							:docFields="whenConditionDocFields"
@@ -224,22 +230,26 @@
 							@update:modelValue="updateDraft"
 						/>
 					</div>
-					<div class="d-flex justify-content-between mt-3">
+
+					<div class="d-flex justify-content-between align-items-center mt-3">
 						<button
-							class="fxr-btn fxr-btn--sm fxr-btn--ghost text-danger"
+							v-if="hasWhenCondition(assignments[whenEditor.index])"
+							class="fxr-btn fxr-btn--sm fxr-btn--ghost text-danger p-0"
 							@click="clearWhenCondition"
 						>
-							{{ __("Clear Condition") }}
+							<i class="fa fa-eraser me-1"></i>
+							{{ __("Clear Conditions") }}
 						</button>
+						<div v-else></div>
 						<button
-							class="fxr-btn fxr-btn--sm fxr-btn--secondary"
+							class="fxr-btn fxr-btn--sm fxr-btn--primary"
 							@click="closeWhenConditionEditor"
 						>
-							{{ __("Close") }}
+							{{ __("Done") }}
 						</button>
 					</div>
 				</div>
-			</div>
+			</transition>
 		</Teleport>
 	</div>
 </template>
@@ -248,6 +258,7 @@
 import { computed, watch, ref, onMounted, onBeforeUnmount } from "vue";
 import { fromCodeString } from "../../../utils/serialization";
 import { useActionConfig } from "../../../composables/useActionConfig";
+import { useFloatingDropdown } from "../../../composables/useFloatingDropdown";
 import ComboBoxControl from "../../../controls/ComboBoxControl.vue";
 import FlexValueControl from "../../../controls/FlexValueControl.vue";
 import ConditionBuilder from "../../condition_builder/ConditionBuilder.vue";
@@ -274,7 +285,21 @@ const supportedTemplateModes = [
 	"json",
 	"add-key",
 ];
-const whenEditor = ref({ open: false, index: -1, draft: null });
+const whenEditor = ref({ index: -1, draft: null });
+
+const {
+	triggerRef,
+	dropdownRef: whenDropdownRef,
+	isOpen: isWhenOpen,
+	dropdownStyle: whenDropdownStyle,
+	openDropdown: openWhenDropdown,
+	closeDropdown: closeWhenDropdown,
+	cleanup: cleanupWhenDropdown,
+} = useFloatingDropdown({
+	minWidth: 480,
+	maxWidth: 800,
+	matchTriggerWidth: false,
+});
 
 // ─── Operator Helpers ────────────────────────────────────────────────────────
 
@@ -559,22 +584,29 @@ const whenConditionDocFields = computed(() =>
 	}))
 );
 
-function openWhenConditionEditor(index) {
+function openWhenConditionEditor(index, event) {
+	if (whenEditor.value.index === index && isWhenOpen.value) {
+		closeWhenConditionEditor();
+		return;
+	}
+
+	triggerRef.value = event.currentTarget;
 	const current = assignments.value[index];
 	const fallback = { op: "and", conditions: [] };
 	whenEditor.value = {
-		open: true,
 		index,
 		draft: JSON.parse(JSON.stringify(current?.when_condition || fallback)),
 	};
+	openWhenDropdown();
 }
 
 function closeWhenConditionEditor() {
-	whenEditor.value = { open: false, index: -1, draft: null };
+	closeWhenDropdown();
+	whenEditor.value = { index: -1, draft: null };
 }
 
 function handleKeydown(e) {
-	if (e.key === "Escape" && whenEditor.value.open) {
+	if (e.key === "Escape" && isWhenOpen.value) {
 		e.preventDefault();
 		e.stopPropagation();
 		e.stopImmediatePropagation();
@@ -582,12 +614,22 @@ function handleKeydown(e) {
 	}
 }
 
+function handleClickOutside(e) {
+	if (!isWhenOpen.value) return;
+	if (whenDropdownRef.value?.contains(e.target)) return;
+	if (triggerRef.value?.contains(e.target)) return;
+	closeWhenConditionEditor();
+}
+
 onMounted(() => {
 	window.addEventListener("keydown", handleKeydown, { capture: true });
+	document.addEventListener("mousedown", handleClickOutside, { capture: true });
 });
 
 onBeforeUnmount(() => {
 	window.removeEventListener("keydown", handleKeydown, { capture: true });
+	document.removeEventListener("mousedown", handleClickOutside, { capture: true });
+	cleanupWhenDropdown();
 });
 
 function updateDraft(val) {
@@ -768,34 +810,30 @@ defineExpose({ validate });
 	border-color: var(--fxr-accent);
 }
 
-.fxr-modal-overlay {
-	position: fixed;
-	inset: 0;
-	background-color: rgba(0, 0, 0, 0.5);
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	z-index: 13000;
-}
-
-.fxr-modal-card {
-	width: min(980px, 92vw);
-	max-height: 86vh;
+.when-condition-popover {
 	background-color: var(--fxr-surface-elevated);
-	border-radius: 14px;
-	border: 1px solid var(--fxr-border-subtle);
-	padding: 14px;
-	overflow: hidden;
+	border: 1px solid var(--fxr-border-strong);
+	border-radius: var(--fxr-radius-lg);
+	box-shadow: var(--fxr-shadow-xl);
+	padding: 16px;
 	display: flex;
 	flex-direction: column;
+	z-index: 15000;
+	overflow: hidden;
+}
+
+.popover-header {
+	padding-bottom: 0;
 }
 
 .condition-builder-wrap {
-	overflow: auto;
+	overflow-y: auto;
+	overflow-x: hidden;
 	border: 1px solid var(--fxr-border-subtle);
 	border-radius: 12px;
 	padding: 8px;
 	background-color: var(--fxr-surface-soft);
+	max-height: 400px;
 }
 
 /* Value mode toggle + control wrapper */

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
@@ -72,7 +72,7 @@
 				<!-- Target ComboBox with Type Badge support -->
 				<div class="grid-col-target">
 					<ComboBoxControl
-						ref="targetComboBoxRefs"
+						:ref="(el) => (targetComboBoxRefs[index] = el)"
 						data-fxr-fieldname="assignments.target"
 						:df="{ fieldtype: 'FieldPicker', label: '' }"
 						:modelValue="assignment.target"
@@ -295,7 +295,7 @@ const {
 	closeDropdown: closeWhenDropdown,
 	cleanup: cleanupWhenDropdown,
 } = useFloatingDropdown({
-	minWidth: 480,
+	minWidth: 320,
 	maxWidth: 800,
 	maxHeight: 600,
 	matchTriggerWidth: false,
@@ -513,7 +513,7 @@ function syncToNode() {
 }
 
 function addAssignment() {
-	assignments.value.push({
+	const newAssignment = {
 		name: makeRandomString(9),
 		target: "",
 		operator: "set",
@@ -521,20 +521,28 @@ function addAssignment() {
 		when_expression: "",
 		pythonExpression: "",
 		value: { mode: "static", value: "" },
-	});
+	};
+	assignments.value.push(newAssignment);
 	syncToNode();
 
+	const newIndex = assignments.value.length - 1;
 	nextTick(() => {
-		const newIndex = assignments.value.length - 1;
-		const comboBox = targetComboBoxRefs.value[newIndex];
-		if (comboBox) {
-			comboBox.focus();
-		}
+		// Wait an extra tick to ensure v-for has completed rendering the new element
+		nextTick(() => {
+			const comboBox = targetComboBoxRefs.value[newIndex];
+			if (comboBox) {
+				comboBox.focus();
+			}
+		});
 	});
 }
 
 function removeAssignment(index) {
 	assignments.value.splice(index, 1);
+	// Cleanup ref if needed, though Vue usually handles it
+	if (targetComboBoxRefs.value[index]) {
+		targetComboBoxRefs.value.splice(index, 1);
+	}
 	syncToNode();
 }
 

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
@@ -33,7 +33,7 @@
 				class="grid-col-when"
 				v-tippy="{
 					content: __(
-						'<b>Execution Condition</b><br/>This assignment will only run if the conditions are met. If left empty, it will always run.'
+						'<b>Execution Condition</b><br/>This assignment will only run if the conditions below are met. If left empty, it will always run.'
 					),
 					allowHTML: true,
 					placement: 'top-start',
@@ -60,13 +60,6 @@
 							class="fxr-btn fxr-btn--sm w-100 when-toggle-btn"
 							:class="hasWhenCondition(assignment) ? 'is-active' : 'is-default'"
 							:disabled="isReadOnly"
-							v-tippy="{
-								content: __(
-									'<b>Execution Condition</b><br/>This assignment will only run if the conditions are met. If left empty, it will always run.'
-								),
-								allowHTML: true,
-								placement: 'left',
-							}"
 							@click="openWhenConditionEditor(index, $event)"
 						>
 							<i
@@ -240,7 +233,7 @@
 
 					<div
 						v-if="hasWhenCondition(assignments[whenEditor.index])"
-						class="d-flex justify-content-start align-items-center mt-3"
+						class="d-flex justify-content-start align-items-center mt-2 px-3 pb-2"
 					>
 						<button
 							class="fxr-btn fxr-btn--sm fxr-btn--ghost text-danger p-0"
@@ -543,7 +536,6 @@ function addAssignment() {
 
 function removeAssignment(index) {
 	assignments.value.splice(index, 1);
-	// Cleanup ref if needed, though Vue usually handles it
 	if (targetComboBoxRefs.value[index]) {
 		targetComboBoxRefs.value.splice(index, 1);
 	}
@@ -849,7 +841,7 @@ defineExpose({ validate });
 	border: 1px solid var(--fxr-border-strong);
 	border-radius: var(--fxr-radius-md);
 	box-shadow: var(--fxr-shadow-xl);
-	padding: 8px;
+	padding: 0;
 	display: flex;
 	flex-direction: column;
 	z-index: 15000;
@@ -861,13 +853,14 @@ defineExpose({ validate });
 	overflow-x: hidden;
 	flex: 1;
 	min-height: 0;
+	padding: 12px;
 }
 
 @media (max-width: 768px) {
 	.when-condition-popover {
 		width: calc(100vw - 24px) !important;
 		left: 12px !important;
-		max-height: 70vh !important;
+		max-height: 80vh !important;
 		bottom: 12px !important;
 		top: auto !important;
 		border-radius: var(--fxr-radius-lg) !important;

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
@@ -72,6 +72,7 @@
 				<!-- Target ComboBox with Type Badge support -->
 				<div class="grid-col-target">
 					<ComboBoxControl
+						ref="targetComboBoxRefs"
 						data-fxr-fieldname="assignments.target"
 						:df="{ fieldtype: 'FieldPicker', label: '' }"
 						:modelValue="assignment.target"
@@ -255,7 +256,7 @@
 </template>
 
 <script setup>
-import { computed, watch, ref, onMounted, onBeforeUnmount } from "vue";
+import { computed, watch, ref, onMounted, onBeforeUnmount, nextTick } from "vue";
 import { fromCodeString } from "../../../utils/serialization";
 import { useActionConfig } from "../../../composables/useActionConfig";
 import { useFloatingDropdown } from "../../../composables/useFloatingDropdown";
@@ -286,6 +287,7 @@ const supportedTemplateModes = [
 	"add-key",
 ];
 const whenEditor = ref({ index: -1, draft: null });
+const targetComboBoxRefs = ref([]);
 
 const {
 	triggerRef,
@@ -523,6 +525,14 @@ function addAssignment() {
 		value: { mode: "static", value: "" },
 	});
 	syncToNode();
+
+	nextTick(() => {
+		const newIndex = assignments.value.length - 1;
+		const comboBox = targetComboBoxRefs.value[newIndex];
+		if (comboBox) {
+			comboBox.focus();
+		}
+	});
 }
 
 function removeAssignment(index) {

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
@@ -211,8 +211,10 @@
 				>
 					<div class="popover-header d-flex align-items-center justify-content-between">
 						<div class="d-flex flex-column">
-							<h6 class="mb-0 fw-bold">{{ __("Execution Condition") }}</h6>
-							<span class="text-muted fxr-text-xs">
+							<h6 class="mb-0 fw-bold fxr-text-sm">
+								{{ __("Execution Condition") }}
+							</h6>
+							<span class="text-muted" style="font-size: 10px; line-height: 1.3">
 								{{
 									__(
 										"This assignment will only run if the conditions below are met. If left empty, it will always run."
@@ -232,21 +234,16 @@
 						/>
 					</div>
 
-					<div class="d-flex justify-content-between align-items-center mt-3">
+					<div
+						v-if="hasWhenCondition(assignments[whenEditor.index])"
+						class="d-flex justify-content-start align-items-center mt-3"
+					>
 						<button
-							v-if="hasWhenCondition(assignments[whenEditor.index])"
 							class="fxr-btn fxr-btn--sm fxr-btn--ghost text-danger p-0"
 							@click="clearWhenCondition"
 						>
 							<i class="fa fa-eraser me-1"></i>
 							{{ __("Clear Conditions") }}
-						</button>
-						<div v-else></div>
-						<button
-							class="fxr-btn fxr-btn--sm fxr-btn--primary"
-							@click="closeWhenConditionEditor"
-						>
-							{{ __("Done") }}
 						</button>
 					</div>
 				</div>
@@ -300,6 +297,7 @@ const {
 } = useFloatingDropdown({
 	minWidth: 480,
 	maxWidth: 800,
+	maxHeight: 600,
 	matchTriggerWidth: false,
 });
 
@@ -843,7 +841,8 @@ defineExpose({ validate });
 	border-radius: 12px;
 	padding: 8px;
 	background-color: var(--fxr-surface-soft);
-	max-height: 400px;
+	flex: 1;
+	min-height: 0;
 }
 
 /* Value mode toggle + control wrapper */

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
@@ -29,7 +29,19 @@
 
 		<!-- Horizontal Table Grid Header -->
 		<div v-if="assignments.length" class="assignment-grid-header">
-			<div class="grid-col-when">{{ __("Run If") }}</div>
+			<div
+				class="grid-col-when"
+				v-tippy="{
+					content: __(
+						'<b>Execution Condition</b><br/>This assignment will only run if the conditions are met. If left empty, it will always run.'
+					),
+					allowHTML: true,
+					placement: 'top-start',
+				}"
+			>
+				{{ __("Run If") }}
+				<i class="fa fa-question-circle ms-1 opacity-50"></i>
+			</div>
 			<div class="grid-col-target">{{ __("Target Field") }}</div>
 			<div class="grid-col-operator">{{ __("Operator") }}</div>
 			<div class="grid-col-value">{{ __("Value Expression") }}</div>
@@ -48,6 +60,13 @@
 							class="fxr-btn fxr-btn--sm w-100 when-toggle-btn"
 							:class="hasWhenCondition(assignment) ? 'is-active' : 'is-default'"
 							:disabled="isReadOnly"
+							v-tippy="{
+								content: __(
+									'<b>Execution Condition</b><br/>This assignment will only run if the conditions are met. If left empty, it will always run.'
+								),
+								allowHTML: true,
+								placement: 'left',
+							}"
 							@click="openWhenConditionEditor(index, $event)"
 						>
 							<i
@@ -209,21 +228,6 @@
 					:style="whenDropdownStyle"
 					@mousedown.stop
 				>
-					<div class="popover-header">
-						<div class="d-flex flex-column">
-							<div class="fw-bold" style="font-size: 11px; line-height: 1.2">
-								{{ __("Execution Condition") }}
-							</div>
-							<div class="text-muted" style="font-size: 9px; line-height: 1.2">
-								{{
-									__(
-										"This assignment will only run if the conditions below are met. If left empty, it will always run."
-									)
-								}}
-							</div>
-						</div>
-					</div>
-
 					<div class="condition-builder-wrap">
 						<ConditionBuilder
 							:modelValue="whenEditor.draft"
@@ -845,16 +849,11 @@ defineExpose({ validate });
 	border: 1px solid var(--fxr-border-strong);
 	border-radius: var(--fxr-radius-md);
 	box-shadow: var(--fxr-shadow-xl);
-	padding: 10px;
+	padding: 8px;
 	display: flex;
 	flex-direction: column;
 	z-index: 15000;
 	overflow: hidden;
-}
-
-.popover-header {
-	padding-bottom: 8px;
-	border-bottom: 1px solid var(--fxr-border-subtle);
 }
 
 .condition-builder-wrap {
@@ -862,7 +861,17 @@ defineExpose({ validate });
 	overflow-x: hidden;
 	flex: 1;
 	min-height: 0;
-	padding: 8px 0;
+}
+
+@media (max-width: 768px) {
+	.when-condition-popover {
+		width: calc(100vw - 24px) !important;
+		left: 12px !important;
+		max-height: 70vh !important;
+		bottom: 12px !important;
+		top: auto !important;
+		border-radius: var(--fxr-radius-lg) !important;
+	}
 }
 
 /* Value mode toggle + control wrapper */

--- a/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
@@ -1416,7 +1416,7 @@ onBeforeUnmount(() => {
 .fvc-tiptap-editor :deep(.ProseMirror) {
 	outline: none;
 	font-size: var(--fxr-input-font-size);
-	min-height: 20px;
+	min-height: 26px;
 	display: flex;
 	align-items: center;
 	white-space: nowrap;

--- a/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
@@ -1414,7 +1414,7 @@ onBeforeUnmount(() => {
 .fvc-tiptap-editor :deep(.ProseMirror) {
 	outline: none;
 	font-size: var(--fxr-input-font-size);
-	min-height: 30px;
+	min-height: 24px;
 	display: flex;
 	align-items: center;
 	white-space: nowrap;

--- a/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
@@ -1287,10 +1287,7 @@ onBeforeUnmount(() => {
 	display: flex;
 	align-items: center;
 	width: 100%;
-	height: var(--fxr-input-height, 32px);
 	min-height: var(--fxr-input-height, 32px);
-	max-height: var(--fxr-input-height, 32px);
-	overflow: hidden;
 	border: 1px solid var(--fxr-border);
 	border-radius: var(--fxr-radius-sm);
 	background-color: var(--fxr-bg-input);
@@ -1344,10 +1341,11 @@ onBeforeUnmount(() => {
 	overflow: hidden;
 }
 .fvc-editor-container {
-	padding: 2px 8px;
+	padding: 0 8px;
 	flex: 1;
 	position: relative;
-	overflow: hidden;
+	display: flex;
+	align-items: center;
 }
 .fvc-editor-wrapper {
 	width: 100%;
@@ -1416,7 +1414,7 @@ onBeforeUnmount(() => {
 .fvc-tiptap-editor :deep(.ProseMirror) {
 	outline: none;
 	font-size: var(--fxr-input-font-size);
-	min-height: 26px;
+	min-height: 30px;
 	display: flex;
 	align-items: center;
 	white-space: nowrap;

--- a/flexirule/public/js/flexirule/rule_builder/controls/ResolverTokenView.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/ResolverTokenView.vue
@@ -33,9 +33,11 @@ const handleUpdate = (config, details) => {
 	align-items: center;
 	vertical-align: middle;
 	line-height: 1;
+	padding: 2px 0;
 }
 
 .resolver-token-wrapper.is-selected :deep(.fxr-token) {
 	outline: 2px solid var(--fxr-accent);
+	outline-offset: 1px;
 }
 </style>

--- a/flexirule/public/js/flexirule/rule_builder/controls/ResolverTokenView.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/ResolverTokenView.vue
@@ -29,11 +29,9 @@ const handleUpdate = (config, details) => {
 
 <style scoped>
 .resolver-token-wrapper {
-	display: inline-flex;
-	align-items: center;
+	display: inline-block;
 	vertical-align: middle;
 	line-height: 1;
-	padding: 2px 0;
 }
 
 .resolver-token-wrapper.is-selected :deep(.fxr-token) {

--- a/flexirule/public/js/flexirule/rule_builder/controls/ResolverTokenView.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/ResolverTokenView.vue
@@ -29,10 +29,10 @@ const handleUpdate = (config, details) => {
 
 <style scoped>
 .resolver-token-wrapper {
-	display: inline-block;
-	vertical-align: top;
+	display: inline-flex;
+	align-items: center;
+	vertical-align: middle;
 	line-height: 1;
-	margin-top: 1px;
 }
 
 .resolver-token-wrapper.is-selected :deep(.fxr-token) {


### PR DESCRIPTION
Refactored the assignment execution condition UI in the rule builder. The condition editor now opens as a lightweight popover anchored to the 'Always Run' / 'Condition Set' button instead of a full-screen modal. This change includes a clear, non-technical explanation to help users understand how the condition affects the assignment. Logic was updated to utilize the existing `useFloatingDropdown` composable for consistent behavior across the application.

---
*PR created automatically by Jules for task [16805037553474250873](https://jules.google.com/task/16805037553474250873) started by @Sendipad*