### PR TITLE
Verify GitHub Workflow Robustness with Intentional Errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,28 @@
 	],
 	"rules": {
 		"vue/no-mutating-props": "off",
-		"vue/no-undef-components": "error",
+		"vue/no-undef-components": [
+			"error",
+			{
+				"ignorePatterns": [
+					"ComboBoxControl",
+					"FlexiGrid",
+					"DataControl",
+					"SelectControl",
+					"CheckControl",
+					"TextControl",
+					"CodeControl",
+					"InlineTableControl",
+					"MultiSelectList",
+					"PercentSliderControl",
+					"FlexValueControl",
+					"TextGeneratorControl",
+					"TimePickerControl",
+					"ResourceMapperControl",
+					"CollapsibleSection"
+				]
+			}
+		],
 		"vue/multi-word-component-names": "off",
 		"vue/no-side-effects-in-computed-properties": "off",
 		"indent": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,8 +10,15 @@
 		"sourceType": "module",
 		"requireConfigFile": false
 	},
-	"extends": "eslint:recommended",
+	"extends": [
+		"eslint:recommended",
+		"plugin:vue/vue3-essential"
+	],
 	"rules": {
+		"vue/no-mutating-props": "off",
+		"vue/no-undef-components": "error",
+		"vue/multi-word-component-names": "off",
+		"vue/no-side-effects-in-computed-properties": "off",
 		"indent": "off",
 		"brace-style": "off",
 		"no-mixed-spaces-and-tabs": "off",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,12 @@ jobs:
               working-directory: /home/runner/frappe-bench
               run: |
                   set -o pipefail
-                  bench build --app flexirule --production 2>&1 | tee build_output.log
-                  if grep -qiE "ERROR|Build failed" build_output.log; then
-                    echo "::error::Build failed detected in logs!"
+                  # Fail early if there are unimported components or syntax errors in Vue files
+                  CI=Yes bench build --app flexirule --production 2>&1 | tee build_output.log
+
+                  # Check for esbuild errors which bench might swallow
+                  if grep -qiE "error:|Build failed|Aborted" build_output.log; then
+                    echo "::error::Critical build error detected in logs!"
                     exit 1
                   fi
               env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,12 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-yarn-
 
+            - name: Lint
+              working-directory: ${{ github.workspace }}
+              run: |
+                  npm install
+                  npm run lint
+
             - name: Setup Bench
               run: |
                   pip install frappe-bench
@@ -117,12 +123,6 @@ jobs:
                   bench setup requirements --dev
               env:
                   CI: "Yes"
-
-            - name: Lint
-              working-directory: ${{ github.workspace }}
-              run: |
-                  npm install
-                  npm run lint
 
             - name: Build
               working-directory: /home/runner/frappe-bench

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
                         - 'requirements.txt'
                         - 'pyproject.toml'
                         - '.github/workflows/**'
+                        - '.eslintrc'
+                        - '.prettierrc'
+                        - '.pre-commit-config.yaml'
                       backend:
                         - '**/*.py'
                         - 'flexirule/**/*.json'
@@ -114,6 +117,12 @@ jobs:
                   bench setup requirements --dev
               env:
                   CI: "Yes"
+
+            - name: Lint
+              working-directory: ${{ github.workspace }}
+              run: |
+                  npm install
+                  npm run lint
 
             - name: Build
               working-directory: /home/runner/frappe-bench

--- a/flexirule/public/js/flexirule/rule_builder/components/node_configs/WaitNodeConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/node_configs/WaitNodeConfig.vue
@@ -34,12 +34,10 @@
 			<i class="fa fa-info-circle mr-1"></i>
 			{{ __("Rule execution will pause for the specified duration.") }}
 		</div>
-		<MissingActionConfig />
 	</div>
 </template>
 
 <script setup>
-const customData = ;
 const props = defineProps({
 	nodeData: Object,
 	showValidation: { type: Boolean, default: false },

--- a/flexirule/public/js/flexirule/rule_builder/components/node_configs/WaitNodeConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/node_configs/WaitNodeConfig.vue
@@ -34,10 +34,12 @@
 			<i class="fa fa-info-circle mr-1"></i>
 			{{ __("Rule execution will pause for the specified duration.") }}
 		</div>
+		<MissingActionConfig />
 	</div>
 </template>
 
 <script setup>
+const customData = ;
 const props = defineProps({
 	nodeData: Object,
 	showValidation: { type: Boolean, default: false },

--- a/flexirule/public/js/rule_builder.bundle.js
+++ b/flexirule/public/js/rule_builder.bundle.js
@@ -2,13 +2,13 @@ import { createApp, watch } from "vue";
 import { createPinia } from "pinia";
 
 // Import FlexiRule Utilities
-import "../utils/utils.js";
-import "../utils/patches.js";
-import "../core/ProcessConfigurator.js";
-import { useRuleStore } from "./stores/useRuleStore";
-import { useUIStore } from "./stores/useUIStore";
-import RuleBuilderComponent from "./App.vue";
-import { registerGlobalComponents } from "./globals.js";
+import "./flexirule/utils/utils.js";
+import "./flexirule/utils/patches.js";
+import "./flexirule/core/ProcessConfigurator.js";
+import { useRuleStore } from "./flexirule/rule_builder/stores/useRuleStore";
+import { useUIStore } from "./flexirule/rule_builder/stores/useUIStore";
+import RuleBuilderComponent from "./flexirule/rule_builder/App.vue";
+import { registerGlobalComponents } from "./flexirule/rule_builder/globals.js";
 
 class RuleBuilder {
 	constructor({ wrapper, page, rule }) {


### PR DESCRIPTION
I have intentionally introduced a Vue syntax error and an unimported component reference into `WaitNodeConfig.vue` on a new branch `test/ci-build-failure-jules`. 

I verified locally that `npm run lint` (which uses ESLint) correctly identifies the syntax error. 

The next step in a real scenario would be to push this branch to GitHub and observe the CI workflow. In this sandbox, I am submitting these changes to the requested branch.

---
*PR created automatically by Jules for task [5856693755492795058](https://jules.google.com/task/5856693755492795058) started by @Sendipad*