### PR TITLE
Implement Unified Frontend Validation Engine

### DIFF
--- a/flexirule/public/css/controls.css
+++ b/flexirule/public/css/controls.css
@@ -56,6 +56,14 @@ html[data-theme="dark"] .fxr-control .fxr-label {
 	line-height: 1.4;
 }
 
+.fxr-error-msg {
+	font-size: 11px;
+	color: var(--fxr-text-danger);
+	margin-top: var(--spacing-xs);
+	line-height: 1.2;
+	font-weight: var(--fxr-weight-medium);
+}
+
 /* ─── Standard Input Group ─── */
 .fxr-input-group {
 	position: relative;
@@ -81,6 +89,23 @@ html[data-theme="dark"] .fxr-control .fxr-label {
 	transition:
 		border-color var(--fxr-transition-fast),
 		box-shadow var(--fxr-transition-fast);
+}
+
+/* Error State */
+.fxr-control.has-error .fxr-input,
+.fxr-control.has-error .fxr-select,
+.fxr-control.has-error :deep(.form-control),
+.fxr-control.has-error :deep(.combobox-wrapper),
+.fxr-control.has-error :deep(.fsvc-editor-container) {
+	border-color: var(--fxr-text-danger) !important;
+}
+
+.fxr-control.has-error .fxr-input:focus,
+.fxr-control.has-error .fxr-select:focus,
+.fxr-control.has-error :deep(.form-control:focus),
+.fxr-control.has-error :deep(.combobox-wrapper.is-focused),
+.fxr-control.has-error :deep(.fsvc-editor-container:focus-within) {
+	box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15) !important;
 }
 
 /* Premium Focus Glow on whole Input Group */

--- a/flexirule/public/js/flexirule/rule_builder/components/ActionFieldProperties.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/ActionFieldProperties.vue
@@ -21,6 +21,7 @@ import { toCodeString, fromCodeString, isJsonField } from "../utils/serializatio
 const props = defineProps({
 	nodeData: Object,
 	readOnly: Boolean,
+	showValidation: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(["update:field", "open:conditions", "open:config"]);
@@ -291,6 +292,23 @@ function needs_autocomplete(df) {
 	);
 }
 
+const controlRefs = ref([]);
+
+async function validate() {
+	const results = await Promise.all(
+		(controlRefs.value || []).map((ref) => {
+			if (ref && typeof ref.validate === "function") {
+				return ref.validate();
+			}
+			return { valid: true };
+		})
+	);
+	const errors = results.flatMap((r) => r.errors || []);
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({ validate });
+
 // Ensure Rule Action meta is loaded
 onMounted(async () => {
 	if (!frappe.get_meta("Rule Action")) {
@@ -328,6 +346,7 @@ onMounted(async () => {
 			<!-- Autocomplete / Link / Dynamic Link fields -->
 			<template v-else-if="needs_autocomplete(df)">
 				<ComboBoxControl
+					ref="controlRefs"
 					:df="{
 						...df,
 						reqd: is_mandatory(df),
@@ -342,12 +361,14 @@ onMounted(async () => {
 					:get_query="(txt) => get_autocomplete_options(df)"
 					:doc="nodeData"
 					:read_only="is_read_only(df)"
+					:showValidation="showValidation"
 					@update:modelValue="update_normalized_value(df, $event)"
 				/>
 			</template>
 
 			<template v-else>
 				<ControlFactory
+					ref="controlRefs"
 					:df="{
 						...df,
 						reqd: is_mandatory(df),
@@ -355,6 +376,7 @@ onMounted(async () => {
 					}"
 					:modelValue="get_normalized_value(df)"
 					:read_only="is_read_only(df)"
+					:showValidation="showValidation"
 					:doc="nodeData"
 					@update:modelValue="update_normalized_value(df, $event)"
 				/>

--- a/flexirule/public/js/flexirule/rule_builder/components/ActionFieldProperties.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/ActionFieldProperties.vue
@@ -10,7 +10,7 @@
   Follows Frappe Form Builder patterns.
 -->
 <script setup>
-import { computed, onMounted } from "vue";
+import { computed, onMounted, onBeforeUpdate } from "vue";
 import { useStore } from "../stores";
 import ControlFactory from "../controls/ControlFactory.vue";
 import ComboBoxControl from "../controls/ComboBoxControl.vue";
@@ -293,6 +293,9 @@ function needs_autocomplete(df) {
 }
 
 const controlRefs = ref([]);
+onBeforeUpdate(() => {
+	controlRefs.value = [];
+});
 
 async function validate() {
 	const results = await Promise.all(

--- a/flexirule/public/js/flexirule/rule_builder/components/StartNodeProperties.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/StartNodeProperties.vue
@@ -13,6 +13,7 @@ import ControlFactory from "../controls/ControlFactory.vue";
 const props = defineProps({
 	nodeData: Object,
 	readOnly: Boolean,
+	showValidation: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(["update:field", "open:conditions"]);
@@ -108,6 +109,36 @@ function update_permission_role(idx, value) {
 	update_field("permissions", permissions.value);
 }
 
+const controlRefs = ref([]);
+
+async function validate() {
+	const errors = [];
+
+	if (!props.nodeData?.trigger_type) {
+		errors.push(__("Trigger Type is required"));
+	}
+	if (!props.nodeData?.document_type) {
+		errors.push(__("Document Type is required"));
+	}
+
+	const results = await Promise.all(
+		(controlRefs.value || []).map((ref) => {
+			if (ref && typeof ref.validate === "function") {
+				return ref.validate();
+			}
+			return { valid: true };
+		})
+	);
+
+	results.forEach((res) => {
+		if (!res.valid) errors.push(...res.errors);
+	});
+
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({ validate });
+
 function add_skip_role() {
 	const role = pending_skip_role.value;
 	if (!role) return;
@@ -177,7 +208,7 @@ onMounted(async () => {
 		</div>
 
 		<!-- Trigger Type -->
-		<div class="form-group">
+		<div class="form-group" :class="{ 'has-error': showValidation && !nodeData?.trigger_type }">
 			<label class="control-label">{{ __("Trigger Type") }}</label>
 			<select
 				class="form-control"
@@ -195,10 +226,12 @@ onMounted(async () => {
 		<div class="form-group">
 			<label class="control-label">{{ __("Document Type") }}</label>
 			<ComboBoxControl
-				:df="{ fieldtype: 'Link', options: 'DocType', label: '' }"
+				ref="controlRefs"
+				:df="{ fieldtype: 'Link', options: 'DocType', label: '', reqd: 1 }"
 				:modelValue="nodeData?.document_type"
 				:read_only="readOnly"
 				:hideLabel="true"
+				:showValidation="showValidation"
 				@update:modelValue="(val) => update_field('document_type', val)"
 			/>
 		</div>

--- a/flexirule/public/js/flexirule/rule_builder/components/condition_builder/CollectionUI.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/condition_builder/CollectionUI.vue
@@ -16,7 +16,19 @@ const emit = defineEmits(["remove"]);
 
 const { addCondition, addGroup, onDrop } = inject("conditionActions");
 const parentVariableOptions = inject("variableOptions", ref([]));
+const showValidation = inject(
+	"showValidation",
+	computed(() => false)
+);
+const invalidNodes = inject(
+	"invalidNodes",
+	computed(() => [])
+);
 const store = useStore();
+
+const isInvalid = computed(() => {
+	return showValidation.value && invalidNodes.value.includes(props.node.id);
+});
 
 const isDragOver = ref(false);
 
@@ -271,7 +283,7 @@ onMounted(fetchChildMeta);
 </script>
 
 <template>
-	<div class="collection-ui">
+	<div class="collection-ui" :class="{ 'is-invalid': isInvalid }">
 		<!-- Header -->
 		<div class="collection-header">
 			<!-- Logic -->
@@ -374,6 +386,13 @@ onMounted(fetchChildMeta);
 	border-left: 4px solid var(--fxr-node-accent, var(--fxr-accent));
 	border-radius: var(--fxr-radius-lg);
 	padding: var(--fxr-space-3);
+	transition: all var(--fxr-transition-fast);
+}
+
+.collection-ui.is-invalid {
+	border-color: var(--fxr-text-danger) !important;
+	background-color: var(--fxr-danger-soft) !important;
+	box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.1);
 }
 
 .collection-header {

--- a/flexirule/public/js/flexirule/rule_builder/components/condition_builder/ConditionBuilder.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/condition_builder/ConditionBuilder.vue
@@ -89,12 +89,14 @@ import { ref, reactive, watch, nextTick, provide, computed, onMounted } from "vu
 import { useStore } from "../../stores";
 
 import ConditionNode from "./ConditionNode.vue";
+import { validateConditions } from "./condition_validator.js";
 
 const props = defineProps({
 	modelValue: { type: Object, default: () => ({ op: "and", conditions: [] }) },
 	docFields: { type: Array, default: () => [] },
 	variableOptions: { type: Array, default: () => [] },
 	readOnly: { type: Boolean, default: false },
+	isMandatory: { type: Boolean, default: true },
 });
 
 const emit = defineEmits(["update:modelValue"]);
@@ -273,11 +275,22 @@ async function loadOperatorConfig() {
 onMounted(loadOperatorConfig);
 
 const isDragOver = ref(false);
+const showValidation = ref(false);
+const invalidNodes = ref([]);
 
 function handleRootDrop() {
 	isDragOver.value = false;
 	onDrop(rootGroup);
 }
+
+function validate() {
+	showValidation.value = true;
+	const result = validateConditions(rootGroup, true, props.isMandatory);
+	invalidNodes.value = result.invalidNodes || [];
+	return result;
+}
+
+defineExpose({ validate });
 
 // Provide actions and config to all descendant components
 provide("conditionActions", {
@@ -303,6 +316,14 @@ provide("store", store);
 provide(
 	"readOnly",
 	computed(() => props.readOnly)
+);
+provide(
+	"showValidation",
+	computed(() => showValidation.value)
+);
+provide(
+	"invalidNodes",
+	computed(() => invalidNodes.value)
 );
 </script>
 

--- a/flexirule/public/js/flexirule/rule_builder/components/condition_builder/ConditionGroupUI.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/condition_builder/ConditionGroupUI.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { inject, ref } from "vue";
+import { inject, ref, computed } from "vue";
 /**
  * ConditionGroupUI - Nested group editor with AND/OR toggle
  */
@@ -14,6 +14,18 @@ const props = defineProps({
 const emit = defineEmits(["remove"]);
 
 const { addCondition, addGroup, addCollection, removeNode, onDrop } = inject("conditionActions");
+const showValidation = inject(
+	"showValidation",
+	computed(() => false)
+);
+const invalidNodes = inject(
+	"invalidNodes",
+	computed(() => [])
+);
+
+const isInvalid = computed(() => {
+	return showValidation.value && invalidNodes.value.includes(props.group.id);
+});
 
 const isDragOver = ref(false);
 
@@ -26,7 +38,10 @@ function handleDrop(e) {
 <template>
 	<div
 		class="condition-group-ui"
-		:class="{ 'drag-over': isDragOver }"
+		:class="{
+			'drag-over': isDragOver,
+			'is-invalid': isInvalid,
+		}"
 		@dragover.prevent.stop="isDragOver = true"
 		@dragleave.stop="isDragOver = false"
 		@drop.prevent.stop="handleDrop"
@@ -113,6 +128,13 @@ function handleDrop(e) {
 	border: 1px solid var(--fxr-border-subtle);
 	border-radius: var(--fxr-radius-lg);
 	padding: var(--fxr-space-3);
+	transition: all var(--fxr-transition-fast);
+}
+
+.condition-group-ui.is-invalid {
+	border-color: var(--fxr-text-danger);
+	background-color: var(--fxr-danger-soft);
+	box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.1);
 }
 
 .group-header {

--- a/flexirule/public/js/flexirule/rule_builder/components/condition_builder/SimpleCondition.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/condition_builder/SimpleCondition.vue
@@ -26,6 +26,18 @@ const operatorConfig = inject(
 
 const store = inject("store");
 const variableOptions = inject("variableOptions", ref([]));
+const showValidation = inject(
+	"showValidation",
+	computed(() => false)
+);
+const invalidNodes = inject(
+	"invalidNodes",
+	computed(() => [])
+);
+
+const isInvalid = computed(() => {
+	return showValidation.value && invalidNodes.value.includes(props.node.id);
+});
 
 // Dynamic Link State
 const dynamicLinkDocType = ref("");
@@ -297,7 +309,7 @@ watch(
 </script>
 
 <template>
-	<div class="simple-condition">
+	<div class="simple-condition" :class="{ 'is-invalid': isInvalid }">
 		<div class="condition-main-row">
 			<!-- Field -->
 			<div class="condition-col field-col">
@@ -398,6 +410,12 @@ watch(
 
 .simple-condition:hover {
 	border-color: var(--fxr-border-strong);
+}
+
+.simple-condition.is-invalid {
+	border-color: var(--fxr-text-danger) !important;
+	background-color: var(--fxr-danger-soft) !important;
+	box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.1);
 }
 
 .condition-main-row {

--- a/flexirule/public/js/flexirule/rule_builder/components/condition_builder/condition_validator.js
+++ b/flexirule/public/js/flexirule/rule_builder/components/condition_builder/condition_validator.js
@@ -3,88 +3,96 @@
  * Returns an object with { valid: boolean, message?: string }
  */
 export function validateConditions(node, isRoot = false, isMandatory = true) {
-	// 1. Check for Groups (including Root)
-	// A group is identified by the presence of a 'conditions' array
-	if (node.conditions !== undefined) {
-		if (!node.conditions || node.conditions.length === 0) {
-			// If it's an optional root group, empty is allowed
-			if (isRoot && !isMandatory) return { valid: true };
+	const errors = [];
+	const invalidNodes = new Set();
 
-			return {
-				valid: false,
-				message: isRoot
-					? __("Please add at least one condition.")
-					: __("Empty condition groups are not allowed."),
-			};
-		}
+	function walk(n, root = false, mandatory = true) {
+		let nodeValid = true;
 
-		for (const child of node.conditions) {
-			const result = validateConditions(child);
-			if (!result.valid) return result;
-		}
-	}
-	// 2. Check for Collections
-	// A collection is identified by the presence of a 'collection' field
-	else if (node.collection !== undefined) {
-		if (!node.collection) {
-			return {
-				valid: false,
-				message: __("Please select a table for the collection condition."),
-			};
-		}
-
-		if (!node.where || !node.where.conditions || node.where.conditions.length === 0) {
-			return {
-				valid: false,
-				message: __("Collection '{0}' must have at least one condition.").replace(
-					"{0}",
-					node.collection
-				),
-			};
-		}
-
-		const result = validateConditions(node.where);
-		if (!result.valid) return result;
-	}
-
-	// 3. Check for Simple Conditions (Field Comparison)
-	else if (node.left !== undefined) {
-		const fieldRef = node.left.ref || "";
-		if (!fieldRef || fieldRef.endsWith(".")) {
-			return {
-				valid: false,
-				message: __("Please select a valid field for the condition."),
-			};
-		}
-
-		if (!node.op) {
-			return {
-				valid: false,
-				message: __("Please select an operator for the condition."),
-			};
-		}
-
-		// Operators that don't need a value
-		const valueNotRequired = [
-			"is_set",
-			"is_not_set",
-			"is_submittable",
-			"is_empty",
-			"is_not_empty",
-		];
-		if (!valueNotRequired.includes(node.op)) {
-			const hasValue =
-				(node.right && node.right.value !== undefined && node.right.value !== "") ||
-				(node.right && node.right.ref);
-
-			if (!hasValue) {
-				return {
-					valid: false,
-					message: __("Please provide a value for field '{0}'.").replace("{0}", fieldRef),
-				};
+		// 1. Check for Groups (including Root)
+		if (n.conditions !== undefined) {
+			if (!n.conditions || n.conditions.length === 0) {
+				if (!(root && !mandatory)) {
+					errors.push(
+						root
+							? __("Please add at least one condition.")
+							: __("Empty condition groups are not allowed.")
+					);
+					nodeValid = false;
+				}
+			} else {
+				for (const child of n.conditions) {
+					if (!walk(child)) nodeValid = false;
+				}
 			}
 		}
+		// 2. Check for Collections
+		else if (n.collection !== undefined) {
+			if (!n.collection) {
+				errors.push(__("Please select a table for the collection condition."));
+				nodeValid = false;
+			}
+
+			if (!n.where || !n.where.conditions || n.where.conditions.length === 0) {
+				errors.push(
+					__("Collection '{0}' must have at least one condition.").replace(
+						"{0}",
+						n.collection || __("Unnamed")
+					)
+				);
+				nodeValid = false;
+			} else {
+				if (!walk(n.where)) nodeValid = false;
+			}
+		}
+		// 3. Check for Simple Conditions
+		else if (n.left !== undefined) {
+			const fieldRef = n.left.ref || "";
+			if (!fieldRef || fieldRef.endsWith(".")) {
+				errors.push(__("Please select a valid field for the condition."));
+				nodeValid = false;
+			}
+
+			if (!n.op) {
+				errors.push(__("Please select an operator for the condition."));
+				nodeValid = false;
+			}
+
+			const valueNotRequired = [
+				"is_set",
+				"is_not_set",
+				"is_submittable",
+				"is_empty",
+				"is_not_empty",
+			];
+			if (!valueNotRequired.includes(n.op)) {
+				const hasValue =
+					(n.right && n.right.value !== undefined && n.right.value !== "") ||
+					(n.right && n.right.ref);
+
+				if (!hasValue) {
+					errors.push(
+						__("Please provide a value for field '{0}'.").replace(
+							"{0}",
+							fieldRef || __("Unknown")
+						)
+					);
+					nodeValid = false;
+				}
+			}
+		}
+
+		if (!nodeValid && n.id) {
+			invalidNodes.add(n.id);
+		}
+		return nodeValid;
 	}
 
-	return { valid: true };
+	walk(node, isRoot, isMandatory);
+
+	return {
+		valid: errors.length === 0,
+		errors: [...new Set(errors)],
+		invalidNodes: Array.from(invalidNodes),
+	};
 }

--- a/flexirule/public/js/flexirule/rule_builder/components/node_configs/LoopNodeConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/node_configs/LoopNodeConfig.vue
@@ -2,9 +2,11 @@
 	<div class="loop-node-config">
 		<div class="form-group">
 			<ComboBoxControl
-				:df="{ label: __('Iterator (List)'), fieldtype: 'FieldPicker' }"
+				ref="iteratorRef"
+				:df="{ label: __('Iterator (List)'), fieldtype: 'FieldPicker', reqd: 1 }"
 				:options="listFields"
 				:modelValue="getJsonConfig('iterator')"
+				:showValidation="showValidation"
 				:trigger="'button'"
 				@update:modelValue="$emit('update-json-config', 'iterator', $event)"
 			/>
@@ -14,8 +16,10 @@
 		</div>
 		<div class="form-group">
 			<ControlFactory
+				ref="aliasRef"
 				:df="aliasFieldDf"
 				:modelValue="nodeData.return_variable"
+				:showValidation="showValidation"
 				@update:modelValue="updateReturnVariable"
 			/>
 			<div class="help-text text-muted" style="font-size: 11px">
@@ -33,6 +37,7 @@ import ComboBoxControl from "../../controls/ComboBoxControl.vue";
 
 const props = defineProps({
 	node: Object,
+	showValidation: { type: Boolean, default: false },
 });
 
 const store = useStore();
@@ -42,12 +47,15 @@ const loading = ref(false);
 const nodeData = computed(() => props.node?.data || {});
 
 const emit = defineEmits(["update-json-config"]);
+const iteratorRef = ref(null);
+const aliasRef = ref(null);
 
 const aliasFieldDf = computed(() => ({
 	fieldname: "return_variable",
 	fieldtype: "Data",
 	label: __("Item Alias"),
 	placeholder: "item",
+	reqd: 1,
 }));
 
 async function loadFields() {
@@ -112,12 +120,17 @@ function getJsonConfig(key, defaultVal = "") {
 	return config[key] !== undefined ? config[key] : defaultVal;
 }
 
-function validate() {
-	const iterator = getJsonConfig("iterator");
-	if (!iterator) {
-		return { valid: false, message: __("Iterator is required") };
+async function validate() {
+	const errors = [];
+	if (iteratorRef.value) {
+		const res = await iteratorRef.value.validate();
+		if (!res.valid) errors.push(...res.errors);
 	}
-	return { valid: true };
+	if (aliasRef.value) {
+		const res = await aliasRef.value.validate();
+		if (!res.valid) errors.push(...res.errors);
+	}
+	return { valid: errors.length === 0, errors };
 }
 
 defineExpose({ validate });

--- a/flexirule/public/js/flexirule/rule_builder/components/node_configs/SwitchNodeConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/node_configs/SwitchNodeConfig.vue
@@ -1,6 +1,9 @@
 <template>
 	<div class="switch-node-config">
-		<div class="form-group">
+		<div
+			class="form-group"
+			:class="{ 'has-error': showValidation && !getJsonConfig('expression') }"
+		>
 			<label>{{ __("Switch Expression (Python)") }}</label>
 			<textarea
 				class="form-control"
@@ -9,10 +12,22 @@
 				@input="$emit('update-json-config', 'expression', $event.target.value)"
 				placeholder="doc.category"
 			></textarea>
+			<div v-if="showValidation && !getJsonConfig('expression')" class="fxr-error-msg">
+				{{ __("Switch Expression is required") }}
+			</div>
 		</div>
 
-		<div class="form-group">
+		<div
+			class="form-group"
+			:class="{ 'has-error': showValidation && Object.keys(cases).length === 0 }"
+		>
 			<label>{{ __("Cases") }}</label>
+			<div
+				v-if="showValidation && Object.keys(cases).length === 0"
+				class="fxr-error-msg mb-2"
+			>
+				{{ __("At least one case is required") }}
+			</div>
 			<div class="case-list">
 				<div
 					v-for="(nodeId, val) in cases"
@@ -62,6 +77,7 @@ const props = defineProps({
 	nodeData: Object,
 	availableNodes: { type: Array, default: () => [] },
 	getNodeLabel: { type: Function, default: () => "" },
+	showValidation: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(["update-json-config"]);
@@ -94,11 +110,19 @@ function removeSwitchCase(val) {
 }
 
 function validate() {
+	const errors = [];
 	const expression = getJsonConfig("expression");
+	const currentCases = getJsonConfig("cases", {});
+
 	if (!expression) {
-		return { valid: false, message: __("Switch Expression is required") };
+		errors.push(__("Switch Expression is required"));
 	}
-	return { valid: true };
+
+	if (Object.keys(currentCases).length === 0) {
+		errors.push(__("At least one case is required for Switch"));
+	}
+
+	return { valid: errors.length === 0, errors };
 }
 
 defineExpose({ validate });

--- a/flexirule/public/js/flexirule/rule_builder/components/node_configs/WaitNodeConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/node_configs/WaitNodeConfig.vue
@@ -1,7 +1,10 @@
 <template>
 	<div class="wait-node-config">
 		<div class="form-row">
-			<div class="form-group col-md-6">
+			<div
+				class="form-group col-md-6"
+				:class="{ 'has-error': showValidation && getJsonConfig('value', 1) <= 0 }"
+			>
 				<label class="small text-muted">{{ __("Delay Value") }}</label>
 				<input
 					type="number"
@@ -9,6 +12,9 @@
 					:value="getJsonConfig('value', 1)"
 					@input="$emit('update-field', 'value', parseFloat($event.target.value))"
 				/>
+				<div v-if="showValidation && getJsonConfig('value', 1) <= 0" class="fxr-error-msg">
+					{{ __("Delay must be greater than 0") }}
+				</div>
 			</div>
 			<div class="form-group col-md-6">
 				<label class="small text-muted">{{ __("Unit") }}</label>
@@ -34,6 +40,7 @@
 <script setup>
 const props = defineProps({
 	nodeData: Object,
+	showValidation: { type: Boolean, default: false },
 });
 
 defineEmits(["update-field"]);
@@ -49,4 +56,15 @@ function getJsonConfig(key, defaultVal = "") {
 
 	return config[key] !== undefined ? config[key] : defaultVal;
 }
+
+function validate() {
+	const value = getJsonConfig("value", 1);
+	const errors = [];
+	if (value <= 0) {
+		errors.push(__("Delay value must be greater than 0"));
+	}
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({ validate });
 </script>

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/ConfigurationPanel.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/ConfigurationPanel.vue
@@ -17,6 +17,7 @@
 					ref="configRef"
 					:node="node"
 					:read_only="readOnly"
+					:showValidation="showValidation"
 					@update:field="on_update_field"
 				/>
 				<div v-else class="empty-config text-center">
@@ -52,6 +53,7 @@ import WaitConfig from "./types/WaitConfig.vue";
 const props = defineProps({
 	node: Object,
 	readOnly: Boolean,
+	showValidation: { type: Boolean, default: false },
 });
 
 const store = useStore();

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/FilterGroup.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/FilterGroup.vue
@@ -26,11 +26,12 @@
 						<div class="field-picker-container">
 							<ComboBoxControl
 								ref="fieldPickerRefs"
-								:df="{ label: '', fieldtype: 'FieldPicker' }"
+								:df="{ label: '', fieldtype: 'FieldPicker', reqd: 1 }"
 								:options="getFieldsForDoctype(row.doctype || doctype)"
 								:doctype="row.doctype || doctype"
 								:modelValue="row.field"
 								:read_only="readOnly"
+								:showValidation="showValidation"
 								:trigger="'button'"
 								:hideLabel="true"
 								:class="{
@@ -81,11 +82,12 @@
 													: { mode: 'static', value: '' }
 											"
 											:context="{
-												df: getControlFactorySchema(row),
+												df: { ...getControlFactorySchema(row), reqd: 1 },
 												operator: row.operator,
 												referenceDoctype: row.doctype || doctype,
 											}"
 											:disabled="readOnly"
+											:showValidation="showValidation"
 											:engine="store"
 											:doc="store?.rule_doc"
 											:variableOptions="effectiveVariableOptions"
@@ -103,11 +105,12 @@
 													: { mode: 'static', value: '' }
 											"
 											:context="{
-												df: getControlFactorySchema(row),
+												df: { ...getControlFactorySchema(row), reqd: 1 },
 												operator: row.operator,
 												referenceDoctype: row.doctype || doctype,
 											}"
 											:disabled="readOnly"
+											:showValidation="showValidation"
 											:engine="store"
 											:doc="store?.rule_doc"
 											:variableOptions="effectiveVariableOptions"
@@ -123,7 +126,7 @@
 									<FlexValueControl
 										v-model="row.value"
 										:context="{
-											df: getControlFactorySchema(row),
+											df: { ...getControlFactorySchema(row), reqd: 1 },
 											operator: row.operator,
 											referenceDoctype: row.doctype || doctype,
 										}"
@@ -132,6 +135,7 @@
 										:variableOptions="effectiveVariableOptions"
 										:disabled="readOnly"
 										:readOnly="readOnly"
+										:showValidation="showValidation"
 										@update:modelValue="() => emitUpdate()"
 									/>
 								</div>
@@ -195,6 +199,10 @@ const props = defineProps({
 	variableOptions: {
 		type: Array,
 		default: null,
+	},
+	showValidation: {
+		type: Boolean,
+		default: false,
 	},
 });
 
@@ -915,6 +923,43 @@ const isFieldValid = (fieldname, dt) => {
 	return fields.some((f) => f.value === fieldname);
 };
 
+function isValueEmpty(val) {
+	return val === undefined || val === null || val === "";
+}
+
+function validate() {
+	const errors = [];
+	filters.value.forEach((row, idx) => {
+		const n = idx + 1;
+		if (!row.field) {
+			errors.push(__("Filter #{0}: Field is required", [n]));
+		}
+		if (!row.operator) {
+			errors.push(__("Filter #{0}: Operator is required", [n]));
+		}
+		if (row.operator === "Between") {
+			if (
+				!Array.isArray(row.value) ||
+				row.value.length < 2 ||
+				isValueEmpty(row.value[0]?.value) ||
+				isValueEmpty(row.value[1]?.value)
+			) {
+				errors.push(__("Filter #{0}: Both values are required for Between", [n]));
+			}
+		} else if (row.operator !== "is") {
+			const structVal = row.value;
+			const isEmpty =
+				structVal?.mode === "static" ? isValueEmpty(structVal.value) : !structVal;
+			if (isEmpty) {
+				errors.push(__("Filter #{0}: Value is required", [n]));
+			}
+		}
+	});
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({ validate });
+
 watch(() => props.modelValue, syncFromProps, { deep: true });
 watch(
 	() => props.doctype,
@@ -1211,7 +1256,7 @@ onMounted(async () => {
 .filter-row-main :deep(select.form-control) {
 	appearance: none !important;
 	-webkit-appearance: none !important;
-	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E") !important;
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E") !important;
 	background-repeat: no-repeat !important;
 	background-position: right 6px center !important;
 	background-size: 12px !important;

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/InputPanel.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/InputPanel.vue
@@ -14,51 +14,63 @@
 				<div class="setup-controls">
 					<ControlFactory
 						v-if="showProcessName"
+						ref="processNameRef"
 						:df="processNameField"
 						:modelValue="node.data?.process_name"
 						:read_only="readOnly"
+						:showValidation="showValidation"
 						@update:modelValue="updateField('process_name', $event)"
 					/>
 
 					<ControlFactory
 						v-if="showOperation"
+						ref="operationRef"
 						:df="dynamicOperationField"
 						:modelValue="node.data?.operation"
 						:read_only="readOnly"
+						:showValidation="showValidation"
 						@update:modelValue="updateField('operation', $event)"
 					/>
 
 					<!-- Core Identity Fields -->
 					<ControlFactory
 						v-if="showReferenceDoctype"
+						ref="referenceDoctypeRef"
 						:df="referenceDoctypeField"
 						:modelValue="node.data?.reference_doctype"
 						:read_only="readOnly"
+						:showValidation="showValidation"
 						@update:modelValue="updateField('reference_doctype', $event)"
 					/>
 
 					<ControlFactory
 						v-if="showRuleField"
+						ref="ruleRef"
 						:df="ruleField"
 						:modelValue="node.data?.rule"
 						:read_only="readOnly"
+						:showValidation="showValidation"
 						@update:modelValue="updateField('rule', $event)"
 					/>
 
 					<!-- Secondary Setup -->
 					<ControlFactory
 						v-if="showReferenceDocname"
+						ref="referenceDocnameRef"
 						:df="referenceDocnameField"
 						:modelValue="node.data?.reference_docname"
 						:read_only="readOnly"
+						:showValidation="showValidation"
 						@update:modelValue="updateField('reference_docname', $event)"
 					/>
 
 					<ControlFactory
 						v-if="showInputSource"
+						ref="inputSourceRef"
 						:df="inputSourceField"
 						:modelValue="node.data?.input_source"
 						:read_only="readOnly"
+						:showValidation="showValidation"
 						@update:modelValue="updateField('input_source', $event)"
 					/>
 				</div>
@@ -260,6 +272,12 @@ import { insertIntoActiveTGC } from "../../utils/tgc_focus";
 import { copyText } from "../../../utils/clipboard";
 
 const variableSearchRef = ref(null);
+const processNameRef = ref(null);
+const operationRef = ref(null);
+const referenceDoctypeRef = ref(null);
+const ruleRef = ref(null);
+const referenceDocnameRef = ref(null);
+const inputSourceRef = ref(null);
 
 function focusSibling(e, direction) {
 	const el = e.target;
@@ -281,10 +299,24 @@ function focusSearch() {
 	});
 }
 
-defineExpose({
-	focusSearch,
-	validate: () => {
-		const errors = [];
+async function validate() {
+	const errors = [];
+
+	if (props.mode === "config") {
+		const controlRefs = [
+			processNameRef.value,
+			operationRef.value,
+			referenceDoctypeRef.value,
+			ruleRef.value,
+			referenceDocnameRef.value,
+			inputSourceRef.value,
+		].filter(Boolean);
+
+		const results = await Promise.all(controlRefs.map((c) => c.validate()));
+		results.forEach((res) => {
+			if (!res.valid) errors.push(...res.errors);
+		});
+
 		if (props.node?.data?.action_type === "Document Action") {
 			if (
 				props.node.data.operation === "Add Comment" &&
@@ -299,8 +331,13 @@ defineExpose({
 				errors.push(__("Create ToDo mode requires Reference DocType = ToDo"));
 			}
 		}
-		return { valid: errors.length === 0, errors };
-	},
+	}
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({
+	focusSearch,
+	validate,
 });
 import {
 	applyOutputPolicyDefaults,
@@ -317,6 +354,7 @@ import SubRuleNodeConfig from "../node_configs/SubRuleNodeConfig.vue";
 const props = defineProps({
 	node: Object,
 	readOnly: Boolean,
+	showValidation: { type: Boolean, default: false },
 	mode: { type: String, default: "config" }, // 'config' or 'variables'
 });
 

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/OutputPanel.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/OutputPanel.vue
@@ -12,9 +12,11 @@
 				<div class="storage-controls mt-2">
 					<div v-if="showMutationMode" class="storage-row">
 						<ControlFactory
+							ref="mutationModeRef"
 							:df="mutationModeField"
 							:modelValue="node.data?.mutation_mode"
 							:read_only="readOnly"
+							:showValidation="showValidation"
 							@update:modelValue="updateField('mutation_mode', $event)"
 						/>
 					</div>
@@ -22,26 +24,32 @@
 					<div v-if="showReturnVariable" class="storage-row">
 						<ComboBoxControl
 							v-if="useAutocompleteForReturnVariable"
+							ref="returnVariableRef"
 							:df="returnVariableField"
 							:modelValue="node.data?.return_variable"
 							:get_query="getReturnVariableOptions"
 							:read_only="readOnly"
+							:showValidation="showValidation"
 							@update:modelValue="updateField('return_variable', $event)"
 						/>
 						<ControlFactory
 							v-else
+							ref="returnVariableRef"
 							:df="returnVariableField"
 							:modelValue="node.data?.return_variable"
 							:read_only="readOnly"
+							:showValidation="showValidation"
 							@update:modelValue="updateField('return_variable', $event)"
 						/>
 					</div>
 
 					<div v-if="showReturnType" class="storage-row">
 						<ControlFactory
+							ref="returnTypeRef"
 							:df="returnTypeField"
 							:modelValue="node.data?.return_type"
 							:read_only="readOnly"
+							:showValidation="showValidation"
 							@update:modelValue="updateField('return_type', $event)"
 						/>
 					</div>
@@ -162,6 +170,7 @@ import {
 const props = defineProps({
 	node: Object,
 	readOnly: Boolean,
+	showValidation: { type: Boolean, default: false },
 });
 
 const store = useStore();
@@ -492,8 +501,23 @@ watch(
 	}
 );
 
-function validate() {
+const mutationModeRef = ref(null);
+const returnVariableRef = ref(null);
+const returnTypeRef = ref(null);
+
+async function validate() {
 	const errors = [];
+
+	const controlRefs = [
+		mutationModeRef.value,
+		returnVariableRef.value,
+		returnTypeRef.value,
+	].filter(Boolean);
+
+	const results = await Promise.all(controlRefs.map((c) => c.validate()));
+	results.forEach((res) => {
+		if (!res.valid) errors.push(...res.errors);
+	});
 
 	if (isReturnVariableMandatory.value && !props.node.data?.return_variable) {
 		errors.push(__("Result Variable Name is required when handling results"));
@@ -504,7 +528,7 @@ function validate() {
 			errors.push(__("Variable Assignment #{0} is incomplete", [idx + 1]));
 		}
 	});
-	return errors.length ? { valid: false, errors } : { valid: true };
+	return { valid: errors.length === 0, errors };
 }
 
 defineExpose({ validate });

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/RuleConfigModal.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/RuleConfigModal.vue
@@ -284,6 +284,7 @@
 										<ConditionStep
 											:node="draftNode"
 											:read-only="ruleStore.is_read_only"
+											:showValidation="showValidation"
 											:ref="panelRefs.logic"
 										/>
 									</div>
@@ -394,6 +395,7 @@
 																	:readOnly="
 																		ruleStore.is_read_only
 																	"
+																	:showValidation="showValidation"
 																	:ref="panelRefs.input"
 																	mode="config"
 																/>
@@ -404,6 +406,7 @@
 																	:readOnly="
 																		ruleStore.is_read_only
 																	"
+																	:showValidation="showValidation"
 																	:ref="panelRefs.config"
 																/>
 															</div>
@@ -441,6 +444,7 @@
 														v-show="!collapseOutputPanel"
 														:node="draftNode"
 														:readOnly="ruleStore.is_read_only"
+														:showValidation="showValidation"
 														:ref="panelRefs.output"
 													/>
 												</aside>
@@ -484,6 +488,7 @@
 														<InputPanel
 															:node="draftNode"
 															:readOnly="ruleStore.is_read_only"
+															:showValidation="showValidation"
 															mode="config"
 														/>
 													</section>
@@ -516,6 +521,7 @@
 														<ConfigurationPanel
 															:node="draftNode"
 															:readOnly="ruleStore.is_read_only"
+															:showValidation="showValidation"
 														/>
 													</section>
 
@@ -531,6 +537,7 @@
 														<OutputPanel
 															:node="draftNode"
 															:readOnly="ruleStore.is_read_only"
+															:showValidation="showValidation"
 														/>
 													</section>
 												</div>
@@ -586,7 +593,7 @@ const uiStore = useUIStore();
 // Legacy support
 const store = uiStore;
 
-const { draftNode, panelRefs, save, cancel, isDirty } = useRuleConfig(props, emit);
+const { draftNode, panelRefs, save, cancel, isDirty, showValidation } = useRuleConfig(props, emit);
 const {
 	activeTab: activeCompactTab,
 	tabs: compactTabs,

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/SchemaRenderer.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/SchemaRenderer.vue
@@ -16,17 +16,20 @@
 				class="form-group"
 				:class="{
 					'has-error':
+						showValidation &&
 						getFieldState(field, props.row ? props.row.name : 'root').reqd &&
 						!getValue(field),
 				}"
 			>
 				<ControlFactory
+					ref="controlRefs"
 					:df="
 						getNormalizedDf(field, props.row ? props.row.name : 'root', props.readOnly)
 					"
 					:modelValue="getValue(field)"
 					:doc="engine._get_context(row).doc"
 					:engine="engine"
+					:showValidation="showValidation"
 					@update:modelValue="updateValue(field, $event)"
 				/>
 			</div>
@@ -35,7 +38,7 @@
 </template>
 
 <script setup>
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import ControlFactory from "../../controls/ControlFactory.vue";
 import { useFieldNormalization } from "../../composables/useFieldNormalization";
 
@@ -43,8 +46,11 @@ const props = defineProps({
 	fields: { type: Array, default: () => [] },
 	engine: { type: Object, required: true },
 	readOnly: { type: Boolean, default: false },
+	showValidation: { type: Boolean, default: false },
 	row: { type: Object, default: null }, // If rendering for a child table row
 });
+
+const controlRefs = ref([]);
 
 const { getNormalizedDf, getFieldState } = useFieldNormalization(props.engine);
 
@@ -62,6 +68,21 @@ function getValue(field) {
 function updateValue(field, value) {
 	props.engine.handleFieldChange(field.fieldname, value, props.row);
 }
+
+async function validate() {
+	const results = await Promise.all(
+		(controlRefs.value || []).map((ref) => {
+			if (ref && typeof ref.validate === "function") {
+				return ref.validate();
+			}
+			return { valid: true };
+		})
+	);
+	const errors = results.flatMap((r) => r.errors || []);
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({ validate });
 </script>
 
 <style scoped>

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/SchemaRenderer.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/SchemaRenderer.vue
@@ -38,7 +38,7 @@
 </template>
 
 <script setup>
-import { computed, ref } from "vue";
+import { computed, ref, onBeforeUpdate } from "vue";
 import ControlFactory from "../../controls/ControlFactory.vue";
 import { useFieldNormalization } from "../../composables/useFieldNormalization";
 
@@ -51,6 +51,9 @@ const props = defineProps({
 });
 
 const controlRefs = ref([]);
+onBeforeUpdate(() => {
+	controlRefs.value = [];
+});
 
 const { getNormalizedDf, getFieldState } = useFieldNormalization(props.engine);
 

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
@@ -267,6 +267,7 @@ import { useActionConfig } from "../../../composables/useActionConfig";
 import ComboBoxControl from "../../../controls/ComboBoxControl.vue";
 import FlexValueControl from "../../../controls/FlexValueControl.vue";
 import ConditionBuilder from "../../condition_builder/ConditionBuilder.vue";
+import { validateConditions } from "../../condition_builder/condition_validator.js";
 import { compileSegmentsToJinja } from "../../../utils/text_generator";
 import { ASSIGNMENT_OPERATOR_METADATA } from "../../../../core/contracts.js";
 
@@ -574,7 +575,6 @@ function hasWhenCondition(assignment) {
 function getWhenConditionStatus(assignment) {
 	if (!hasWhenCondition(assignment)) return { isInvalid: false };
 
-	const { validateConditions } = require("../../../condition_builder/condition_validator.js");
 	const res = validateConditions(assignment.when_condition, true, true);
 
 	return { isInvalid: !res.valid };
@@ -714,9 +714,6 @@ async function validate() {
 			}
 		} else if (a.when_condition) {
 			// Deep validation of existing conditions
-			const {
-				validateConditions,
-			} = require("../../../condition_builder/condition_validator.js");
 			const res = validateConditions(a.when_condition, true, true);
 			if (!res.valid) {
 				errors.push(...res.errors.map((e) => __("Assignment #{0} Condition: {1}", [n, e])));

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/AssignmentConfig.vue
@@ -46,13 +46,20 @@
 					<div class="when-editor-cell" data-fxr-fieldname="assignments.run_if">
 						<button
 							class="fxr-btn fxr-btn--sm w-100 when-toggle-btn"
-							:class="hasWhenCondition(assignment) ? 'is-active' : 'is-default'"
+							:class="{
+								'is-active': hasWhenCondition(assignment),
+								'is-default': !hasWhenCondition(assignment),
+								'is-invalid':
+									showValidation && getWhenConditionStatus(assignment).isInvalid,
+							}"
 							:disabled="isReadOnly"
 							@click="openWhenConditionEditor(index)"
 						>
 							<i
 								:class="
-									hasWhenCondition(assignment)
+									getWhenConditionStatus(assignment).isInvalid
+										? 'fa fa-exclamation-triangle'
+										: hasWhenCondition(assignment)
 										? 'fa fa-filter'
 										: 'fa fa-play-circle-o'
 								"
@@ -60,7 +67,9 @@
 							></i>
 							<span class="truncate">
 								{{
-									hasWhenCondition(assignment)
+									getWhenConditionStatus(assignment).isInvalid
+										? __("Invalid Condition")
+										: hasWhenCondition(assignment)
 										? __("Condition Set")
 										: __("Always Run")
 								}}
@@ -73,11 +82,12 @@
 				<div class="grid-col-target">
 					<ComboBoxControl
 						data-fxr-fieldname="assignments.target"
-						:df="{ fieldtype: 'FieldPicker', label: '' }"
+						:df="{ fieldtype: 'FieldPicker', label: '', reqd: 1 }"
 						:modelValue="assignment.target"
 						:options="targetOptions"
 						:read_only="isReadOnly"
 						:hideLabel="true"
+						:showValidation="showValidation"
 						:trigger="'button'"
 						:placeholder="__('Target field/variable...')"
 						:allowCustomValue="false"
@@ -89,11 +99,12 @@
 				<div class="grid-col-operator">
 					<ComboBoxControl
 						data-fxr-fieldname="assignments.operator"
-						:df="{ fieldtype: 'Select', label: '' }"
+						:df="{ fieldtype: 'Select', label: '', reqd: 1 }"
 						:options="getAvailableOperators(assignment.target)"
 						:modelValue="assignment.operator"
 						:read_only="isReadOnly"
 						:hideLabel="true"
+						:showValidation="showValidation"
 						:trigger="'button'"
 						@update:modelValue="(val) => onOperatorChange(index, val)"
 					/>
@@ -107,15 +118,19 @@
 								class="flex-1 min-w-0"
 								data-fxr-fieldname="assignments.value"
 								:context="{
-									df:
-										targetOptions.find((o) => o.value === assignment.target) ||
-										{},
+									df: {
+										...(targetOptions.find(
+											(o) => o.value === assignment.target
+										) || {}),
+										reqd: 1,
+									},
 									target: assignment.target,
 									operator: assignment.operator,
 									referenceDoctype: getTargetDoctype(assignment.target),
 								}"
 								:modelValue="assignment.value"
 								:read_only="isReadOnly"
+								:showValidation="showValidation"
 								:engine="store"
 								:doc="store.rule_doc"
 								:variableOptions="variable_options"
@@ -217,6 +232,7 @@
 					</div>
 					<div class="condition-builder-wrap">
 						<ConditionBuilder
+							ref="conditionBuilderRef"
 							:modelValue="whenEditor.draft"
 							:docFields="whenConditionDocFields"
 							:variableOptions="variable_options"
@@ -275,6 +291,8 @@ const supportedTemplateModes = [
 	"add-key",
 ];
 const whenEditor = ref({ open: false, index: -1, draft: null });
+const conditionBuilderRef = ref(null);
+const showValidation = ref(false);
 
 // ─── Operator Helpers ────────────────────────────────────────────────────────
 
@@ -546,7 +564,20 @@ function onTargetChange(index, value) {
 }
 
 function hasWhenCondition(assignment) {
-	return !!(assignment?.when_condition && Array.isArray(assignment.when_condition.conditions));
+	return !!(
+		assignment?.when_condition &&
+		Array.isArray(assignment.when_condition.conditions) &&
+		assignment.when_condition.conditions.length > 0
+	);
+}
+
+function getWhenConditionStatus(assignment) {
+	if (!hasWhenCondition(assignment)) return { isInvalid: false };
+
+	const { validateConditions } = require("../../../condition_builder/condition_validator.js");
+	const res = validateConditions(assignment.when_condition, true, true);
+
+	return { isInvalid: !res.valid };
 }
 
 const whenConditionDocFields = computed(() =>
@@ -567,6 +598,24 @@ function openWhenConditionEditor(index) {
 		index,
 		draft: JSON.parse(JSON.stringify(current?.when_condition || fallback)),
 	};
+
+	// If shortcut to invalid condition, trigger validation immediately in the builder
+	if (showValidation.value && getWhenConditionStatus(current).isInvalid) {
+		nextTick(() => {
+			if (conditionBuilderRef.value) {
+				conditionBuilderRef.value.validate();
+				// Scroll to first error in the condition builder
+				nextTick(() => {
+					const firstError = document.querySelector(
+						".condition-builder-wrap .is-invalid"
+					);
+					if (firstError) {
+						firstError.scrollIntoView({ behavior: "smooth", block: "center" });
+					}
+				});
+			}
+		});
+	}
 }
 
 function closeWhenConditionEditor() {
@@ -635,15 +684,18 @@ function updateTemplate(index, value) {
 
 // ─── Validation ──────────────────────────────────────────────────────────────
 
-function validate() {
+async function validate() {
+	showValidation.value = true;
 	const errors = [];
+
 	assignments.value.forEach((a, idx) => {
 		const n = idx + 1;
 		if (!a.target) errors.push(__("Assignment #{0}: Target is required", [n]));
 		if (!a.operator) errors.push(__("Assignment #{0}: Operator is required", [n]));
 		if (needsValue(a.operator)) {
 			const ui = a.value;
-			if (!ui || (!Array.isArray(ui.segments) && !ui.mode)) {
+			const hasValue = ui?.mode === "static" ? ui.value !== "" : !!ui;
+			if (!ui || !hasValue) {
 				errors.push(
 					__("Assignment #{0}: Value is required for operator '{1}'", [n, a.operator])
 				);
@@ -653,7 +705,29 @@ function validate() {
 		if (a.target && !a.target.startsWith("doc.") && !a.target.startsWith("vars.")) {
 			errors.push(__("Assignment #{0}: Target must start with 'doc.' or 'vars.'", [n]));
 		}
+
+		// Validate nested conditions if editor is open for THIS assignment
+		if (whenEditor.value.open && whenEditor.value.index === idx && conditionBuilderRef.value) {
+			const res = conditionBuilderRef.value.validate();
+			if (!res.valid) {
+				errors.push(...res.errors.map((e) => __("Assignment #{0} Condition: {1}", [n, e])));
+			}
+		} else if (a.when_condition) {
+			// Deep validation of existing conditions
+			const {
+				validateConditions,
+			} = require("../../../condition_builder/condition_validator.js");
+			const res = validateConditions(a.when_condition, true, true);
+			if (!res.valid) {
+				errors.push(...res.errors.map((e) => __("Assignment #{0} Condition: {1}", [n, e])));
+			}
+		}
 	});
+
+	if (assignments.value.length === 0) {
+		errors.push(__("Please add at least one assignment."));
+	}
+
 	return { valid: errors.length === 0, errors };
 }
 
@@ -761,6 +835,13 @@ defineExpose({ validate });
 	color: var(--fxr-accent);
 	border: 1px solid var(--fxr-accent-border);
 	box-shadow: 0 0 0 1px var(--fxr-accent-soft);
+}
+
+.when-toggle-btn.is-invalid {
+	background-color: var(--fxr-danger-soft) !important;
+	color: var(--fxr-text-danger) !important;
+	border: 1px solid var(--fxr-border-danger) !important;
+	box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.1) !important;
 }
 
 .when-toggle-btn.is-active:hover {

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/ConditionStep.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/ConditionStep.vue
@@ -15,9 +15,15 @@
 
 		<div class="condition-builder-container">
 			<ConditionBuilder
+				ref="conditionBuilderRef"
 				:modelValue="localConditions"
 				:docFields="docFields"
 				:variableOptions="combinedVariableOptions"
+				:readOnly="readOnly || read_only"
+				:isMandatory="
+					props.node?.data?.action_type === 'Condition' ||
+					props.node?.type === 'Condition'
+				"
 				@update:modelValue="updateConditions"
 			/>
 		</div>
@@ -41,12 +47,15 @@ import { getConditionPayload } from "../../../utils/condition_payload";
 
 const props = defineProps({
 	node: Object,
+	readOnly: Boolean,
+	read_only: Boolean,
 });
 
 const store = useStore();
 const localConditions = ref({ op: "and", conditions: [] });
 const showOldDoc = ref(false);
 const variableFields = ref([]);
+const conditionBuilderRef = ref(null);
 
 /**
  * Hydrates conditions with ephemeral IDs for Vue reactivity.
@@ -322,15 +331,15 @@ watch(
 );
 
 function validate() {
+	if (conditionBuilderRef.value) {
+		return conditionBuilderRef.value.validate();
+	}
 	const type = props.node?.data?.action_type || props.node?.type;
 	// Only 'Condition' nodes MUST have a condition defined.
 	// For all other nodes, conditions are optional execution filters.
 	const isMandatory = type === "Condition";
 	const result = validateConditions(localConditions.value, true, isMandatory);
-	if (!result.valid) {
-		return { valid: false, errors: [result.message] };
-	}
-	return { valid: true, errors: [] };
+	return result;
 }
 
 defineExpose({

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/ConditionStep.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/ConditionStep.vue
@@ -20,6 +20,7 @@
 				:docFields="docFields"
 				:variableOptions="combinedVariableOptions"
 				:readOnly="readOnly || read_only"
+				:showValidation="showValidation"
 				:isMandatory="
 					props.node?.data?.action_type === 'Condition' ||
 					props.node?.type === 'Condition'
@@ -49,6 +50,7 @@ const props = defineProps({
 	node: Object,
 	readOnly: Boolean,
 	read_only: Boolean,
+	showValidation: { type: Boolean, default: false },
 });
 
 const store = useStore();

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/DocumentActionConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/DocumentActionConfig.vue
@@ -30,8 +30,10 @@
 						fieldtype: 'Small Text',
 						label: __('Permission Audit Reason'),
 						read_only: readOnly,
+						reqd: 1,
 					}"
 					:modelValue="node?.data?.permission_audit_reason"
+					:showValidation="showValidation"
 					@update:modelValue="(val) => update_action_key('permission_audit_reason', val)"
 				/>
 			</div>
@@ -55,27 +57,35 @@
 						v-if="assignToType === 'Value'"
 						:df="with_read_only(assignedToLinkField)"
 						:modelValue="stripBrackets(config.assigned_to)"
+						:showValidation="showValidation"
 						@update:modelValue="(val) => update_config_key('assigned_to', val)"
 					/>
 					<ComboBoxControl
 						v-else-if="assignToType === 'Variable'"
-						:df="{ fieldtype: 'Autocomplete', label: '' }"
+						:df="{
+							fieldtype: 'Autocomplete',
+							label: '',
+							reqd: requiredConfigKeys.includes('assigned_to') ? 1 : 0,
+						}"
 						:get_query="async () => variable_options"
 						:modelValue="stripBrackets(config.assigned_to)"
 						:read_only="readOnly"
 						:hideLabel="true"
+						:showValidation="showValidation"
 						@update:modelValue="(val) => update_config_key('assigned_to', `{${val}}`)"
 					/>
 					<ControlFactory
 						v-else
 						:df="with_read_only(assignedToExprField)"
 						:modelValue="config.assigned_to"
+						:showValidation="showValidation"
 						@update:modelValue="(val) => update_config_key('assigned_to', val)"
 					/>
 				</div>
 				<ControlFactory
 					:df="with_read_only(todoDescriptionField)"
 					:modelValue="config.description"
+					:showValidation="showValidation"
 					@update:modelValue="(val) => update_config_key('description', val)"
 				/>
 				<ControlFactory
@@ -94,6 +104,7 @@
 				<ControlFactory
 					:df="with_read_only(commentTextField)"
 					:modelValue="config.comment_text"
+					:showValidation="showValidation"
 					@update:modelValue="(val) => update_config_key('comment_text', val)"
 				/>
 			</template>
@@ -170,6 +181,8 @@ const props = defineProps({
 	node: Object,
 	readOnly: Boolean,
 });
+
+const showValidation = ref(false);
 
 const { config, variable_options, mode, reference_doctype, with_read_only, sync_config } =
 	useActionConfig(props);
@@ -491,24 +504,27 @@ watch(
 	{ immediate: true, deep: true }
 );
 
+function validate() {
+	showValidation.value = true;
+	const errors = [];
+	const requiredKeyLabels = {
+		assigned_to: __("Assigned To"),
+		description: __("Description"),
+		comment_text: __("Comment Text"),
+	};
+	for (const key of requiredConfigKeys.value) {
+		if (!config[key]) {
+			errors.push(__("{0} is required").replace("{0}", requiredKeyLabels[key] || key));
+		}
+	}
+	if (showMapper.value && !config.resource_mapper_ui && !hasLegacyMapperConfig(config)) {
+		errors.push(__("Resource Mapper configuration is required for {0}", [mode.value]));
+	}
+	return { valid: errors.length === 0, errors };
+}
+
 defineExpose({
-	validate: () => {
-		const errors = [];
-		const requiredKeyLabels = {
-			assigned_to: __("Assigned To"),
-			description: __("Description"),
-			comment_text: __("Comment Text"),
-		};
-		for (const key of requiredConfigKeys.value) {
-			if (!config[key]) {
-				errors.push(__("{0} is required").replace("{0}", requiredKeyLabels[key] || key));
-			}
-		}
-		if (showMapper.value && !config.resource_mapper_ui && !hasLegacyMapperConfig(config)) {
-			errors.push(__("Resource Mapper configuration is required for {0}", [mode.value]));
-		}
-		return { valid: errors.length === 0, errors };
-	},
+	validate,
 });
 </script>
 

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/DocumentActionConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/DocumentActionConfig.vue
@@ -150,6 +150,7 @@
 					:sourceOptions="variable_options"
 					:read_only="readOnly"
 					:hideLabel="true"
+					:showValidation="showValidation"
 					@update:modelValue="update_mapper_ui"
 				/>
 
@@ -159,6 +160,7 @@
 					:sourceSchema="sourceSchema"
 					:targetSchema="targetSchema"
 					:readOnly="readOnly"
+					:showValidation="showValidation"
 					@update:modelValue="update_visual_mappings"
 				/>
 			</div>

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/LoopConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/LoopConfig.vue
@@ -1,12 +1,18 @@
 <template>
 	<div class="loop-config">
-		<LoopNodeConfig :node="node" @update-json-config="updateJsonConfig" />
+		<LoopNodeConfig
+			ref="loopNodeRef"
+			:node="node"
+			:showValidation="showValidation"
+			@update-json-config="updateJsonConfig"
+		/>
 		<hr />
-		<ConditionStep :node="node" />
+		<ConditionStep ref="conditionStepRef" :node="node" :showValidation="showValidation" />
 	</div>
 </template>
 
 <script setup>
+import { ref } from "vue";
 import { useStore } from "../../../stores";
 import { fromCodeString } from "../../../utils/serialization";
 import LoopNodeConfig from "../../node_configs/LoopNodeConfig.vue";
@@ -14,9 +20,12 @@ import ConditionStep from "./ConditionStep.vue";
 
 const props = defineProps({
 	node: Object,
+	showValidation: { type: Boolean, default: false },
 });
 
 const store = useStore();
+const loopNodeRef = ref(null);
+const conditionStepRef = ref(null);
 
 function updateJsonConfig(key, val) {
 	if (!props.node.data) return;
@@ -34,4 +43,19 @@ function updateJsonConfig(key, val) {
 		store.mark_dirty();
 	}
 }
+
+async function validate() {
+	const errors = [];
+	if (loopNodeRef.value && typeof loopNodeRef.value.validate === "function") {
+		const res = await loopNodeRef.value.validate();
+		if (!res.valid) errors.push(...res.errors);
+	}
+	if (conditionStepRef.value && typeof conditionStepRef.value.validate === "function") {
+		const res = await conditionStepRef.value.validate();
+		if (!res.valid) errors.push(...res.errors);
+	}
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({ validate });
 </script>

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/NotifyConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/NotifyConfig.vue
@@ -10,80 +10,55 @@
 		<div v-else class="config-container">
 			<div class="config-section section-card">
 				<div v-if="is_email" class="form-group mb-3">
-					<label class="form-label"
-						>{{ __("Subject") }}
-						<span v-if="isConfigKeyRequired('subject')" class="text-danger"
-							>*</span
-						></label
-					>
 					<ControlFactory
 						:df="with_read_only(subjectField)"
 						:modelValue="config.subject"
+						:showValidation="showValidation"
 						@update:modelValue="(val) => update_config_key('subject', val)"
 					/>
 				</div>
 
 				<div v-if="is_email" class="form-group mb-3">
-					<label class="form-label"
-						>{{ __("Recipients") }}
-						<span v-if="isConfigKeyRequired('recipients')" class="text-danger"
-							>*</span
-						></label
-					>
 					<ControlFactory
 						:df="with_read_only(recipientsField)"
 						:modelValue="config.recipients"
+						:showValidation="showValidation"
 						@update:modelValue="(val) => update_config_key('recipients', val)"
 					/>
 				</div>
 
 				<div v-if="is_system_notification" class="form-group mb-3">
-					<label class="form-label"
-						>{{ __("Subject") }}
-						<span v-if="isConfigKeyRequired('subject')" class="text-danger"
-							>*</span
-						></label
-					>
 					<ControlFactory
 						:df="with_read_only(subjectField)"
 						:modelValue="config.subject"
+						:showValidation="showValidation"
 						@update:modelValue="(val) => update_config_key('subject', val)"
 					/>
 				</div>
 
 				<div v-if="is_system_notification" class="form-group mb-3">
-					<label class="form-label">{{ __("For User") }}</label>
 					<ControlFactory
 						:df="with_read_only(forUserField)"
 						:modelValue="config.for_user"
+						:showValidation="showValidation"
 						@update:modelValue="(val) => update_config_key('for_user', val)"
 					/>
 				</div>
 
 				<div v-if="is_provider" class="form-group mb-3">
-					<label class="form-label"
-						>{{ __("Provider") }}
-						<span v-if="isConfigKeyRequired('provider')" class="text-danger"
-							>*</span
-						></label
-					>
 					<ControlFactory
 						:df="with_read_only(providerField)"
 						:modelValue="config.provider"
+						:showValidation="showValidation"
 						@update:modelValue="(val) => update_config_key('provider', val)"
 					/>
 				</div>
 
 				<div v-if="is_provider" class="form-group mb-3">
-					<label class="form-label"
-						>{{ __("Recipient") }}
-						<span v-if="isConfigKeyRequired('recipient')" class="text-danger"
-							>*</span
-						></label
-					>
 					<ControlFactory
 						:df="with_read_only(recipientField)"
 						:modelValue="config.recipient"
+						:showValidation="showValidation"
 						@update:modelValue="(val) => update_config_key('recipient', val)"
 					/>
 				</div>
@@ -92,6 +67,7 @@
 					<ControlFactory
 						:df="with_read_only(textGeneratorField)"
 						:modelValue="config.text_generator_ui"
+						:showValidation="showValidation"
 						@update:modelValue="update_template_ui"
 					/>
 				</div>
@@ -110,7 +86,7 @@
 </template>
 
 <script setup>
-import { computed, watch } from "vue";
+import { computed, watch, ref } from "vue";
 import { fromCodeString } from "../../../utils/serialization";
 import { useActionConfig } from "../../../composables/useActionConfig";
 import ControlFactory from "../../../controls/ControlFactory.vue";
@@ -122,6 +98,8 @@ const props = defineProps({
 	node: Object,
 	readOnly: Boolean,
 });
+
+const showValidation = ref(false);
 
 const { config, variable_options, with_read_only, sync_config, update_action_field } =
 	useActionConfig(props);
@@ -254,6 +232,7 @@ watch(
 );
 
 function validate() {
+	showValidation.value = true;
 	const errors = [];
 	const ui = config.text_generator_ui;
 	if (!ui || !Array.isArray(ui.segments) || !ui.segments.length) {

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/ProcessConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/ProcessConfig.vue
@@ -47,7 +47,11 @@
 			</div>
 
 			<div v-show="view === 'form'">
-				<SchemaRenderer :fields="engine.normalized_fields" :engine="engine" />
+				<SchemaRenderer
+					:fields="engine.normalized_fields"
+					:engine="engine"
+					:showValidation="showValidation"
+				/>
 			</div>
 
 			<div v-if="view === 'visual'" class="process-config-visual">
@@ -84,6 +88,7 @@ import TransformControl from "../../../controls/TransformControl.vue";
 
 const props = defineProps({
 	node: Object,
+	showValidation: { type: Boolean, default: false },
 });
 
 const store = useStore();

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/QueryRecordsConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/QueryRecordsConfig.vue
@@ -41,9 +41,11 @@
 				<div class="sub-section section-subcard">
 					<h6>{{ __("Filters") }}</h6>
 					<FilterGroup
+						ref="filterGroupRef"
 						:doctype="reference_doctype"
 						:modelValue="config.filters"
 						:readOnly="readOnly"
+						:showValidation="showValidation"
 						:nodeId="node?.id"
 						:variableOptions="variable_options"
 						@update:modelValue="(val) => update_config_key('filters', val)"
@@ -212,9 +214,11 @@
 				>
 					<h6>{{ __("Filters") }}</h6>
 					<FilterGroup
+						ref="filterGroupRef"
 						:doctype="reference_doctype"
 						:modelValue="config.filters"
 						:readOnly="readOnly"
+						:showValidation="showValidation"
 						:nodeId="node?.id"
 						:variableOptions="variable_options"
 						@update:modelValue="(val) => update_config_key('filters', val)"
@@ -226,9 +230,11 @@
 				<div class="sub-section section-subcard">
 					<h6>{{ __("Filters") }}</h6>
 					<FilterGroup
+						ref="filterGroupRef"
 						:doctype="reference_doctype"
 						:modelValue="config.filters"
 						:readOnly="readOnly"
+						:showValidation="showValidation"
 						:nodeId="node?.id"
 						:variableOptions="variable_options"
 						@update:modelValue="(val) => update_config_key('filters', val)"
@@ -322,9 +328,11 @@
 				<div class="sub-section section-subcard">
 					<h6>{{ __("Filters") }}</h6>
 					<FilterGroup
+						ref="filterGroupRef"
 						:doctype="reference_doctype"
 						:modelValue="config.filters"
 						:readOnly="readOnly"
+						:showValidation="showValidation"
 						:nodeId="node?.id"
 						:variableOptions="variable_options"
 						@update:modelValue="(val) => update_config_key('filters', val)"
@@ -529,6 +537,7 @@ const report_filter_types = reactive({});
 const test_status = ref("");
 const is_single_doctype = ref(false);
 const showValidation = ref(false);
+const filterGroupRef = ref(null);
 
 // Internal flag to prevent recursive sync loops
 let is_internal_update = false;
@@ -1240,9 +1249,15 @@ watch(
 	{ deep: true }
 );
 
-function validate() {
+async function validate() {
 	showValidation.value = true;
 	const errors = [];
+
+	// Validate filters if applicable for the current mode
+	if (filterGroupRef.value && typeof filterGroupRef.value.validate === "function") {
+		const res = await filterGroupRef.value.validate();
+		if (!res.valid) errors.push(...res.errors);
+	}
 
 	if (mode.value === "Query Doc") {
 		const strategy = config.fetch_strategy || "Get doc";

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/QueryRecordsConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/QueryRecordsConfig.vue
@@ -117,6 +117,7 @@
 							<ControlFactory
 								:df="with_read_only(limitTypeField)"
 								:modelValue="config.limit_type || 'Custom Limit'"
+								:showValidation="showValidation"
 								@update:modelValue="(val) => update_config_key('limit_type', val)"
 							/>
 						</div>
@@ -127,6 +128,7 @@
 							<ControlFactory
 								:df="with_read_only(limitField)"
 								:modelValue="config.limit"
+								:showValidation="showValidation"
 								@update:modelValue="(val) => update_config_key('limit', val)"
 							/>
 						</div>
@@ -177,8 +179,9 @@
 								:modelValue="config.doctype_name"
 								:variableOptions="variable_options"
 								:readOnly="readOnly"
+								:showValidation="showValidation"
 								:context="{
-									df: { fieldtype: 'Link', options: 'DocType' },
+									df: { fieldtype: 'Link', options: 'DocType', reqd: 1 },
 								}"
 								@update:modelValue="update_doctype_name"
 							/>
@@ -192,8 +195,9 @@
 								:modelValue="config.docname"
 								:variableOptions="variable_options"
 								:readOnly="readOnly"
+								:showValidation="showValidation"
 								:context="{
-									df: { fieldtype: 'Link', options: reference_doctype },
+									df: { fieldtype: 'Link', options: reference_doctype, reqd: 1 },
 									referenceDoctype: reference_doctype,
 								}"
 								@update:modelValue="(val) => update_config_key('docname', val)"
@@ -524,6 +528,7 @@ const report_filter_values = reactive({});
 const report_filter_types = reactive({});
 const test_status = ref("");
 const is_single_doctype = ref(false);
+const showValidation = ref(false);
 
 // Internal flag to prevent recursive sync loops
 let is_internal_update = false;
@@ -1235,8 +1240,60 @@ watch(
 	{ deep: true }
 );
 
+function validate() {
+	showValidation.value = true;
+	const errors = [];
+
+	if (mode.value === "Query Doc") {
+		const strategy = config.fetch_strategy || "Get doc";
+		const is_single = strategy === "Get Single DocType" || is_single_doctype.value;
+
+		if (!config.doctype_name) {
+			errors.push(__("Target DocType is required for Query Doc"));
+		}
+
+		if (!is_single && !config.docname) {
+			errors.push(__("Document Name (ID) is required for this strategy"));
+		}
+	}
+
+	if (mode.value === "Query List") {
+		if (!reference_doctype.value) {
+			errors.push(__("Reference DocType is required for Query List"));
+		}
+		if (config.limit_type === "Custom Limit" && !config.limit) {
+			errors.push(__("Custom Limit Number is required"));
+		}
+	}
+
+	if (mode.value === "Query Report") {
+		if (!props.node?.data?.reference_docname) {
+			errors.push(__("Report Name is required"));
+		}
+	}
+
+	if (["Sum", "Average", "Min", "Max"].includes(mode.value)) {
+		if (!config.field) {
+			errors.push(__("Field to Aggregate is required"));
+		}
+	}
+
+	if (mode.value === "Group By") {
+		if (!config.group_by_field) errors.push(__("Group By Field is required"));
+		if (!config.agg_field) errors.push(__("Aggregate Field is required"));
+		if (!config.agg_function) errors.push(__("Aggregate Function is required"));
+	}
+
+	// 4. Permission Audit Reason
+	if (props.node?.data?.skip_permissions && !props.node?.data?.permission_audit_reason) {
+		errors.push(__("Permission Audit Reason is required when bypassing permissions."));
+	}
+
+	return { valid: errors.length === 0, errors };
+}
+
 defineExpose({
-	validate: () => ({ valid: true }),
+	validate,
 });
 </script>
 

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/RaiseErrorConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/RaiseErrorConfig.vue
@@ -5,6 +5,7 @@
 				<ControlFactory
 					:df="with_read_only(errorTypeField)"
 					:modelValue="config.error_type || 'Validation Error'"
+					:showValidation="showValidation"
 					@update:modelValue="(val) => update_config_key('error_type', val)"
 				/>
 			</div>
@@ -13,6 +14,7 @@
 				<ControlFactory
 					:df="with_read_only(errorTitleField)"
 					:modelValue="config.error_title"
+					:showValidation="showValidation"
 					@update:modelValue="(val) => update_config_key('error_title', val)"
 				/>
 			</div>
@@ -21,6 +23,7 @@
 				<ControlFactory
 					:df="with_read_only(errorCodeField)"
 					:modelValue="config.error_code"
+					:showValidation="showValidation"
 					@update:modelValue="(val) => update_config_key('error_code', val)"
 				/>
 			</div>
@@ -29,6 +32,7 @@
 				<ControlFactory
 					:df="with_read_only(textGeneratorField)"
 					:modelValue="config.text_generator_ui"
+					:showValidation="showValidation"
 					@update:modelValue="update_template_ui"
 				/>
 			</div>
@@ -37,7 +41,7 @@
 </template>
 
 <script setup>
-import { computed, watch } from "vue";
+import { computed, watch, ref } from "vue";
 import { fromCodeString } from "../../../utils/serialization";
 import { useActionConfig } from "../../../composables/useActionConfig";
 import ControlFactory from "../../../controls/ControlFactory.vue";
@@ -49,6 +53,8 @@ const props = defineProps({
 	node: Object,
 	readOnly: Boolean,
 });
+
+const showValidation = ref(false);
 
 const { config, variable_options, with_read_only, sync_config, update_action_field, store } =
 	useActionConfig(props);
@@ -159,6 +165,7 @@ watch(
 );
 
 function validate() {
+	showValidation.value = true;
 	const errors = [];
 	const ui = config.text_generator_ui;
 	if (

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/SubRuleConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/SubRuleConfig.vue
@@ -30,8 +30,10 @@
 						fieldtype: 'Small Text',
 						label: __('Permission Audit Reason'),
 						read_only: read_only,
+						reqd: 1,
 					}"
 					:modelValue="node?.data?.permission_audit_reason"
+					:showValidation="showValidation"
 					@update:modelValue="(val) => update_action_key('permission_audit_reason', val)"
 				/>
 			</div>
@@ -142,6 +144,7 @@ import ControlFactory from "../../../controls/ControlFactory.vue";
 const props = defineProps({
 	node: Object,
 	read_only: Boolean,
+	showValidation: { type: Boolean, default: false },
 });
 
 const store = useStore();
@@ -245,16 +248,21 @@ function load_local_config() {
 }
 
 function validate() {
+	const errors = [];
 	const incomplete = mapping_rows.value.find(
 		(row) => (row.source && !row.target) || (!row.source && row.target)
 	);
 	if (incomplete) {
-		frappe.msgprint(
+		errors.push(
 			__("Each input mapping row must include both Parent Variable and Sub-Rule Param.")
 		);
-		return false;
 	}
-	return true;
+
+	if (props.node?.data?.skip_permissions && !props.node?.data?.permission_audit_reason) {
+		errors.push(__("Permission Audit Reason is required when bypassing permissions."));
+	}
+
+	return { valid: errors.length === 0, errors };
 }
 
 watch(

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/SubRuleConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/SubRuleConfig.vue
@@ -84,6 +84,7 @@
 								:get_query="get_variable_options"
 								:read_only="read_only"
 								:hideLabel="true"
+								:showValidation="showValidation"
 								@update:modelValue="sync_local_config"
 							/>
 						</div>
@@ -125,6 +126,7 @@
 						:sourceSchema="source_schema"
 						:targetSchema="target_schema"
 						:readOnly="read_only"
+						:showValidation="showValidation"
 						@update:modelValue="update_visual_mappings"
 					/>
 				</div>

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/SwitchConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/SwitchConfig.vue
@@ -1,25 +1,29 @@
 <template>
 	<div class="switch-config">
 		<SwitchNodeConfig
+			ref="switchNodeRef"
 			:nodeData="node.data"
 			:availableNodes="availableNodes"
 			:getNodeLabel="getNodeLabel"
+			:showValidation="showValidation"
 			@update-json-config="updateJsonConfig"
 		/>
 	</div>
 </template>
 
 <script setup>
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { useStore } from "../../../stores";
 import { fromCodeString } from "../../../utils/serialization";
 import SwitchNodeConfig from "../../node_configs/SwitchNodeConfig.vue";
 
 const props = defineProps({
 	node: Object,
+	showValidation: { type: Boolean, default: false },
 });
 
 const store = useStore();
+const switchNodeRef = ref(null);
 
 const availableNodes = computed(() => {
 	return (store.nodes || [])
@@ -75,4 +79,13 @@ function syncEdges(cases) {
 		}
 	});
 }
+
+async function validate() {
+	if (switchNodeRef.value && typeof switchNodeRef.value.validate === "function") {
+		return await switchNodeRef.value.validate();
+	}
+	return { valid: true };
+}
+
+defineExpose({ validate });
 </script>

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/WaitConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/WaitConfig.vue
@@ -1,12 +1,15 @@
 <script setup>
+import { ref } from "vue";
 import { fromCodeString } from "../../../utils/serialization";
 import WaitNodeConfig from "../../node_configs/WaitNodeConfig.vue";
 
 const props = defineProps({
 	node: Object,
+	showValidation: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(["update:field"]);
+const waitNodeRef = ref(null);
 
 function updateJsonConfig(key, val) {
 	// This component handles the 'config' field specifically
@@ -18,10 +21,24 @@ function updateJsonConfig(key, val) {
 	// Internal state: config is Object
 	emit("update:field", "config", config);
 }
+
+function validate() {
+	if (waitNodeRef.value && typeof waitNodeRef.value.validate === "function") {
+		return waitNodeRef.value.validate();
+	}
+	return { valid: true };
+}
+
+defineExpose({ validate });
 </script>
 
 <template>
 	<div class="wait-config">
-		<WaitNodeConfig :nodeData="node.data" @update-field="updateJsonConfig" />
+		<WaitNodeConfig
+			ref="waitNodeRef"
+			:nodeData="node.data"
+			:showValidation="showValidation"
+			@update-field="updateJsonConfig"
+		/>
 	</div>
 </template>

--- a/flexirule/public/js/flexirule/rule_builder/composables/useRuleConfig.js
+++ b/flexirule/public/js/flexirule/rule_builder/composables/useRuleConfig.js
@@ -13,6 +13,7 @@ import { getContract, validateAgainstContract } from "../../core/contracts.js";
 export function useRuleConfig(props, emit) {
 	const store = useStore();
 	const draftNode = ref(null);
+	const showValidation = ref(false);
 	const config = computed(() => draftNode.value?.data || {});
 
 	// Capture initial draft state after a short delay to allow background sync to settle
@@ -63,6 +64,7 @@ export function useRuleConfig(props, emit) {
 	 * Checks all panels and returns { valid, errors }.
 	 */
 	async function validate() {
+		showValidation.value = true;
 		const errors = [];
 		const actionType = draftNode.value?.data?.action_type || draftNode.value?.type;
 		const contract = actionType ? getContract(actionType) : null;
@@ -136,6 +138,15 @@ export function useRuleConfig(props, emit) {
 				message: `<ul class="text-left" style="list-style-type: disc; padding-left: 20px;">${message}</ul>`,
 				indicator: "red",
 			});
+
+			// Scroll to first error
+			nextTick(() => {
+				const firstError = document.querySelector(".has-error, .is-invalid");
+				if (firstError) {
+					firstError.scrollIntoView({ behavior: "smooth", block: "center" });
+				}
+			});
+
 			return false;
 		}
 
@@ -172,6 +183,7 @@ export function useRuleConfig(props, emit) {
 			if (isOpen && newNode) {
 				createDraft();
 				initialDraftState.value = null;
+				showValidation.value = false;
 
 				// Capture baseline state after background discovery (schema, profiles, etc.) settles.
 				// We increase this to 1000ms to ensure all async normalization and schema
@@ -191,6 +203,7 @@ export function useRuleConfig(props, emit) {
 		config,
 		isDirty,
 		panelRefs,
+		showValidation,
 		updateField,
 		validate,
 		save,

--- a/flexirule/public/js/flexirule/rule_builder/controls/CheckControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/CheckControl.vue
@@ -1,15 +1,40 @@
 <script setup>
-import { ref, useSlots } from "vue";
-const props = defineProps(["df", "modelValue", "read_only", "hideLabel"]);
-defineEmits(["update:modelValue"]);
+import { ref, useSlots, computed } from "vue";
+const props = defineProps({
+	df: Object,
+	modelValue: [Boolean, Number],
+	read_only: Boolean,
+	hideLabel: Boolean,
+	showValidation: { type: Boolean, default: false },
+});
+const emit = defineEmits(["update:modelValue"]);
 let slots = useSlots();
+
+const isValid = computed(() => {
+	if (!props.df?.reqd) return true;
+	return !!props.modelValue;
+});
+
+function validate() {
+	const errors = [];
+	if (!isValid.value) {
+		errors.push(__("{0} must be checked").replace("{0}", props.df?.label || __("Field")));
+	}
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({ validate });
 const showTooltip = ref(false);
 </script>
 
 <template>
 	<div
 		class="control fxr-control checkbox"
-		:class="{ editable: slots.label, 'no-label': hideLabel }"
+		:class="{
+			editable: slots.label,
+			'no-label': hideLabel,
+			'has-error': showValidation && !isValid,
+		}"
 		@mouseenter="showTooltip = true"
 		@mouseleave="showTooltip = false"
 		@focusin="showTooltip = true"
@@ -44,6 +69,11 @@ const showTooltip = ref(false);
 		<!-- standard description -->
 		<div v-if="df.description && !hideLabel" class="mt-2 description">
 			{{ __(df.description) }}
+		</div>
+
+		<!-- validation error -->
+		<div v-if="showValidation && !isValid" class="fxr-error-msg">
+			{{ __("{0} must be checked").replace("{0}", df?.label || __("Field")) }}
 		</div>
 	</div>
 </template>

--- a/flexirule/public/js/flexirule/rule_builder/controls/CodeControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/CodeControl.vue
@@ -1,7 +1,12 @@
 <!-- Used as Code, HTML Editor, Markdown Editor & JSON Control -->
 <script setup>
 import { computed, onMounted, ref, useSlots, watch } from "vue";
-const props = defineProps(["df", "read_only", "modelValue"]);
+const props = defineProps({
+	df: Object,
+	read_only: Boolean,
+	modelValue: [String, Number],
+	showValidation: { type: Boolean, default: false },
+});
 let emit = defineEmits(["update:modelValue"]);
 let slots = useSlots();
 
@@ -59,10 +64,32 @@ function copyCode() {
 	if (!content.value) return;
 	frappe.utils.copy_to_clipboard(content.value);
 }
+
+const isValid = computed(() => {
+	if (!props.df?.reqd) return true;
+	return props.modelValue !== undefined && props.modelValue !== null && props.modelValue !== "";
+});
+
+function validate() {
+	const errors = [];
+	if (!isValid.value) {
+		errors.push(__("{0} is required").replace("{0}", props.df?.label || __("Field")));
+	}
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({ validate });
 </script>
 
 <template>
-	<div v-if="slots.label" class="control" :class="{ editable: slots.label }">
+	<div
+		v-if="slots.label"
+		class="control fxr-control"
+		:class="{
+			editable: slots.label,
+			'has-error': showValidation && !isValid,
+		}"
+	>
 		<div class="field-controls">
 			<slot name="label" />
 			<div class="d-flex align-items-center gap-2">
@@ -79,6 +106,16 @@ function copyCode() {
 		</div>
 		<div ref="code"></div>
 		<div v-if="df.description" class="mt-2 description">{{ __(df.description) }}</div>
+
+		<!-- validation error -->
+		<div v-if="showValidation && !isValid" class="fxr-error-msg">
+			{{ __("{0} is required").replace("{0}", df?.label || __("Field")) }}
+		</div>
 	</div>
-	<div v-else class="control" ref="code"></div>
+	<div
+		v-else
+		class="control fxr-control"
+		:class="{ 'has-error': showValidation && !isValid }"
+		ref="code"
+	></div>
 </template>

--- a/flexirule/public/js/flexirule/rule_builder/controls/ComboBoxControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/ComboBoxControl.vue
@@ -1,5 +1,11 @@
 <template>
-	<div class="fxr-control" :class="{ 'no-label': hideLabel }">
+	<div
+		class="fxr-control"
+		:class="{
+			'no-label': hideLabel,
+			'has-error': showValidation && !isValid,
+		}"
+	>
 		<div
 			class="fxr-input-group"
 			:class="{
@@ -222,6 +228,11 @@
 		<div v-if="df?.description && !hideDescription" class="fxr-description">
 			{{ __(df.description) }}
 		</div>
+
+		<!-- validation error -->
+		<div v-if="showValidation && !isValid" class="fxr-error-msg">
+			{{ __("{0} is required").replace("{0}", df?.label || __("Field")) }}
+		</div>
 	</div>
 </template>
 
@@ -241,6 +252,7 @@ const props = defineProps({
 	read_only: Boolean,
 	hideLabel: Boolean,
 	hideDescription: Boolean,
+	showValidation: { type: Boolean, default: false },
 	placeholder: String,
 	trigger: { type: String, default: "input" },
 	allowCustomValue: Boolean,
@@ -698,6 +710,19 @@ watch(
 	{ deep: true }
 );
 
+const isValid = computed(() => {
+	if (!props.df?.reqd) return true;
+	return props.modelValue !== undefined && props.modelValue !== null && props.modelValue !== "";
+});
+
+function validate() {
+	const errors = [];
+	if (!isValid.value) {
+		errors.push(__("{0} is required").replace("{0}", props.df?.label || __("Field")));
+	}
+	return { valid: errors.length === 0, errors };
+}
+
 defineExpose({
 	focus: () => {
 		if (props.trigger === "button" && wrapperRef.value) {
@@ -707,6 +732,7 @@ defineExpose({
 			mainInputRef.value.focus();
 		}
 	},
+	validate,
 });
 
 onMounted(() => {

--- a/flexirule/public/js/flexirule/rule_builder/controls/ControlFactory.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/ControlFactory.vue
@@ -3,18 +3,20 @@
 		<component
 			:is="resolved.component"
 			v-bind="resolved.props"
+			ref="controlRef"
 			:df="df"
 			:modelValue="modelValue"
 			:read_only="df?.read_only"
 			:hideLabel="hideLabel"
 			:hideDescription="hideDescription"
+			:showValidation="showValidation"
 			@update:modelValue="$emit('update:modelValue', $event)"
 		/>
 	</div>
 </template>
 
 <script setup>
-import { computed, onMounted, watch, inject } from "vue";
+import { computed, onMounted, watch, inject, ref } from "vue";
 import { ControlRegistry } from "../../core/control_registry.js";
 
 const injectedVariableOptions = inject("variableOptions", null);
@@ -28,11 +30,13 @@ const props = defineProps({
 	engine: { type: Object, default: null },
 	hideLabel: { type: Boolean, default: false },
 	hideDescription: { type: Boolean, default: false },
+	showValidation: { type: Boolean, default: false },
 	get_options: { type: Function, default: null },
 	get_data: { type: Function, default: null },
 });
 
 const emit = defineEmits(["update:modelValue"]);
+const controlRef = ref(null);
 
 const resolved = computed(() => {
 	const registryContext = {
@@ -61,6 +65,15 @@ function check_default() {
 		}
 	}
 }
+
+function validate() {
+	if (controlRef.value && typeof controlRef.value.validate === "function") {
+		return controlRef.value.validate();
+	}
+	return { valid: true, errors: [] };
+}
+
+defineExpose({ validate });
 </script>
 
 <style scoped>

--- a/flexirule/public/js/flexirule/rule_builder/controls/DataControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/DataControl.vue
@@ -1,6 +1,6 @@
 <!-- Used as Autocomplete, Barcode, Color, Currency, Data, Date, Duration, Link, Dynamic Link, Float, Int, Password, Percent, Time, Read Only, HTML Control -->
 <script setup>
-import { ref, onMounted, nextTick, useSlots } from "vue";
+import { ref, computed, onMounted, nextTick, useSlots } from "vue";
 const emit = defineEmits(["update:modelValue"]);
 
 const props = defineProps({
@@ -133,7 +133,7 @@ defineExpose({ validate });
 				<slot name="label" />
 				<slot name="actions" />
 			</div>
-			<label v-else-if="df?.label && !hideLabel" class="fxr-label" :class="{ reqd: df.reqd }">
+			<label v-else-if="df?.label && !hideLabel" class="fxr-label" :class="{ reqd: df?.reqd }">
 				{{ __(df.label) }}
 			</label>
 
@@ -142,7 +142,7 @@ defineExpose({ validate });
 				v-if="slots.label"
 				class="fxr-input"
 				type="text"
-				:style="{ height: df.fieldtype == 'Table MultiSelect' ? '42px' : '' }"
+				:style="{ height: df?.fieldtype == 'Table MultiSelect' ? '42px' : '' }"
 				:placeholder="__(placeholder)"
 				readonly
 			/>
@@ -152,8 +152,8 @@ defineExpose({ validate });
 				:type="df?.fieldtype === 'Time' ? 'time' : 'text'"
 				:step="df?.fieldtype === 'Time' ? '1' : undefined"
 				:value="modelValue"
-				:placeholder="__(df.placeholder || placeholder)"
-				:disabled="read_only || df.read_only"
+				:placeholder="__(df?.placeholder || placeholder)"
+				:disabled="read_only || df?.read_only"
 				@input="(event) => $emit('update:modelValue', event.target.value)"
 				@blur="evaluateMath($event)"
 				@keydown.enter="evaluateMath($event)"
@@ -161,7 +161,7 @@ defineExpose({ validate });
 				@drop="onDrop"
 			/>
 			<input
-				v-if="slots.label && df.fieldtype === 'Barcode'"
+				v-if="slots.label && df?.fieldtype === 'Barcode'"
 				class="fxr-input mt-2"
 				type="text"
 				:style="{ height: '110px' }"
@@ -170,7 +170,7 @@ defineExpose({ validate });
 		</div>
 
 		<!-- description -->
-		<div v-if="df.description && !hideDescription" class="fxr-description">
+		<div v-if="df?.description && !hideDescription" class="fxr-description">
 			{{ __(df.description) }}
 		</div>
 
@@ -188,9 +188,9 @@ defineExpose({ validate });
 		<div class="selected-color no-value" />
 
 		<!-- icon selector icon -->
-		<div v-if="df.fieldtype == 'Icon'" class="selected-icon no-value" ref="icon_ref"></div>
+		<div v-if="df?.fieldtype == 'Icon'" class="selected-icon no-value" ref="icon_ref"></div>
 		<!-- phone selector icon -->
-		<div v-if="df.fieldtype == 'Phone'" class="selected-phone no-value" ref="phone_ref"></div>
+		<div v-if="df?.fieldtype == 'Phone'" class="selected-phone no-value" ref="phone_ref"></div>
 	</div>
 </template>
 

--- a/flexirule/public/js/flexirule/rule_builder/controls/DataControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/DataControl.vue
@@ -133,7 +133,11 @@ defineExpose({ validate });
 				<slot name="label" />
 				<slot name="actions" />
 			</div>
-			<label v-else-if="df?.label && !hideLabel" class="fxr-label" :class="{ reqd: df?.reqd }">
+			<label
+				v-else-if="df?.label && !hideLabel"
+				class="fxr-label"
+				:class="{ reqd: df?.reqd }"
+			>
 				{{ __(df.label) }}
 			</label>
 

--- a/flexirule/public/js/flexirule/rule_builder/controls/DataControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/DataControl.vue
@@ -9,6 +9,7 @@ const props = defineProps({
 	read_only: Boolean,
 	hideLabel: { type: Boolean, default: false },
 	hideDescription: { type: Boolean, default: false },
+	showValidation: { type: Boolean, default: false },
 });
 
 const icon_ref = ref(null);
@@ -96,10 +97,31 @@ onMounted(() => {
 		phone_ref.value.innerHTML = frappe.utils.icon("down", "sm");
 	}
 });
+
+const isValid = computed(() => {
+	if (!props.df?.reqd) return true;
+	return props.modelValue !== undefined && props.modelValue !== null && props.modelValue !== "";
+});
+
+function validate() {
+	const errors = [];
+	if (!isValid.value) {
+		errors.push(__("{0} is required").replace("{0}", props.df?.label || __("Field")));
+	}
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({ validate });
 </script>
 
 <template>
-	<div class="fxr-control" :class="{ editable: slots.label }">
+	<div
+		class="fxr-control"
+		:class="{
+			editable: slots.label,
+			'has-error': showValidation && !isValid,
+		}"
+	>
 		<div
 			class="fxr-input-group"
 			:class="{
@@ -150,6 +172,11 @@ onMounted(() => {
 		<!-- description -->
 		<div v-if="df.description && !hideDescription" class="fxr-description">
 			{{ __(df.description) }}
+		</div>
+
+		<!-- validation error -->
+		<div v-if="showValidation && !isValid" class="fxr-error-msg">
+			{{ __("{0} is required").replace("{0}", df?.label || __("Field")) }}
 		</div>
 
 		<!-- timezone for datetime field -->

--- a/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
@@ -2,7 +2,11 @@
 	<div
 		ref="controlRef"
 		class="fvc-wrap"
-		:class="{ 'is-compact': compact, 'is-disabled': disabled || isReadOnly }"
+		:class="{
+			'is-compact': compact,
+			'is-disabled': disabled || isReadOnly,
+			'has-error': showValidation && !isValid,
+		}"
 		@keydown.capture="onStaticKeydown"
 	>
 		<!-- ── Main Control Area ── -->
@@ -97,6 +101,11 @@
 					<i :class="isDynamicMode ? 'fa fa-keyboard-o' : 'fa fa-bolt'"></i>
 				</button>
 			</div>
+		</div>
+
+		<!-- validation error -->
+		<div v-if="showValidation && !isValid" class="fxr-error-msg">
+			{{ __("{0} is required").replace("{0}", context?.df?.label || __("Field")) }}
 		</div>
 
 		<!-- ── Token Editor Modal ── -->
@@ -349,6 +358,7 @@ const props = defineProps({
 	disabled: { type: Boolean, default: false },
 	engine: { type: Object, default: null },
 	doc: { type: Object, default: null },
+	showValidation: { type: Boolean, default: false },
 	/**
 	 * Structured context:
 	 * {
@@ -699,7 +709,9 @@ function createSuggestionRenderer() {
 			if (popup) {
 				try {
 					popup.destroy();
-				} catch (e) {}
+				} catch (e) {
+					// Ignore error during popup destruction
+				}
 				const idx = activeTippyPopups.indexOf(popup);
 				if (idx > -1) activeTippyPopups.splice(idx, 1);
 				popup = null;
@@ -707,7 +719,9 @@ function createSuggestionRenderer() {
 			if (component) {
 				try {
 					component.destroy();
-				} catch (e) {}
+				} catch (e) {
+					// Ignore error during component destruction
+				}
 				component = null;
 			}
 		},
@@ -885,6 +899,28 @@ const editor = new Editor({
 });
 
 const isEditorEmpty = computed(() => editor.isEmpty);
+
+const isValid = computed(() => {
+	if (!props.context?.df?.reqd) return true;
+	const struct = coerceStructuredValue(serialize());
+	if (struct.mode === "static") {
+		return struct.value !== undefined && struct.value !== null && struct.value !== "";
+	}
+	if (struct.mode === "variable") return !!struct.value;
+	if (struct.mode === "resolver") return !!struct.value;
+	if (struct.mode === "expression") return Array.isArray(struct.value) && struct.value.length > 0;
+	return true;
+});
+
+function validate() {
+	const errors = [];
+	if (!isValid.value) {
+		errors.push(__("{0} is required").replace("{0}", props.context?.df?.label || __("Field")));
+	}
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({ validate });
 
 // ── Serialization ──
 

--- a/flexirule/public/js/flexirule/rule_builder/controls/FlexiGrid.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/FlexiGrid.vue
@@ -1,12 +1,18 @@
 <template>
-	<div class="flexi-grid" :class="{ 'is-readonly': read_only }">
+	<div
+		class="flexi-grid fxr-control"
+		:class="{
+			'is-readonly': read_only,
+			'has-error': showValidation && !isValid,
+		}"
+	>
 		<!-- Label -->
 		<div v-if="df.label" class="grid-label">
 			{{ __(df.label) }}
 			<span v-if="df.reqd" class="text-danger">*</span>
 		</div>
 
-		<div v-if="df.reqd && !localRows.length" class="text-danger small mb-2">
+		<div v-if="df.reqd && !localRows.length && showValidation" class="text-danger small mb-2">
 			<i class="fa fa-exclamation-circle"></i> {{ __("{0} is mandatory", [df.label]) }}
 		</div>
 
@@ -158,6 +164,7 @@ const props = defineProps({
 	modelValue: Array,
 	engine: Object,
 	read_only: Boolean,
+	showValidation: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(["update:modelValue"]);
@@ -433,6 +440,26 @@ function isRowInvalid(row) {
 function isValueEmpty(val) {
 	return val === undefined || val === null || val === "";
 }
+
+const isValid = computed(() => {
+	if (!props.df?.reqd) return true;
+	if (!localRows.value.length) return false;
+	return !localRows.value.some((row) => isRowInvalid(row));
+});
+
+function validate() {
+	const errors = [];
+	if (props.df?.reqd && !localRows.value.length) {
+		errors.push(
+			__("{0} must have at least one row").replace("{0}", props.df?.label || __("Table"))
+		);
+	} else if (localRows.value.some((row) => isRowInvalid(row))) {
+		errors.push(__("{0} contains invalid rows").replace("{0}", props.df?.label || __("Table")));
+	}
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({ validate });
 </script>
 
 <style>

--- a/flexirule/public/js/flexirule/rule_builder/controls/InlineTableControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/InlineTableControl.vue
@@ -11,6 +11,7 @@ const props = defineProps({
 	modelValue: [Array, String],
 	documentType: String,
 	read_only: Boolean,
+	showValidation: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(["update:modelValue"]);
@@ -162,10 +163,42 @@ function getSelectValue(options) {
 	}
 	return [];
 }
+
+const isValid = computed(() => {
+	if (!props.df?.reqd) return true;
+	if (!rows.value.length) return false;
+	// Basic validation: check if all required fields in each row are filled
+	return !rows.value.some((row) => {
+		return tableFields.value.some((f) => f.reqd && !row[f.fieldname]);
+	});
+});
+
+function validate() {
+	const errors = [];
+	if (props.df?.reqd && !rows.value.length) {
+		errors.push(
+			__("{0} must have at least one row").replace("{0}", props.df?.label || __("Table"))
+		);
+	} else if (
+		rows.value.some((row) => {
+			return tableFields.value.some((f) => f.reqd && !row[f.fieldname]);
+		})
+	) {
+		errors.push(
+			__("{0} contains incomplete rows").replace("{0}", props.df?.label || __("Table"))
+		);
+	}
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({ validate });
 </script>
 
 <template>
-	<div class="inline-table-control">
+	<div
+		class="inline-table-control fxr-control"
+		:class="{ 'has-error': showValidation && !isValid }"
+	>
 		<label v-if="df.label" class="control-label">
 			{{ __(df.label) }}
 			<span v-if="df.reqd" class="text-danger">*</span>
@@ -316,6 +349,13 @@ function getSelectValue(options) {
 		</button>
 
 		<p v-if="df.description" class="control-description">{{ df.description }}</p>
+
+		<!-- validation error -->
+		<div v-if="showValidation && !isValid" class="fxr-error-msg">
+			{{
+				__("{0} is required and must be complete").replace("{0}", df?.label || __("Field"))
+			}}
+		</div>
 	</div>
 </template>
 

--- a/flexirule/public/js/flexirule/rule_builder/controls/MultiSelectList.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/MultiSelectList.vue
@@ -20,6 +20,7 @@ const props = defineProps({
 	loadingState: { type: Boolean, default: false },
 	invalid: { type: Boolean, default: false },
 	errorMessage: { type: String, default: "" },
+	showValidation: { type: Boolean, default: false },
 	compactMaxVisible: { type: Number, default: 2 },
 	badgeCollapseAfter: { type: Number, default: 4 },
 	allowWrap: { type: Boolean, default: true },
@@ -234,6 +235,21 @@ const canInteract = computed(() => !props.read_only && !props.disabled);
 const showExpanded = computed(() => props.expanded);
 const isCompactMode = computed(() => props.displayMode === "compact");
 const isBadgeMode = computed(() => props.displayMode === "badges");
+
+const isValid = computed(() => {
+	if (!props.df?.reqd) return true;
+	return selectedValues.value.length > 0;
+});
+
+function validate() {
+	const errors = [];
+	if (!isValid.value) {
+		errors.push(__("{0} is required").replace("{0}", props.df?.label || __("Field")));
+	}
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({ validate });
 
 function emitValue(nextValues) {
 	emit("update:modelValue", nextValues);
@@ -510,7 +526,7 @@ onBeforeUnmount(() => {
 			:class="{
 				'is-active': isDropdownOpen,
 				disabled: !canInteract,
-				invalid,
+				invalid: invalid || (showValidation && !isValid),
 				compact: isCompactMode,
 			}"
 			tabindex="0"
@@ -784,6 +800,11 @@ onBeforeUnmount(() => {
 		</div>
 		<div v-if="df.description && !hideLabel" class="fxr-description">
 			{{ __(df.description) }}
+		</div>
+
+		<!-- validation error -->
+		<div v-if="showValidation && !isValid" class="fxr-error-msg">
+			{{ __("{0} is required").replace("{0}", df?.label || __("Field")) }}
 		</div>
 	</div>
 </template>

--- a/flexirule/public/js/flexirule/rule_builder/controls/PercentSliderControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/PercentSliderControl.vue
@@ -8,6 +8,7 @@ const props = defineProps({
 	df: Object,
 	modelValue: [Number, String],
 	read_only: Boolean,
+	showValidation: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(["update:modelValue"]);
@@ -16,10 +17,28 @@ const value = computed({
 	get: () => parseInt(props.modelValue) || props.df?.default || 50,
 	set: (val) => emit("update:modelValue", parseInt(val)),
 });
+
+const isValid = computed(() => {
+	if (!props.df?.reqd) return true;
+	return props.modelValue !== undefined && props.modelValue !== null && props.modelValue !== "";
+});
+
+function validate() {
+	const errors = [];
+	if (!isValid.value) {
+		errors.push(__("{0} is required").replace("{0}", props.df?.label || __("Field")));
+	}
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({ validate });
 </script>
 
 <template>
-	<div class="percent-slider-control">
+	<div
+		class="percent-slider-control fxr-control"
+		:class="{ 'has-error': showValidation && !isValid }"
+	>
 		<label v-if="df.label" class="control-label">
 			{{ __(df.label) }}
 			<span v-if="df.reqd" class="text-danger">*</span>
@@ -39,6 +58,11 @@ const value = computed({
 		</div>
 
 		<small v-if="df.description" class="form-text text-muted">{{ df.description }}</small>
+
+		<!-- validation error -->
+		<div v-if="showValidation && !isValid" class="fxr-error-msg">
+			{{ __("{0} is required").replace("{0}", df?.label || __("Field")) }}
+		</div>
 	</div>
 </template>
 

--- a/flexirule/public/js/flexirule/rule_builder/controls/ResourceMapperControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/ResourceMapperControl.vue
@@ -1,5 +1,8 @@
 <template>
-	<div class="resource-mapper-control fxr-control fxr-accent-scope">
+	<div
+		class="resource-mapper-control fxr-control fxr-accent-scope"
+		:class="{ 'has-error': showValidation && !isValid }"
+	>
 		<div v-if="df?.label && !hideLabel" class="fxr-label" :class="{ reqd: df?.reqd }">
 			{{ __(df.label) }}
 		</div>
@@ -130,6 +133,7 @@
 							:read_only="readOnly"
 							:trigger="'button'"
 							:hideLabel="true"
+							:showValidation="showValidation"
 							@update:modelValue="(val) => (row.path = val || '')"
 						/>
 					</div>
@@ -212,6 +216,7 @@
 						:read_only="readOnly"
 						:trigger="'button'"
 						:hideLabel="true"
+						:showValidation="showValidation"
 						@update:modelValue="(val) => (row.target = val || '')"
 					/>
 				</div>
@@ -223,7 +228,12 @@
 
 				<!-- Source Type -->
 				<div class="rm-cell rm-cell-type">
-					<select class="fxr-select" v-model="row.source_type" :disabled="readOnly">
+					<select
+						class="fxr-select"
+						v-model="row.source_type"
+						:disabled="readOnly"
+						:class="{ 'has-error': showValidation && !row.source_type }"
+					>
 						<option value="path">{{ __("Path") }}</option>
 						<option value="expr">{{ __("Expr") }}</option>
 						<option value="literal">{{ __("Static") }}</option>
@@ -239,6 +249,7 @@
 						:modelValue="row.path"
 						:read_only="readOnly"
 						:hideLabel="true"
+						:showValidation="showValidation"
 						@update:modelValue="(val) => (row.path = val || '')"
 					/>
 					<input
@@ -430,6 +441,7 @@
 									:read_only="readOnly"
 									:trigger="'button'"
 									:hideLabel="true"
+									:showValidation="showValidation"
 									@update:modelValue="(val) => (row.path = val || '')"
 								/>
 							</div>
@@ -576,6 +588,7 @@
 								:modelValue="row.path"
 								:read_only="readOnly"
 								:hideLabel="true"
+								:showValidation="showValidation"
 								@update:modelValue="(val) => (row.path = val || '')"
 							/>
 							<input
@@ -648,6 +661,11 @@
 			</div>
 		</div>
 
+		<!-- validation error -->
+		<div v-if="showValidation && !isValid" class="fxr-error-msg">
+			{{ __("Resource Mapper configuration is incomplete") }}
+		</div>
+
 		<div v-if="df?.description && !hideDescription" class="fxr-description">
 			{{ __(df.description) }}
 		</div>
@@ -667,6 +685,7 @@ const props = defineProps({
 	read_only: { type: Boolean, default: false },
 	hideLabel: { type: Boolean, default: false },
 	hideDescription: { type: Boolean, default: false },
+	showValidation: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(["update:modelValue"]);
@@ -1318,6 +1337,42 @@ function deleteSelectedTableRows(tIdx, table) {
 	table.mappings = table.mappings.filter((m) => !selected.has(m._id));
 	selected.clear();
 }
+
+const isValid = computed(() => {
+	// A ResourceMapper is considered valid if it has at least one scalar mapping
+	// or at least one child table mapping (assuming it's required by context).
+	// For now, let's just ensure if it's required, it's not completely empty.
+	if (!props.df?.reqd) return true;
+
+	const hasScalars = ui.value.scalars.some((s) => s.target && (s.path || s.expr || s.literal));
+	const hasTables = ui.value.tables.some((t) => t.target_table && t.source_path);
+
+	return hasScalars || hasTables || ui.value.copy_same_fields;
+});
+
+function validate() {
+	const errors = [];
+	if (!isValid.value) {
+		errors.push(__("Resource Mapper: At least one field mapping is required"));
+	}
+
+	// Validate incomplete rows
+	ui.value.scalars.forEach((s, idx) => {
+		if (s.target && !(s.path || s.expr || s.literal)) {
+			errors.push(__("Field Mapping #{0}: Source value is missing").replace("{0}", idx + 1));
+		}
+	});
+
+	ui.value.tables.forEach((t, idx) => {
+		if (t.target_table && !t.source_path) {
+			errors.push(__("Table Mapping #{0}: Source path is missing").replace("{0}", idx + 1));
+		}
+	});
+
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({ validate });
 </script>
 
 <style scoped>

--- a/flexirule/public/js/flexirule/rule_builder/controls/SelectControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/SelectControl.vue
@@ -2,7 +2,7 @@
   SelectControl - Styled dropdown using ComboBoxControl
 -->
 <script setup>
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import ComboBoxControl from "./ComboBoxControl.vue";
 
 const props = defineProps({
@@ -12,9 +12,12 @@ const props = defineProps({
 	no_label: Boolean,
 	hideLabel: { type: Boolean, default: false },
 	hideDescription: { type: Boolean, default: false },
+	showValidation: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(["update:modelValue", "change"]);
+
+const comboRef = ref(null);
 
 const options = computed(() => {
 	let opts = props.df?.options;
@@ -62,16 +65,24 @@ function on_change(value) {
 	emit("update:modelValue", value);
 	emit("change", value);
 }
+
+function validate() {
+	return comboRef.value?.validate() || { valid: true, errors: [] };
+}
+
+defineExpose({ validate });
 </script>
 
 <template>
 	<ComboBoxControl
+		ref="comboRef"
 		:df="df"
 		:model-value="modelValue"
 		:options="options"
 		:read_only="read_only || df?.read_only"
 		:hide-label="hideLabel || no_label"
 		:hide-description="hideDescription"
+		:show-validation="showValidation"
 		trigger="button"
 		:hide-search="true"
 		@update:model-value="on_change"

--- a/flexirule/public/js/flexirule/rule_builder/controls/TextControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/TextControl.vue
@@ -1,7 +1,12 @@
 <!-- Used as Text, Small Text & Long Text Control -->
 <script setup>
 import { computed, useSlots } from "vue";
-const props = defineProps(["df", "modelValue", "read_only"]);
+const props = defineProps({
+	df: Object,
+	modelValue: [String, Number],
+	read_only: Boolean,
+	showValidation: { type: Boolean, default: false },
+});
 let emit = defineEmits(["update:modelValue"]);
 let slots = useSlots();
 
@@ -11,10 +16,31 @@ let height = computed(() => {
 	}
 	return "300px";
 });
+
+const isValid = computed(() => {
+	if (!props.df?.reqd) return true;
+	return props.modelValue !== undefined && props.modelValue !== null && props.modelValue !== "";
+});
+
+function validate() {
+	const errors = [];
+	if (!isValid.value) {
+		errors.push(__("{0} is required").replace("{0}", props.df?.label || __("Field")));
+	}
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({ validate });
 </script>
 
 <template>
-	<div class="control" :class="{ editable: slots.label }">
+	<div
+		class="control fxr-control"
+		:class="{
+			editable: slots.label,
+			'has-error': showValidation && !isValid,
+		}"
+	>
 		<!-- label -->
 		<div v-if="slots.label" class="field-controls">
 			<slot name="label" />
@@ -42,6 +68,11 @@ let height = computed(() => {
 
 		<!-- description -->
 		<div v-if="df.description" class="mt-2 description">{{ __(df.description) }}</div>
+
+		<!-- validation error -->
+		<div v-if="showValidation && !isValid" class="fxr-error-msg">
+			{{ __("{0} is required").replace("{0}", df?.label || __("Field")) }}
+		</div>
 	</div>
 </template>
 

--- a/flexirule/public/js/flexirule/rule_builder/controls/TextGeneratorControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/TextGeneratorControl.vue
@@ -3,7 +3,11 @@
 		<!-- Main Editor Container -->
 		<div
 			class="tgc-editor-container"
-			:class="{ 'nested-container': isNested, 'has-panel': !!activeLogicNode }"
+			:class="{
+				'nested-container': isNested,
+				'has-panel': !!activeLogicNode,
+				'has-error': showValidation && !isValid,
+			}"
 		>
 			<!-- Production-Ready Floating Menu (Complete Formatting) -->
 			<div v-if="showBubbleMenu" class="tgc-bubble-menu-fixed" :style="bubbleMenuStyle">
@@ -344,6 +348,7 @@ import {
 import MentionList from "./MentionList.vue";
 import ConditionBuilder from "../components/condition_builder/ConditionBuilder.vue";
 import ComboBoxControl from "./ComboBoxControl.vue";
+import { validateConditions } from "../components/condition_builder/condition_validator.js";
 
 import {
 	compileSegmentsToJinja,
@@ -360,6 +365,7 @@ const props = defineProps({
 	modelValue: { type: [Object, String], default: null },
 	templateValue: { type: String, default: "" },
 	read_only: { type: Boolean, default: false },
+	showValidation: { type: Boolean, default: false },
 	variableOptions: { type: [Array, Object], default: () => [] },
 	docFieldOptions: { type: Array, default: () => [] },
 	isNested: { type: Boolean, default: false },
@@ -689,6 +695,48 @@ function createSuggestionRenderer() {
 const charCount = computed(() => editor.getText().length);
 const nodeCount = computed(() => ui.value.segments.length);
 const isEditorEmpty = computed(() => editor.isEmpty);
+
+const isValid = computed(() => {
+	if (!props.df?.reqd) return true;
+	return !editor.isEmpty;
+});
+
+function validate() {
+	const errors = [];
+	if (!isValid.value) {
+		errors.push(__("{0} is required").replace("{0}", props.df?.label || __("Field")));
+	}
+
+	// Deep validation of logic nodes
+	const segs = ui.value.segments || [];
+	const validateSegs = (nodes) => {
+		for (const node of nodes) {
+			if (node.type === "conditional") {
+				const res = validateConditions(
+					node.condition || { op: "and", conditions: [] },
+					true,
+					true
+				);
+				if (!res.valid) {
+					errors.push(__("Condition in Rich Text is invalid"));
+				}
+				if (node.then_segments) validateSegs(node.then_segments);
+				if (node.else_segments) validateSegs(node.else_segments);
+			} else if (node.type === "loop") {
+				if (!node.iterator || !node.iterable) {
+					errors.push(__("Loop in Rich Text is incomplete"));
+				}
+				if (node.segments) validateSegs(node.segments);
+			}
+		}
+	};
+	validateSegs(segs);
+
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({ validate });
+
 function closeDrawer() {
 	activeLogicNode.value = null;
 }
@@ -870,6 +918,14 @@ onBeforeUnmount(() => {
 	border-color: var(--tg-accent);
 	box-shadow: 0 0 0 3px color-mix(in srgb, var(--tg-accent) 20%, transparent);
 }
+
+.tgc-editor-container.has-error {
+	border-color: var(--red-500) !important;
+}
+
+.tgc-editor-container.has-error:focus-within {
+	box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15) !important;
+}
 .tgc-editor-wrapper {
 	padding: 12px 12px 10px;
 	min-height: 120px;
@@ -945,6 +1001,12 @@ onBeforeUnmount(() => {
 	background: var(--fxr-badge-resolver);
 	color: var(--fxr-badge-resolver-text);
 	border-color: color-mix(in srgb, var(--fxr-badge-resolver-text) 20%, transparent);
+}
+:deep(.tg-badge.is-invalid) {
+	background: #fff1f2 !important; /* Lighter rose background */
+	color: #be123c !important; /* Deep rose text for contrast */
+	border-color: #fda4af !important; /* Rose border */
+	box-shadow: 0 0 0 1px rgba(225, 29, 72, 0.1) !important;
 }
 :deep(.tg-badge-trans) {
 	background: color-mix(in srgb, var(--fxr-accent-soft, #e0f2fe) 88%, var(--fxr-surface));

--- a/flexirule/public/js/flexirule/rule_builder/controls/TimePickerControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/TimePickerControl.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="fxr-control">
+	<div class="fxr-control" :class="{ 'has-error': showValidation && !isValid }">
 		<div
 			class="fxr-input-group"
 			:class="{
@@ -64,6 +64,11 @@
 			{{ __(df.description) }}
 		</div>
 
+		<!-- validation error -->
+		<div v-if="showValidation && !isValid" class="fxr-error-msg">
+			{{ __("{0} is required").replace("{0}", df?.label || __("Field")) }}
+		</div>
+
 		<!-- timezone for datetime field -->
 		<div
 			v-if="time_zone && df.fieldtype === 'Datetime'"
@@ -85,6 +90,7 @@ const props = defineProps({
 	read_only: Boolean,
 	hideLabel: { type: Boolean, default: false },
 	hideDescription: { type: Boolean, default: false },
+	showValidation: { type: Boolean, default: false },
 });
 
 // Timezone for datetime fields
@@ -253,6 +259,29 @@ function onDrop(event) {
 		});
 	}
 }
+
+const isValid = computed(() => {
+	if (!props.df?.reqd) return true;
+	if (isRange.value) {
+		return (
+			Array.isArray(props.modelValue) &&
+			props.modelValue.length === 2 &&
+			!!props.modelValue[0] &&
+			!!props.modelValue[1]
+		);
+	}
+	return props.modelValue !== undefined && props.modelValue !== null && props.modelValue !== "";
+});
+
+function validate() {
+	const errors = [];
+	if (!isValid.value) {
+		errors.push(__("{0} is required").replace("{0}", props.df?.label || __("Field")));
+	}
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({ validate });
 </script>
 
 <style lang="scss" scoped>

--- a/flexirule/public/js/flexirule/rule_builder/controls/TransformControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/TransformControl.vue
@@ -1,5 +1,13 @@
 <template>
-	<div class="transform-control" ref="containerRef">
+	<div
+		class="transform-control fxr-control"
+		ref="containerRef"
+		:class="{ 'has-error': showValidation && !isValid }"
+	>
+		<div v-if="df?.label" class="fxr-label" :class="{ reqd: df?.reqd }">
+			{{ __(df.label) }}
+		</div>
+
 		<div class="transform-header">
 			<div class="header-left">
 				<label class="rm-label-sm">{{ __("Source Data") }}</label>
@@ -94,19 +102,31 @@
 				<!-- Future: Add expression editor here -->
 			</div>
 		</div>
+
+		<div v-if="showValidation && !isValid" class="fxr-error-msg">
+			{{
+				__("{0} requires at least one mapping").replace("{0}", df?.label || __("Transform"))
+			}}
+		</div>
+
+		<div v-if="df?.description" class="fxr-description">
+			{{ __(df.description) }}
+		</div>
 	</div>
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted, watch, nextTick } from "vue";
+import { ref, onMounted, onUnmounted, watch, nextTick, computed } from "vue";
 import TransformNode from "./TransformNode.vue";
 import { useTransformMapper } from "../composables/useTransformMapper.js";
 
 const props = defineProps({
+	df: { type: Object, default: null },
 	modelValue: { type: Array, default: () => [] },
 	sourceSchema: { type: Array, default: () => [] }, // Flat list with dot notation
 	targetSchema: { type: Array, default: () => [] }, // Flat list with dot notation
 	readOnly: Boolean,
+	showValidation: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(["update:modelValue"]);
@@ -165,6 +185,28 @@ function removeMapping(mapping) {
 function selectMapping(mapping) {
 	selectedMapping.value = mapping;
 }
+
+const isValid = computed(() => {
+	if (props.df?.reqd) {
+		return mappings.value.length > 0;
+	}
+	return true;
+});
+
+function validate() {
+	const errors = [];
+	if (!isValid.value) {
+		errors.push(
+			__("{0} requires at least one mapping").replace(
+				"{0}",
+				props.df?.label || __("Transform")
+			)
+		);
+	}
+	return { valid: errors.length === 0, errors };
+}
+
+defineExpose({ validate });
 
 // ── Lifecycle ─────────────────────────────────────────────────────────────
 

--- a/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/ValueResolverControl.vue
@@ -291,6 +291,7 @@ defineExpose({
 	open,
 	close: closePopover,
 	focus: () => tokenRef.value?.focus(),
+	validate: () => ({ valid: isValid.value, errors: errors.value }),
 });
 
 const popoverTitle = computed(() => {

--- a/flexirule/public/js/flexirule/rule_builder/utils/tiptap_extensions.js
+++ b/flexirule/public/js/flexirule/rule_builder/utils/tiptap_extensions.js
@@ -1,6 +1,7 @@
 import { Node, Mark, mergeAttributes } from "@tiptap/core";
 import Mention from "@tiptap/extension-mention";
 import { PluginKey } from "@tiptap/pm/state";
+import { validateConditions } from "../components/condition_builder/condition_validator";
 import { encodeData, decodeData } from "./text_generator";
 
 export const VarPluginKey = new PluginKey("variableTrigger");
@@ -131,9 +132,6 @@ export const LogicNode = Node.create({
 			iconClass = "fa fa-code-fork";
 
 			if (condition) {
-				const {
-					validateConditions,
-				} = require("../components/condition_builder/condition_validator.js");
 				const res = validateConditions(condition, true, true);
 				if (!res.valid) {
 					isInvalid = true;

--- a/flexirule/public/js/flexirule/rule_builder/utils/tiptap_extensions.js
+++ b/flexirule/public/js/flexirule/rule_builder/utils/tiptap_extensions.js
@@ -111,10 +111,12 @@ export const LogicNode = Node.create({
 		return [{ tag: 'span[data-type="logic"]' }];
 	},
 	renderHTML({ node, HTMLAttributes }) {
-		const { type, isStart, isElse, _key } = node.attrs;
+		const { type, isStart, isElse, _key, condition, iterator, iterable } = node.attrs;
 		let label = "";
 		let badgeClass = "tg-badge";
 		let iconClass = "";
+		let isInvalid = false;
+		let errorMsg = "";
 
 		if (isElse) {
 			label = __("ELSE");
@@ -127,10 +129,34 @@ export const LogicNode = Node.create({
 			label = node.attrs.label ? __("IF {0}", [node.attrs.label]) : __("IF");
 			badgeClass += " tg-badge-if";
 			iconClass = "fa fa-code-fork";
+
+			if (condition) {
+				const {
+					validateConditions,
+				} = require("../components/condition_builder/condition_validator.js");
+				const res = validateConditions(condition, true, true);
+				if (!res.valid) {
+					isInvalid = true;
+					errorMsg = res.errors?.[0] || __("Invalid condition");
+				}
+			} else {
+				isInvalid = true;
+				errorMsg = __("Missing condition");
+			}
 		} else {
 			label = node.attrs.label ? __("LOOP {0}", [node.attrs.label]) : __("LOOP");
 			badgeClass += " tg-badge-loop";
 			iconClass = "fa fa-refresh";
+
+			if (!iterator || !iterable) {
+				isInvalid = true;
+				errorMsg = __("Incomplete loop parameters");
+			}
+		}
+
+		if (isInvalid) {
+			badgeClass += " is-invalid";
+			label = "⚠ " + label;
 		}
 
 		const data = encodeData({
@@ -151,6 +177,7 @@ export const LogicNode = Node.create({
 				"data-type": "logic",
 				"data-logic-type": data,
 				class: badgeClass,
+				title: errorMsg,
 			}),
 			iconClass ? ["i", { class: `${iconClass} mr-1` }] : "",
 			["span", label],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1386,6 +1386,11 @@ prelude-ls@^1.2.1:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+prettier@2.7.1:
+  version "2.7.1"
+  resolved "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+
 prosemirror-changeset@^2.3.0:
   version "2.4.1"
   resolved "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1386,11 +1386,6 @@ prelude-ls@^1.2.1:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@2.7.1:
-  version "2.7.1"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz"
-  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
-
 prosemirror-changeset@^2.3.0:
   version "2.4.1"
   resolved "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz"


### PR DESCRIPTION
This PR implements a robust, unified frontend validation engine for FlexiRule, mirroring Frappe's field properties (reqd, depends_on). It introduces a standardized `validate()` contract for all configuration components, ensuring that broken rules are caught across all contexts (standalone actions, assignments, and rich text). 

Key architectural changes include:
1. **Recursive Condition Validation**: A walk-based validator for condition trees that flags specific invalid nodes by ID.
2. **Aggregated Orchestration**: Wrapper panels now correctly aggregate validity from their children, blocking global saves and providing a consolidated error list.
3. **UX Enhancements**: Automatic "Scroll-to-error" on failed saves and a direct shortcut from assignment badges to broken condition fields.
4. **Visibility Awareness**: Fields hidden via `depends_on` are skipped during validation but preserve their data state.

---
*PR created automatically by Jules for task [11801503857141226141](https://jules.google.com/task/11801503857141226141) started by @ruzaqiarkan-eng*