### PR TITLE
Fix unintentional dirty state reset during layout operations

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/composables/useRuleGraph.js
+++ b/flexirule/public/js/flexirule/rule_builder/composables/useRuleGraph.js
@@ -264,7 +264,7 @@ export function useRuleGraph() {
 				// Reset layout flag and sync baseline so layout change isn't "dirty"
 				setTimeout(() => {
 					uiStore.is_performing_layout = false;
-					ruleStore.clear_dirty();
+					ruleStore.sync_initial_state_positions();
 				}, 650);
 			}, 50);
 		});

--- a/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
@@ -644,6 +644,42 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 		_is_dirty.value = false;
 	}
 
+	/**
+	 * Sync only positions to the initial state baseline.
+	 * Used after layout operations to ensure the new positions don't
+	 * trigger a dirty state, while preserving other unsaved changes.
+	 */
+	function sync_initial_state_positions() {
+		if (!initial_state.value) return;
+
+		const graphStore = useGraphStore();
+		const currentSnapshot = graphStore.getStateSnapshot();
+		let initialSnapshot;
+		try {
+			initialSnapshot = JSON.parse(initial_state.value);
+		} catch (e) {
+			return;
+		}
+
+		// Map current positions by ID
+		const currentPositions = new Map(
+			currentSnapshot.filter((el) => el.position).map((el) => [el.id, el.position])
+		);
+
+		// Update initial snapshot with current positions
+		const updatedInitialSnapshot = initialSnapshot.map((el) => {
+			if (el.position && currentPositions.has(el.id)) {
+				return {
+					...el,
+					position: currentPositions.get(el.id),
+				};
+			}
+			return el;
+		});
+
+		initial_state.value = JSON.stringify(updatedInitialSnapshot);
+	}
+
 	// ── UI Helpers (Delegated to UI Store) ──
 	function open_config(nodeId) {
 		const uiStore = useUIStore();
@@ -869,6 +905,7 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 		mark_dirty,
 		mark_position_change,
 		clear_dirty,
+		sync_initial_state_positions,
 
 		// Undo/Redo coordination
 		undo,


### PR DESCRIPTION
### Summary of Changes
This PR addresses a critical dirty-state management issue where automated layout operations (vertical/horizontal toggle) would unintentionally clear all unsaved business-logic changes.

### Key Modifications
- **`useRuleStore.js`**: Introduced `sync_initial_state_positions()`. This method performs a partial update of the `initial_state` snapshot, syncing only the `position` data of nodes while leaving `data`, `edges`, and other metadata untouched.
- **`useRuleGraph.js`**: Switched from `clear_dirty()` to `sync_initial_state_positions()` in the `layoutGraph` callback.

### Verification Results
- **Scenario 1 (Existing Changes)**: Load Rule -> Edit Action -> Toggle Layout. **Result**: Rule remains dirty; action edits are preserved in pending changes. (FIXED)
- **Scenario 2 (Clean Rule)**: Load Rule -> Toggle Layout. **Result**: Rule remains clean. (PRESERVED)
- **Scenario 3 (Bootstrap)**: New Rule -> Auto Layout. **Result**: Rule remains clean. (PRESERVED)

This ensures visual-only operations remain non-destructive to the business state.

---
*PR created automatically by Jules for task [6307160775109285121](https://jules.google.com/task/6307160775109285121) started by @ruzaqiarkan-eng*