### PR TITLE
Fix Debug Rule Visualization and Execution Path Rendering

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/App.vue
+++ b/flexirule/public/js/flexirule/rule_builder/App.vue
@@ -406,7 +406,7 @@ function updateQuickActionsPosition() {
 function runQuickAction(item) {
 	const actions = {
 		save: () => ruleStore.save_changes(),
-		test: () => window.fxrRuleBuilder?.show_test_dialog?.(),
+		test: () => window.fxrRuleBuilder?.show_debug_dialog?.(),
 		status: () => toggleRuleAccess(),
 		shortcuts: () => (uiStore.show_shortcuts_help = true),
 		layout: () => runAutoLayout(),

--- a/flexirule/public/js/flexirule/rule_builder/rule_builder.js
+++ b/flexirule/public/js/flexirule/rule_builder/rule_builder.js
@@ -374,6 +374,16 @@ class RuleBuilder {
 					},
 					callback: (r) => {
 						if (r.message?.multi) {
+							// For multi-run, we might already have results from realtime.
+							// But we should ensure the UI store is populated with what the API returned.
+							// We clear first to avoid duplicates if realtime did work.
+							this.uiStore.clear_test_result();
+							if (r.message.results && r.message.results.length > 0) {
+								r.message.results.forEach((res) => {
+									this.uiStore.add_test_progress_result(res);
+								});
+							}
+
 							if (r.message.success_count > 0) {
 								frappe.show_alert(
 									{


### PR DESCRIPTION
This PR fixes an issue where the Rule Builder's debug visualization (Execution Path panel and canvas node highlights) failed to render.

Key changes:
1. **API Callback Handling**: Modified `rule_builder.js` to ensure that results from multi-document debug runs (triggered by the dialog's document selector) are explicitly pushed to the `uiStore`. Previously, the UI relied solely on real-time events for multi-run visualization, which led to failures when events were missed or delayed.
2. **Quick Action Correction**: Fixed the "Debug" icon action in the canvas Quick Actions menu, which was attempting to call a non-existent method.
3. **State Consistency**: Added explicit clearing of previous debug results before adding new ones to ensure a clean state.

---
*PR created automatically by Jules for task [14383461528065667669](https://jules.google.com/task/14383461528065667669) started by @Sendipad*