### PR TITLE
Fix Auto-Dirty State in Rule Builder

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/App.vue
+++ b/flexirule/public/js/flexirule/rule_builder/App.vue
@@ -465,6 +465,10 @@ function toggleRuleAccess() {
 
 function onPaneReady(instance) {
 	instance.fitView();
+	// Small delay to ensure fitView doesn't trigger a trailing position change
+	setTimeout(() => {
+		uiStore.is_initializing = false;
+	}, 150);
 }
 
 function onDebugProgress(data) {
@@ -479,7 +483,6 @@ onMounted(async () => {
 	document.body.classList.add("fxr-builder-active");
 	if (props.rule) ruleStore.rule_name = props.rule;
 	await ruleStore.fetch();
-	graphStore.autoConnectStartNode();
 
 	pushContext("canvas");
 
@@ -783,11 +786,13 @@ function onConnect(params) {
 }
 
 function onNodesChange(changes) {
+	if (uiStore.is_initializing) return;
 	const hasDrag = changes.some((c) => c.type === "position" && c.dragging === false);
 	if (hasDrag) ruleStore.mark_position_change();
 }
 
 function onEdgesChange(changes) {
+	if (uiStore.is_initializing) return;
 	changes.forEach((change) => {
 		if (change.type === "remove") {
 			graphStore.delete_edge(change.id, ruleStore.is_read_only);

--- a/flexirule/public/js/flexirule/rule_builder/stores/useGraphStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useGraphStore.js
@@ -1314,7 +1314,32 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 
 	function normalize_graph_nodes() {
 		nodes.value = nodes.value.map((node) => {
-			if (node.type === "start" || !node.data?.action_type) return node;
+			if (!node.data?.action_type) return node;
+
+			// 1. Deep sync conditions to config before normalization
+			if (node.data.action_type === "Condition") {
+				const payload = getConditionPayload({
+					config: node.data.config,
+					condition_json: node.data.condition_json,
+				});
+				if (payload) {
+					node.data.config = payload;
+					node.data.condition_json = null;
+				}
+				if (!node.data.config || typeof node.data.config !== "object") {
+					node.data.config = { op: "and", conditions: [] };
+				}
+			}
+
+			// 2. Structural normalization for Assignments
+			if (node.data.action_type === "Assignment") {
+				if (!node.data.config || !Array.isArray(node.data.config)) {
+					node.data.config = [];
+				}
+			}
+
+			if (node.type === "start") return node;
+
 			return {
 				...node,
 				data: normalize_action_data(node.data.action_type, node.data),

--- a/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
@@ -73,10 +73,12 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 		const graphStore = useGraphStore();
 		const metaStore = useMetaStore();
 		const historyStore = useHistoryStore();
+		const uiStore = useUIStore();
 
 		// Guard to prevent redundant fetches
 		if (is_loading.value) return;
 		is_loading.value = true;
+		uiStore.is_initializing = true;
 		// Fetch Settings
 		try {
 			const res = await frappe.call({
@@ -139,6 +141,7 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 			graphStore.initialize_default_graph(rule_doc.value);
 		}
 
+		graphStore.autoConnectStartNode();
 		graphStore.normalize_graph_nodes();
 
 		setup_breadcrumbs();
@@ -152,6 +155,8 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 
 		historyStore.reset(() => graphStore.getGraphSnapshot());
 		is_loading.value = false;
+
+		// Note: is_initializing is kept true until VueFlow reports ready in App.vue
 	}
 
 	// ── Save ──
@@ -573,11 +578,8 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 
 	// ── Dirty tracking ──
 	function mark_dirty() {
-		if (is_read_only.value) return;
-
-		// Guard: If we are currently fetching or loading, don't mark dirty.
-		// This prevents components that sync on mount from triggering a dirty state.
-		if (is_loading.value) return;
+		const uiStore = useUIStore();
+		if (is_read_only.value || is_loading.value || uiStore.is_initializing) return;
 
 		// Set flag for immediate UI response
 		_is_dirty.value = true;
@@ -589,7 +591,8 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 	}
 
 	function mark_position_change() {
-		if (is_read_only.value) return;
+		const uiStore = useUIStore();
+		if (is_read_only.value || is_loading.value || uiStore.is_initializing) return;
 
 		_is_dirty.value = true;
 

--- a/flexirule/public/js/flexirule/rule_builder/stores/useUIStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useUIStore.js
@@ -14,6 +14,7 @@ export const useUIStore = defineStore("rule-builder-ui", () => {
 	const selected_id = ref(null);
 	const show_sidebar = ref(false);
 	const local_clipboard = ref(null);
+	const is_initializing = ref(false);
 
 	// ── Config Modal ──
 	const show_config_modal = ref(false);
@@ -185,6 +186,7 @@ export const useUIStore = defineStore("rule-builder-ui", () => {
 		local_clipboard,
 		test_multi_results,
 		test_current_multi_index,
+		is_initializing,
 
 		// Computed
 		has_selection,


### PR DESCRIPTION
Resolved the critical UX bug where the rule builder Pinia store was marked as "dirty" immediately upon loading a rule. This was caused by a combination of data-healing logic running after the initial state snapshot and framework-level layout events (VueFlow fitView) triggering position change mutations.

Changes implemented:
1. **Lifecycle Reordering:** Moved `autoConnectStartNode` into the `fetch` sequence *before* the `historyStore` reset/snapshot.
2. **Deep Normalization:** Added proactive structural normalization for Condition and Assignment nodes in `useGraphStore` to ensure incoming backend data (which might have `null` fields) matches the frontend's expected reactive schema (`[]` or `{}`) before the baseline snapshot is frozen.
3. **Initialization Guard:** Added a global `is_initializing` flag in `uiStore`. This flag is used to suppress dirty-tracking and position-change notifications during the window between fetching data and VueFlow completing its first render/fit-view cycle.
4. **Event Suppression:** Updated `App.vue` event handlers (`onNodesChange`, `onEdgesChange`) and store mutation triggers to honor the `is_initializing` guard.
5. **Layout Settling:** Utilized the `onPaneReady` hook with a small timeout to ensure all framework-driven position shifts have completed before enabling user-driven change tracking.

---
*PR created automatically by Jules for task [3855732287546090285](https://jules.google.com/task/3855732287546090285) started by @Sendipad*