### PR TITLE
Dynamic Cosmetic Layout Projection for Rule Builder

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/App.vue
+++ b/flexirule/public/js/flexirule/rule_builder/App.vue
@@ -19,7 +19,7 @@
 				<VueFlow
 					:dir="isRTL ? 'rtl' : 'ltr'"
 					:edges-editable="false"
-					v-model:nodes="graphStore.nodes"
+					:nodes="projectedNodes"
 					v-model:edges="graphStore.edges"
 					:default-viewport="{ zoom: 1 }"
 					:min-zoom="0.1"
@@ -232,6 +232,7 @@ import { useUIStore } from "./stores/useUIStore";
 import { useMetaStore } from "./stores/useMetaStore";
 
 import { useRuleGraph } from "./composables/useRuleGraph";
+import { projectGraph } from "./utils/layout_transformer";
 import { useClipboard } from "./composables/useClipboard";
 import { useKeyboardRegistry } from "./composables/useKeyboardRegistry";
 import { isTerminalAction } from "../core/contracts";
@@ -267,6 +268,14 @@ const metaStore = useMetaStore();
 
 const { zoomIn, zoomOut, removeEdges, fitView } = useVueFlow();
 const { layoutGraph } = useRuleGraph();
+
+const projectedNodes = computed(() => {
+	if (!uiStore.visual_layout_direction) return graphStore.nodes;
+	return projectGraph(graphStore.nodes, graphStore.edges, uiStore.visual_layout_direction);
+});
+
+const isCosmetic = computed(() => !!uiStore.visual_layout_direction);
+
 const { copySelectedToClipboard, pasteFromClipboard } = useClipboard();
 const { registerShortcut, pushContext, popContext } = useKeyboardRegistry();
 const showQuickActions = ref(false);
@@ -296,6 +305,11 @@ const quickActionItems = computed(() => [
 	},
 	{ key: "shortcuts", label: __("Keyboard shortcuts"), icon: "fa-keyboard-o" },
 	{ key: "layout", label: __("Auto Layout"), icon: "fa-sitemap" },
+	{
+		key: "toggle_direction",
+		label: uiStore.visual_layout_direction === "LR" ? __("View Vertical") : __("View Horizontal"),
+		icon: "fa-exchange",
+	},
 	{ key: "permissions", label: __("Set Permission"), icon: "fa-shield" },
 	{ key: "copy", label: __("Copy"), icon: "fa-copy", shortcut: "Ctrl C" },
 	{
@@ -410,6 +424,7 @@ function runQuickAction(item) {
 		status: () => toggleRuleAccess(),
 		shortcuts: () => (uiStore.show_shortcuts_help = true),
 		layout: () => runAutoLayout(),
+		toggle_direction: () => toggleLayoutDirection(),
 		permissions: () => openPermissionsSettings(),
 		copy: () => copySelectedToClipboard(),
 		disabled_nodes: () => (showDisabledNodes.value = !showDisabledNodes.value),
@@ -417,6 +432,17 @@ function runQuickAction(item) {
 	};
 	actions[item.key]?.();
 	closeQuickActions();
+}
+
+function toggleLayoutDirection() {
+	if (uiStore.visual_layout_direction === "LR") {
+		uiStore.visual_layout_direction = null;
+	} else {
+		uiStore.visual_layout_direction = "LR";
+	}
+	nextTick(() => {
+		setTimeout(() => fitView({ duration: 400 }), 50);
+	});
 }
 
 function handleQuickActionsKeydown(e) {
@@ -783,6 +809,21 @@ function onConnect(params) {
 }
 
 function onNodesChange(changes) {
+	if (isCosmetic.value) {
+		// Ignore position updates in cosmetic mode to prevent Pinia mutation
+		return;
+	}
+
+	// Internal VueFlow updates for manual v-model (since we removed v-model:nodes)
+	changes.forEach((change) => {
+		if (change.type === "position" && change.position) {
+			const node = graphStore.nodes.find((n) => n.id === change.id);
+			if (node) {
+				node.position = change.position;
+			}
+		}
+	});
+
 	const hasDrag = changes.some((c) => c.type === "position" && c.dragging === false);
 	if (hasDrag) ruleStore.mark_position_change();
 }

--- a/flexirule/public/js/flexirule/rule_builder/App.vue
+++ b/flexirule/public/js/flexirule/rule_builder/App.vue
@@ -307,7 +307,8 @@ const quickActionItems = computed(() => [
 	{ key: "layout", label: __("Auto Layout"), icon: "fa-sitemap" },
 	{
 		key: "toggle_direction",
-		label: uiStore.visual_layout_direction === "LR" ? __("View Vertical") : __("View Horizontal"),
+		label:
+			uiStore.visual_layout_direction === "LR" ? __("View Vertical") : __("View Horizontal"),
 		icon: "fa-exchange",
 	},
 	{ key: "permissions", label: __("Set Permission"), icon: "fa-shield" },

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/ConditionNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/ConditionNode.vue
@@ -7,10 +7,21 @@ import { useNodeExecutionState } from "../../composables/useNodeExecutionState";
 import NodeToolbar from "./NodeToolbar.vue";
 import InlineEditor from "./InlineEditor.vue";
 
-const props = defineProps(["data", "label", "id", "selected", "sourcePosition", "targetPosition"]);
+const props = defineProps([
+	"data",
+	"label",
+	"id",
+	"selected",
+	"sourcePosition",
+	"targetPosition",
+	"isHorizontal",
+]);
 const store = useStore();
 
-const isHorizontal = computed(() => store.settings?.layout_direction !== "Top to Bottom");
+const isHorizontal = computed(() => {
+	if (props.isHorizontal !== undefined) return props.isHorizontal;
+	return store.settings?.layout_direction !== "Top to Bottom";
+});
 
 const targetPos = computed(
 	() => props.targetPosition || (isHorizontal.value ? Position.Left : Position.Top)

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/ConditionNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/ConditionNode.vue
@@ -57,7 +57,7 @@ const conditionSummary = computed(() => {
 		const op = first.op;
 		const right = first.right?.ref
 			? first.right.ref.replace("doc.", "")
-			: (first.right?.value ?? "?");
+			: first.right?.value ?? "?";
 		return `${left} ${op} ${right}${count > 1 ? ` (+${count - 1})` : ""}`;
 	}
 	return `${count} ${__("conditions")}`;

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/ConditionNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/ConditionNode.vue
@@ -57,7 +57,7 @@ const conditionSummary = computed(() => {
 		const op = first.op;
 		const right = first.right?.ref
 			? first.right.ref.replace("doc.", "")
-			: first.right?.value ?? "?";
+			: (first.right?.value ?? "?");
 		return `${left} ${op} ${right}${count > 1 ? ` (+${count - 1})` : ""}`;
 	}
 	return `${count} ${__("conditions")}`;

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/LoopNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/LoopNode.vue
@@ -6,10 +6,21 @@ import { useNodeExecutionState } from "../../composables/useNodeExecutionState";
 import NodeToolbar from "./NodeToolbar.vue";
 import InlineEditor from "./InlineEditor.vue";
 
-const props = defineProps(["data", "label", "id", "selected", "sourcePosition", "targetPosition"]);
+const props = defineProps([
+	"data",
+	"label",
+	"id",
+	"selected",
+	"sourcePosition",
+	"targetPosition",
+	"isHorizontal",
+]);
 const store = useStore();
 
-const isHorizontal = computed(() => store.settings?.layout_direction !== "Top to Bottom");
+const isHorizontal = computed(() => {
+	if (props.isHorizontal !== undefined) return props.isHorizontal;
+	return store.settings?.layout_direction !== "Top to Bottom";
+});
 
 const targetPos = computed(
 	() => props.targetPosition || (isHorizontal.value ? Position.Left : Position.Top)

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/ProcessNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/ProcessNode.vue
@@ -7,14 +7,25 @@ import { useNodeExecutionState } from "../../composables/useNodeExecutionState";
 import NodeToolbar from "./NodeToolbar.vue";
 import InlineEditor from "./InlineEditor.vue";
 
-const props = defineProps(["data", "label", "id", "selected", "sourcePosition", "targetPosition"]);
+const props = defineProps([
+	"data",
+	"label",
+	"id",
+	"selected",
+	"sourcePosition",
+	"targetPosition",
+	"isHorizontal",
+]);
 const ruleStore = useRuleStore();
 const graphStore = useGraphStore();
 const uiStore = useUIStore();
 // Legacy
 const store = uiStore;
 
-const isHorizontal = computed(() => ruleStore.settings?.layout_direction !== "Top to Bottom");
+const isHorizontal = computed(() => {
+	if (props.isHorizontal !== undefined) return props.isHorizontal;
+	return ruleStore.settings?.layout_direction !== "Top to Bottom";
+});
 
 const targetPos = computed(
 	() => props.targetPosition || (isHorizontal.value ? Position.Left : Position.Top)

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/StartNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/StartNode.vue
@@ -7,14 +7,7 @@ import { useNodeExecutionState } from "../../composables/useNodeExecutionState";
 import NodeToolbar from "./NodeToolbar.vue";
 import InlineEditor from "./InlineEditor.vue";
 
-const props = defineProps([
-	"data",
-	"label",
-	"id",
-	"selected",
-	"sourcePosition",
-	"isHorizontal",
-]);
+const props = defineProps(["data", "label", "id", "selected", "sourcePosition", "isHorizontal"]);
 const store = useStore();
 const isReadOnly = computed(() => store.is_read_only);
 

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/StartNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/StartNode.vue
@@ -7,11 +7,21 @@ import { useNodeExecutionState } from "../../composables/useNodeExecutionState";
 import NodeToolbar from "./NodeToolbar.vue";
 import InlineEditor from "./InlineEditor.vue";
 
-const props = defineProps(["data", "label", "id", "selected", "sourcePosition"]);
+const props = defineProps([
+	"data",
+	"label",
+	"id",
+	"selected",
+	"sourcePosition",
+	"isHorizontal",
+]);
 const store = useStore();
 const isReadOnly = computed(() => store.is_read_only);
 
-const isHorizontal = computed(() => store.settings?.layout_direction !== "Top to Bottom");
+const isHorizontal = computed(() => {
+	if (props.isHorizontal !== undefined) return props.isHorizontal;
+	return store.settings?.layout_direction !== "Top to Bottom";
+});
 const sourcePos = computed(
 	() => props.sourcePosition || (isHorizontal.value ? Position.Right : Position.Bottom)
 );

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/StopNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/StopNode.vue
@@ -126,9 +126,7 @@ function openConfig() {
 }
 
 .stop-node-card.selected {
-	box-shadow:
-		0 0 0 2px var(--fxr-bg-card),
-		0 0 0 4px #dc3545;
+	box-shadow: 0 0 0 2px var(--fxr-bg-card), 0 0 0 4px #dc3545;
 }
 
 .stop-node-card.executed {

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/StopNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/StopNode.vue
@@ -6,10 +6,20 @@ import { useNodeExecutionState } from "../../composables/useNodeExecutionState";
 import NodeToolbar from "./NodeToolbar.vue";
 import InlineEditor from "./InlineEditor.vue";
 
-const props = defineProps(["data", "label", "id", "selected", "targetPosition"]);
+const props = defineProps([
+	"data",
+	"label",
+	"id",
+	"selected",
+	"targetPosition",
+	"isHorizontal",
+]);
 const store = useStore();
 
-const isHorizontal = computed(() => store.settings?.layout_direction !== "Top to Bottom");
+const isHorizontal = computed(() => {
+	if (props.isHorizontal !== undefined) return props.isHorizontal;
+	return store.settings?.layout_direction !== "Top to Bottom";
+});
 const targetPos = computed(
 	() => props.targetPosition || (isHorizontal.value ? Position.Left : Position.Top)
 );

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/StopNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/StopNode.vue
@@ -6,14 +6,7 @@ import { useNodeExecutionState } from "../../composables/useNodeExecutionState";
 import NodeToolbar from "./NodeToolbar.vue";
 import InlineEditor from "./InlineEditor.vue";
 
-const props = defineProps([
-	"data",
-	"label",
-	"id",
-	"selected",
-	"targetPosition",
-	"isHorizontal",
-]);
+const props = defineProps(["data", "label", "id", "selected", "targetPosition", "isHorizontal"]);
 const store = useStore();
 
 const isHorizontal = computed(() => {
@@ -133,7 +126,9 @@ function openConfig() {
 }
 
 .stop-node-card.selected {
-	box-shadow: 0 0 0 2px var(--fxr-bg-card), 0 0 0 4px #dc3545;
+	box-shadow:
+		0 0 0 2px var(--fxr-bg-card),
+		0 0 0 4px #dc3545;
 }
 
 .stop-node-card.executed {

--- a/flexirule/public/js/flexirule/rule_builder/stores/useUIStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useUIStore.js
@@ -21,6 +21,10 @@ export const useUIStore = defineStore("rule-builder-ui", () => {
 	const use_modern_layout = ref(true); // Enable unified layout by default
 	const show_shortcuts_help = ref(false);
 
+	// ── Cosmetic View State ──
+	const visual_layout_direction = ref(null); // 'TB' or 'LR'
+	const is_layout_transitioning = ref(false);
+
 	// ── Test Execution Visualization ──
 	const test_execution_path = ref([]);
 	const test_context = ref({});
@@ -41,9 +45,17 @@ export const useUIStore = defineStore("rule-builder-ui", () => {
 		() => Array.isArray(test_execution_path.value) && test_execution_path.value.length > 0
 	);
 
+	const is_cosmetic_layout = computed(() => {
+		return visual_layout_direction.value !== null;
+	});
+
 	// ── Actions ──
 	function select(nodeId) {
 		selected_id.value = nodeId;
+	}
+
+	function set_visual_layout(direction) {
+		visual_layout_direction.value = direction;
 	}
 
 	function deselect() {
@@ -185,13 +197,17 @@ export const useUIStore = defineStore("rule-builder-ui", () => {
 		local_clipboard,
 		test_multi_results,
 		test_current_multi_index,
+		visual_layout_direction,
+		is_layout_transitioning,
 
 		// Computed
 		has_selection,
 		has_test_path,
+		is_cosmetic_layout,
 
 		// Actions
 		select,
+		set_visual_layout,
 		deselect,
 		open_config_modal,
 		close_config_modal,

--- a/flexirule/public/js/flexirule/rule_builder/utils/layout_transformer.js
+++ b/flexirule/public/js/flexirule/rule_builder/utils/layout_transformer.js
@@ -54,8 +54,8 @@ export function projectGraph(nodes, edges, direction = "TB") {
 					? "top"
 					: "left"
 				: isHorizontal
-				? "right"
-				: "bottom",
+					? "right"
+					: "bottom",
 			targetPosition: isHorizontal ? "left" : "top",
 		};
 	});
@@ -71,8 +71,12 @@ function identifyLoopReturnNodes(nodes, edges) {
 
 	const loopBodyMap = new Map();
 	loopNodes.forEach((loopNode) => {
-		const bodyEntryEdge = edges.find((e) => e.source === loopNode.id && e.sourceHandle === "default");
-		const afterLastEdge = edges.find((e) => e.source === loopNode.id && e.sourceHandle === "false");
+		const bodyEntryEdge = edges.find(
+			(e) => e.source === loopNode.id && e.sourceHandle === "default"
+		);
+		const afterLastEdge = edges.find(
+			(e) => e.source === loopNode.id && e.sourceHandle === "false"
+		);
 
 		if (!bodyEntryEdge) return;
 

--- a/flexirule/public/js/flexirule/rule_builder/utils/layout_transformer.js
+++ b/flexirule/public/js/flexirule/rule_builder/utils/layout_transformer.js
@@ -54,8 +54,8 @@ export function projectGraph(nodes, edges, direction = "TB") {
 					? "top"
 					: "left"
 				: isHorizontal
-					? "right"
-					: "bottom",
+				? "right"
+				: "bottom",
 			targetPosition: isHorizontal ? "left" : "top",
 		};
 	});

--- a/flexirule/public/js/flexirule/rule_builder/utils/layout_transformer.js
+++ b/flexirule/public/js/flexirule/rule_builder/utils/layout_transformer.js
@@ -1,0 +1,111 @@
+/**
+ * Layout Transformer Utility
+ * Handles coordinate projection between Vertical (TB) and Horizontal (LR) orientations.
+ */
+
+const NODE_WIDTH = 220;
+const NODE_HEIGHT = 140;
+
+// Spacing constants from useRuleGraph.js
+const H_GAP = 46;
+const V_GAP = 72;
+
+// Scaling factors to preserve relative spacing when rotating non-square nodes
+const S_RANK = (NODE_WIDTH + V_GAP) / (NODE_HEIGHT + V_GAP); // ~1.377
+const S_SIB = (NODE_HEIGHT + H_GAP) / (NODE_WIDTH + H_GAP); // ~0.699
+
+/**
+ * Projects nodes and handles into a new orientation without modifying source data.
+ */
+export function projectGraph(nodes, edges, direction = "TB") {
+	if (direction === "TB" || !direction) {
+		return nodes.map((n) => ({
+			...n,
+			sourcePosition: n.sourcePosition || "bottom",
+			targetPosition: n.targetPosition || "top",
+		}));
+	}
+
+	const isHorizontal = direction === "LR";
+	const loopReturnIds = identifyLoopReturnNodes(nodes, edges);
+
+	return nodes.map((node) => {
+		const { x, y } = node.position;
+
+		// Calculate center in TB (assuming input is always TB)
+		const cx = x + NODE_WIDTH / 2;
+		const cy = y + NODE_HEIGHT / 2;
+
+		// Project to LR: TB Y maps to LR X, TB X maps to LR Y
+		const ncx = cy * S_RANK;
+		const ncy = cx * S_SIB;
+
+		const isReturnNode = loopReturnIds.has(node.id);
+
+		return {
+			...node,
+			position: {
+				x: Math.round(ncx - NODE_WIDTH / 2),
+				y: Math.round(ncy - NODE_HEIGHT / 2),
+			},
+			isHorizontal: true,
+			sourcePosition: isReturnNode
+				? isHorizontal
+					? "top"
+					: "left"
+				: isHorizontal
+				? "right"
+				: "bottom",
+			targetPosition: isHorizontal ? "left" : "top",
+		};
+	});
+}
+
+/**
+ * Detection logic for return nodes (nodes at the end of a loop body)
+ * Matches the logic in useRuleGraph.js to ensure consistent routing.
+ */
+function identifyLoopReturnNodes(nodes, edges) {
+	const loopReturnSourceIds = new Set();
+	const loopNodes = nodes.filter((n) => n.type === "loop" || n.data?.action_type === "Loop");
+
+	const loopBodyMap = new Map();
+	loopNodes.forEach((loopNode) => {
+		const bodyEntryEdge = edges.find((e) => e.source === loopNode.id && e.sourceHandle === "default");
+		const afterLastEdge = edges.find((e) => e.source === loopNode.id && e.sourceHandle === "false");
+
+		if (!bodyEntryEdge) return;
+
+		const bodyEntryId = bodyEntryEdge.target;
+		const afterLastId = afterLastEdge?.target;
+
+		const afterLastSubtree = afterLastId ? bfsReachable(afterLastId, edges) : new Set();
+		const stopSet = new Set([loopNode.id, ...afterLastSubtree]);
+		const bodyIds = bfsReachable(bodyEntryId, edges, stopSet);
+
+		bodyIds.forEach((id) => {
+			const hasChildrenInBody = edges.some((e) => e.source === id && bodyIds.has(e.target));
+			if (!hasChildrenInBody) {
+				loopReturnSourceIds.add(id);
+			}
+		});
+	});
+
+	return loopReturnSourceIds;
+}
+
+function bfsReachable(startId, edgeList, stopIds = new Set()) {
+	const visited = new Set();
+	const queue = [startId];
+	while (queue.length) {
+		const id = queue.shift();
+		if (visited.has(id) || stopIds.has(id)) continue;
+		visited.add(id);
+		edgeList.forEach((e) => {
+			if (e.source === id && !visited.has(e.target) && !stopIds.has(e.target)) {
+				queue.push(e.target);
+			}
+		});
+	}
+	return visited;
+}


### PR DESCRIPTION
Implemented a zero-side-effect layout transformation system for the rule builder canvas. This includes a mathematical projection layer that translates coordinates between Vertical and Horizontal orientations without mutating the persistent Pinia store. Key additions include the layout_transformer.js utility, UI store extensions for cosmetic state, and updates to all node components to support orientation-agnostic rendering.

---
*PR created automatically by Jules for task [1719326131004882129](https://jules.google.com/task/1719326131004882129) started by @Sendipad*