### PR TITLE
Unify Node Status Indicators and Enhance Frontend Validation

### DIFF
--- a/flexirule/public/js/flexirule/core/contracts.js
+++ b/flexirule/public/js/flexirule/core/contracts.js
@@ -48,6 +48,7 @@ const DEFAULT_ACTION_TYPE_CONTRACT = {
 	},
 	Condition: {
 		required_fields: ["config"],
+		required_config_keys: ["conditions"],
 		has_next_true: true,
 		has_next_false: true,
 		terminal: false,
@@ -72,6 +73,7 @@ const DEFAULT_ACTION_TYPE_CONTRACT = {
 	},
 	Loop: {
 		required_fields: ["config", "return_variable"],
+		required_config_keys: ["iterator"],
 		has_next_true: true,
 		has_next_false: true,
 		terminal: false,
@@ -1071,26 +1073,26 @@ export function validateAgainstContract(nodeData) {
 		errors.push(__("Return Schema requires a Return Variable Name"));
 	}
 
-	// 5. Action-specific deep validation (Policy-based)
-	if (nodeData.operation && policy.required_config_keys) {
-		const config = parseJsonSafe(nodeData.config, {});
-		for (const key of policy.required_config_keys) {
-			if (config[key] === undefined || config[key] === null || config[key] === "") {
-				errors.push(
-					__("Configuration key '{0}' is required for {1}", [key, nodeData.operation])
-				);
-			}
-		}
-	}
+	// 5. Action-specific deep validation (Policy & Contract based)
+	const requiredConfigKeys = [
+		...(policy.required_config_keys || []),
+		...(contract.required_config_keys || []),
+	];
 
-	// 6. Condition-specific validation
-	if (actionType === "Condition" || actionType === "Loop") {
+	if (requiredConfigKeys.length) {
 		const config = parseJsonSafe(nodeData.config, {});
-		if (actionType === "Condition" && (!config.conditions || !config.conditions.length)) {
-			errors.push(__("At least one condition is required"));
-		}
-		if (actionType === "Loop" && !config.iterator) {
-			errors.push(__("Iterator is required for Loop"));
+		for (const key of requiredConfigKeys) {
+			const value = config[key];
+			const isEmpty =
+				value === undefined ||
+				value === null ||
+				value === "" ||
+				(Array.isArray(value) && value.length === 0);
+
+			if (isEmpty) {
+				const label = key.charAt(0).toUpperCase() + key.slice(1);
+				errors.push(__("{0} is required for {1}", [label, actionType]));
+			}
 		}
 	}
 

--- a/flexirule/public/js/flexirule/core/contracts.js
+++ b/flexirule/public/js/flexirule/core/contracts.js
@@ -1,8 +1,17 @@
 /**
  * FlexiRule action contracts
  *
- * Backend is the canonical source. This module keeps a local fallback so the
- * builder still works if the contract API is temporarily unavailable.
+ * CANONICAL SOURCE: flexirule/ruleflow/core/contracts.py
+ *
+ * This module provides a frontend implementation of the action contracts.
+ * It is primarily used for:
+ * 1. UI rendering (icons, colors, labels)
+ * 2. Real-time canvas status (getNodeStatus)
+ * 3. Reactive frontend validation (validateAgainstContract)
+ *
+ * Fallbacks defined here MUST match the backend definitions in contracts.py.
+ * The system attempts to load fresh contracts via 'loadContractsFromBackend'
+ * but uses these as static defaults.
  */
 
 const ACTION_TYPE_DESCRIPTION = {

--- a/flexirule/public/js/flexirule/core/contracts.js
+++ b/flexirule/public/js/flexirule/core/contracts.js
@@ -48,7 +48,6 @@ const DEFAULT_ACTION_TYPE_CONTRACT = {
 	},
 	Condition: {
 		required_fields: ["config"],
-		required_config_keys: ["conditions"],
 		has_next_true: true,
 		has_next_false: true,
 		terminal: false,
@@ -73,7 +72,6 @@ const DEFAULT_ACTION_TYPE_CONTRACT = {
 	},
 	Loop: {
 		required_fields: ["config", "return_variable"],
-		required_config_keys: ["iterator"],
 		has_next_true: true,
 		has_next_false: true,
 		terminal: false,
@@ -1093,6 +1091,22 @@ export function validateAgainstContract(nodeData) {
 				const label = key.charAt(0).toUpperCase() + key.slice(1);
 				errors.push(__("{0} is required for {1}", [label, actionType]));
 			}
+		}
+	}
+
+	// 6. Action-specific deep validation (Condition & Loop legacy)
+	if (actionType === "Condition" || actionType === "Loop") {
+		const config = parseJsonSafe(nodeData.config, {});
+		if (actionType === "Condition") {
+			const { getConditionPayload } = window.flexirule?.utils?.condition_payload || {};
+			const payload = getConditionPayload ? getConditionPayload(nodeData) : config.conditions;
+
+			if (!payload || (Array.isArray(payload) && payload.length === 0)) {
+				errors.push(__("At least one condition is required"));
+			}
+		}
+		if (actionType === "Loop" && !config.iterator) {
+			errors.push(__("Iterator is required for Loop"));
 		}
 	}
 

--- a/flexirule/public/js/flexirule/core/contracts.js
+++ b/flexirule/public/js/flexirule/core/contracts.js
@@ -1067,7 +1067,9 @@ export function validateAgainstContract(nodeData) {
 		const config = parseJsonSafe(nodeData.config, {});
 		for (const key of policy.required_config_keys) {
 			if (config[key] === undefined || config[key] === null || config[key] === "") {
-				errors.push(__("Configuration key '{0}' is required for {1}", [key, nodeData.operation]));
+				errors.push(
+					__("Configuration key '{0}' is required for {1}", [key, nodeData.operation])
+				);
 			}
 		}
 	}

--- a/flexirule/public/js/flexirule/core/contracts.js
+++ b/flexirule/public/js/flexirule/core/contracts.js
@@ -969,24 +969,27 @@ export function validateAgainstContract(nodeData) {
 		return { valid: true, errors: [] };
 	}
 
-	const contract = getContract(nodeData.action_type);
-	const policy = getEffectiveActionPolicy(nodeData.action_type, {
+	const actionType = normalizeActionType(nodeData.action_type);
+	const contract = getContract(actionType);
+	const policy = getEffectiveActionPolicy(actionType, {
 		operation: nodeData.operation,
 		processName: nodeData.process_name,
 	});
 	const errors = [];
 
-	if (RELEASE_DISABLED_ACTION_TYPES.has(nodeData.action_type)) {
-		errors.push(__("{0} is not available in this release", [nodeData.action_type]));
+	if (RELEASE_DISABLED_ACTION_TYPES.has(actionType)) {
+		errors.push(__("{0} is not available in this release", [actionType]));
 	}
 
+	// 1. Base Required Fields
 	for (const field of contract.required_fields || []) {
 		const value = nodeData[field];
 		if (value === undefined || value === null || value === "") {
-			errors.push(__("Field '{0}' is required for {1}", [field, nodeData.action_type]));
+			errors.push(__("Field '{0}' is required for {1}", [field, actionType]));
 		}
 	}
 
+	// 2. Operation-specific Mandatory Fields
 	if (nodeData.operation && contract.mandatory_fields?.[nodeData.operation]) {
 		for (const field of contract.mandatory_fields[nodeData.operation]) {
 			const value = nodeData[field];
@@ -994,7 +997,7 @@ export function validateAgainstContract(nodeData) {
 				errors.push(
 					__("Field '{0}' is required for {1} in mode {2}", [
 						field,
-						nodeData.action_type,
+						actionType,
 						nodeData.operation,
 					])
 				);
@@ -1002,28 +1005,25 @@ export function validateAgainstContract(nodeData) {
 		}
 	}
 
+	// 3. Flow Integrity
 	if (contract.terminal) {
 		if (nodeData.next_step_if_true || nodeData.next_step_if_false) {
-			errors.push(
-				__("{0} is terminal and should not have next steps", [nodeData.action_type])
-			);
+			errors.push(__("{0} is terminal and should not have next steps", [actionType]));
 		}
 	}
 
-	// We no longer strictly require a false path for actions that support it (e.g., Loop, Condition).
-	// An empty path simply implies the execution terminates for that branch.
-
 	if (!contract.has_next_false && nodeData.next_step_if_false) {
-		errors.push(__("{0} does not support 'next step if false'", [nodeData.action_type]));
+		errors.push(__("{0} does not support 'next step if false'", [actionType]));
 	}
 
+	// 4. Output/Mutation Policies
 	if (nodeData.mutation_mode) {
 		const allowed = policy.allowed_mutations || [];
 		if (Array.isArray(allowed) && allowed.length && !allowed.includes(nodeData.mutation_mode)) {
 			errors.push(
 				__("Mutation mode '{0}' is not allowed for {1}", [
 					nodeData.mutation_mode,
-					nodeData.action_type,
+					actionType,
 				])
 			);
 		}
@@ -1040,16 +1040,17 @@ export function validateAgainstContract(nodeData) {
 			!allowedReturnTypes.includes(nodeData.return_type)
 		) {
 			errors.push(
-				__("Return type '{0}' is not allowed for {1}", [
-					nodeData.return_type,
-					nodeData.action_type,
-				])
+				__("Return type '{0}' is not allowed for {1}", [nodeData.return_type, actionType])
 			);
 		}
 	}
 
 	if (policy.require_return_type && !nodeData.return_type) {
 		errors.push(__("Return type is required for this operation"));
+	}
+
+	if (policy.require_return_variable && !nodeData.return_variable) {
+		errors.push(__("Return Variable Name is required for this operation"));
 	}
 
 	const showReturnType = policy.show_return_type !== false;
@@ -1061,10 +1062,75 @@ export function validateAgainstContract(nodeData) {
 		errors.push(__("Return Schema requires a Return Variable Name"));
 	}
 
+	// 5. Action-specific deep validation (Policy-based)
+	if (nodeData.operation && policy.required_config_keys) {
+		const config = parseJsonSafe(nodeData.config, {});
+		for (const key of policy.required_config_keys) {
+			if (config[key] === undefined || config[key] === null || config[key] === "") {
+				errors.push(__("Configuration key '{0}' is required for {1}", [key, nodeData.operation]));
+			}
+		}
+	}
+
+	// 6. Condition-specific validation
+	if (actionType === "Condition" || actionType === "Loop") {
+		const config = parseJsonSafe(nodeData.config, {});
+		if (actionType === "Condition" && (!config.conditions || !config.conditions.length)) {
+			errors.push(__("At least one condition is required"));
+		}
+		if (actionType === "Loop" && !config.iterator) {
+			errors.push(__("Iterator is required for Loop"));
+		}
+	}
+
 	return {
 		valid: errors.length === 0,
 		errors,
 	};
+}
+
+/**
+ * Get the status of a node based on its configuration and validation.
+ * @param {Object} nodeData - The node's data object
+ * @returns {'not-configured' | 'configured' | 'invalid'}
+ */
+export function getNodeStatus(nodeData) {
+	if (!nodeData || !nodeData.action_type) {
+		return "not-configured";
+	}
+
+	const actionType = normalizeActionType(nodeData.action_type);
+	if (actionType === "Entry Action") return "configured";
+
+	const contract = getContract(actionType);
+
+	// Check if basic required fields are set
+	const requiredFields = contract.required_fields || [];
+	const hasRequiredFields = requiredFields.every((f) => {
+		const val = nodeData[f];
+		return val !== undefined && val !== null && val !== "";
+	});
+
+	if (!hasRequiredFields) {
+		return "not-configured";
+	}
+
+	// For actions with a config object, check if it's empty
+	if (requiredFields.includes("config")) {
+		const config = parseJsonSafe(nodeData.config);
+		const isEmpty =
+			!config ||
+			(Array.isArray(config) && config.length === 0) ||
+			(typeof config === "object" && Object.keys(config).length === 0);
+
+		if (isEmpty) {
+			return "not-configured";
+		}
+	}
+
+	// If configured, check if it's valid
+	const validation = validateAgainstContract(nodeData);
+	return validation.valid ? "configured" : "invalid";
 }
 
 /**

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/ConditionNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/ConditionNode.vue
@@ -4,9 +4,11 @@ import { useStore } from "../../stores";
 import { getContract } from "../../../core/contracts";
 import { computed } from "vue";
 import { useNodeExecutionState } from "../../composables/useNodeExecutionState";
+import { useNodeStatus } from "../../composables/useNodeStatus";
 import { useCanvasLayout } from "../../composables/useCanvasLayout";
 import NodeToolbar from "./NodeToolbar.vue";
 import InlineEditor from "./InlineEditor.vue";
+import NodeStatusIndicator from "./NodeStatusIndicator.vue";
 
 const props = defineProps(["data", "label", "id", "selected", "sourcePosition", "targetPosition"]);
 const store = useStore();
@@ -57,11 +59,7 @@ const conditionSummary = computed(() => {
 
 const nodeIdRef = computed(() => props.id);
 const { isExecuted, isRunning, isErrored, executionOrder } = useNodeExecutionState(nodeIdRef);
-
-const isConfigured = computed(() => {
-	const config = props.data?.config;
-	return config && Array.isArray(config.conditions) && config.conditions.length > 0;
-});
+const { status, errors } = useNodeStatus(nodeIdRef);
 
 function deleteNode() {
 	frappe.confirm(__("Delete this node?"), () => store.delete_node(props.id));
@@ -124,10 +122,7 @@ function openConfig() {
 
 		<!-- Footer/Status -->
 		<div class="node-footer">
-			<div class="config-status" :class="{ configured: isConfigured }">
-				<i class="fa" :class="isConfigured ? 'fa-check-circle' : 'fa-circle-o'"></i>
-				<span>{{ isConfigured ? __("Configured") : __("Not Configured") }}</span>
-			</div>
+			<NodeStatusIndicator :status="status" :errors="errors" @click="openConfig" />
 		</div>
 
 		<!-- True Output (Right/Bottom) -->

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/LoopNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/LoopNode.vue
@@ -3,9 +3,11 @@ import { computed } from "vue";
 import { Handle, Position } from "@vue-flow/core";
 import { useStore } from "../../stores";
 import { useNodeExecutionState } from "../../composables/useNodeExecutionState";
+import { useNodeStatus } from "../../composables/useNodeStatus";
 import { useCanvasLayout } from "../../composables/useCanvasLayout";
 import NodeToolbar from "./NodeToolbar.vue";
 import InlineEditor from "./InlineEditor.vue";
+import NodeStatusIndicator from "./NodeStatusIndicator.vue";
 
 const props = defineProps(["data", "label", "id", "selected", "sourcePosition", "targetPosition"]);
 const store = useStore();
@@ -31,11 +33,7 @@ const isReadOnly = computed(() => store.is_read_only);
 
 const nodeIdRef = computed(() => props.id);
 const { isExecuted, isRunning, isErrored, executionOrder } = useNodeExecutionState(nodeIdRef);
-
-const isConfigured = computed(() => {
-	const config = props.data?.config;
-	return config && config.iterator;
-});
+const { status, errors } = useNodeStatus(nodeIdRef);
 
 function deleteNode() {
 	frappe.confirm(__("Delete this node?"), () => store.delete_node(props.id));
@@ -111,10 +109,7 @@ function openConfig() {
 
 		<!-- Footer/Status -->
 		<div class="node-footer">
-			<div class="config-status" :class="{ configured: isConfigured }">
-				<i class="fa" :class="isConfigured ? 'fa-check-circle' : 'fa-circle-o'"></i>
-				<span>{{ isConfigured ? __("Configured") : __("Not Configured") }}</span>
-			</div>
+			<NodeStatusIndicator :status="status" :errors="errors" @click="openConfig" />
 		</div>
 
 		<!-- Iteration Handle: For Each → body branch -->

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/NodeStatusIndicator.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/NodeStatusIndicator.vue
@@ -7,6 +7,10 @@ const props = defineProps({
 		required: true,
 		validator: (val) => ["not-configured", "configured", "invalid"].includes(val),
 	},
+	label: {
+		type: String,
+		default: null,
+	},
 	errors: {
 		type: Array,
 		default: () => [],
@@ -18,19 +22,19 @@ const statusMeta = computed(() => {
 		case "invalid":
 			return {
 				icon: "fa-exclamation-circle",
-				label: __("Invalid Configuration"),
+				label: props.label || __("Invalid Configuration"),
 				class: "is-invalid",
 			};
 		case "configured":
 			return {
 				icon: "fa-check-circle",
-				label: __("Configured"),
+				label: props.label || __("Configured"),
 				class: "is-configured",
 			};
 		default:
 			return {
 				icon: "fa-circle-o",
-				label: __("Not Configured"),
+				label: props.label || __("Not Configured"),
 				class: "not-configured",
 			};
 	}

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/NodeStatusIndicator.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/NodeStatusIndicator.vue
@@ -1,0 +1,97 @@
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+	status: {
+		type: String,
+		required: true,
+		validator: (val) => ["not-configured", "configured", "invalid"].includes(val),
+	},
+	errors: {
+		type: Array,
+		default: () => [],
+	},
+});
+
+const statusMeta = computed(() => {
+	switch (props.status) {
+		case "invalid":
+			return {
+				icon: "fa-exclamation-circle",
+				label: __("Invalid Configuration"),
+				class: "is-invalid",
+			};
+		case "configured":
+			return {
+				icon: "fa-check-circle",
+				label: __("Configured"),
+				class: "is-configured",
+			};
+		default:
+			return {
+				icon: "fa-circle-o",
+				label: __("Not Configured"),
+				class: "not-configured",
+			};
+	}
+});
+
+const tooltipContent = computed(() => {
+	if (props.status === "invalid" && props.errors.length > 0) {
+		return props.errors.join("\n");
+	}
+	return statusMeta.value.label;
+});
+</script>
+
+<template>
+	<div class="node-status-indicator" :class="statusMeta.class" :title="tooltipContent">
+		<i class="fa" :class="statusMeta.icon"></i>
+		<span class="status-label">{{ statusMeta.label }}</span>
+	</div>
+</template>
+
+<style>
+.node-status-indicator {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 10px;
+	cursor: pointer;
+	color: var(--fxr-text-faint);
+	transition: all 0.2s ease;
+	--indicator-color: var(--fxr-text-faint);
+}
+
+.node-status-indicator.is-configured {
+	--indicator-color: var(--fxr-text-success, #198754);
+	color: var(--indicator-color);
+}
+
+.node-status-indicator.is-invalid {
+	--indicator-color: var(--fxr-text-danger, #dc3545);
+	color: var(--indicator-color);
+	font-weight: 600;
+}
+
+.node-status-indicator:hover {
+	opacity: 0.8;
+}
+
+.stop-node-card .node-status-indicator {
+	color: #ffffff !important;
+	opacity: 0.8;
+}
+
+.stop-node-card .node-status-indicator.is-invalid {
+	color: #fff1f2 !important;
+}
+
+.stop-node-card .node-status-indicator.is-invalid .status-label {
+	text-decoration: underline;
+}
+
+.node-status-indicator i {
+	font-size: 11px;
+}
+</style>

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/ProcessNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/ProcessNode.vue
@@ -4,9 +4,11 @@ import { Handle, Position } from "@vue-flow/core";
 import { useRuleStore, useGraphStore, useUIStore } from "../../stores";
 import { getContract } from "../../../core/contracts";
 import { useNodeExecutionState } from "../../composables/useNodeExecutionState";
+import { useNodeStatus } from "../../composables/useNodeStatus";
 import { useCanvasLayout } from "../../composables/useCanvasLayout";
 import NodeToolbar from "./NodeToolbar.vue";
 import InlineEditor from "./InlineEditor.vue";
+import NodeStatusIndicator from "./NodeStatusIndicator.vue";
 
 const props = defineProps(["data", "label", "id", "selected", "sourcePosition", "targetPosition"]);
 const ruleStore = useRuleStore();
@@ -44,31 +46,7 @@ const nodeMeta = computed(() => {
 
 const nodeIdRef = computed(() => props.id);
 const { isExecuted, isRunning, isErrored, executionOrder } = useNodeExecutionState(nodeIdRef);
-
-const isConfigured = computed(() => {
-	const actionType = props.data?.action_type;
-	if (!actionType) return false;
-
-	const contract = getContract(actionType);
-	const requiredFields = contract.required_fields || [];
-	const hasRequiredFields = requiredFields.every((fieldname) => {
-		const value = props.data?.[fieldname];
-		return value !== undefined && value !== null && value !== "";
-	});
-
-	if (!requiredFields.length) {
-		return true;
-	}
-
-	const config = props.data?.config;
-	const hasConfig =
-		config &&
-		(typeof config === "string"
-			? config.trim() !== "" && config.trim() !== "{}"
-			: Object.keys(config).length > 0);
-
-	return hasRequiredFields || hasConfig;
-});
+const { status, errors } = useNodeStatus(nodeIdRef);
 
 function deleteNode() {
 	frappe.confirm(__("Delete this node?"), () => graphStore.delete_node(props.id));
@@ -163,10 +141,7 @@ const isTerminal = computed(() => {
 
 		<!-- Footer/Status -->
 		<div class="node-footer">
-			<div class="config-status" :class="{ configured: isConfigured }">
-				<i class="fa" :class="isConfigured ? 'fa-check-circle' : 'fa-circle-o'"></i>
-				<span>{{ isConfigured ? __("Configured") : __("Not Configured") }}</span>
-			</div>
+			<NodeStatusIndicator :status="status" :errors="errors" @click="openConfig" />
 		</div>
 
 		<Handle

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/StartNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/StartNode.vue
@@ -4,9 +4,11 @@ import { useStore } from "../../stores";
 import { getContract } from "../../../core/contracts";
 import { computed } from "vue";
 import { useNodeExecutionState } from "../../composables/useNodeExecutionState";
+import { useNodeStatus } from "../../composables/useNodeStatus";
 import { useCanvasLayout } from "../../composables/useCanvasLayout";
 import NodeToolbar from "./NodeToolbar.vue";
 import InlineEditor from "./InlineEditor.vue";
+import NodeStatusIndicator from "./NodeStatusIndicator.vue";
 
 const props = defineProps(["data", "label", "id", "selected", "sourcePosition"]);
 const store = useStore();
@@ -60,6 +62,7 @@ const nodeMeta = computed(() => {
 
 const nodeIdRef = computed(() => props.id || "root");
 const { isExecuted, isRunning, isErrored, executionOrder } = useNodeExecutionState(nodeIdRef);
+const { status, errors } = useNodeStatus(nodeIdRef);
 
 function openConfig() {
 	store.open_config(props.id || "start");
@@ -123,6 +126,7 @@ function openConfig() {
 			>
 				<i class="fa fa-users"></i> {{ role }}
 			</span>
+			<NodeStatusIndicator :status="status" :errors="errors" @click="openConfig" />
 		</div>
 		<Handle
 			type="source"
@@ -320,6 +324,7 @@ function openConfig() {
 	gap: 4px;
 	pointer-events: all;
 	z-index: 5;
+	align-items: center;
 }
 
 .start-node-d:not(.is-vertical) .permission-flags {
@@ -362,6 +367,14 @@ function openConfig() {
 .permission-flag i {
 	margin-right: 4px;
 	color: var(--fxr-text-soft);
+}
+
+.permission-flags :deep(.node-status-indicator) {
+	background-color: var(--fxr-surface-soft);
+	border: 1px solid var(--fxr-border);
+	padding: 3px 8px;
+	border-radius: 12px;
+	box-shadow: var(--fxr-shadow-sm);
 }
 
 /* RTL Support */

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/StopNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/StopNode.vue
@@ -3,9 +3,11 @@ import { computed } from "vue";
 import { Handle, Position } from "@vue-flow/core";
 import { useStore } from "../../stores";
 import { useNodeExecutionState } from "../../composables/useNodeExecutionState";
+import { useNodeStatus } from "../../composables/useNodeStatus";
 import { useCanvasLayout } from "../../composables/useCanvasLayout";
 import NodeToolbar from "./NodeToolbar.vue";
 import InlineEditor from "./InlineEditor.vue";
+import NodeStatusIndicator from "./NodeStatusIndicator.vue";
 
 const props = defineProps(["data", "label", "id", "selected", "targetPosition"]);
 const store = useStore();
@@ -21,6 +23,7 @@ const isReadOnly = computed(() => store.is_read_only);
 
 const nodeIdRef = computed(() => props.id);
 const { isExecuted, isRunning, isErrored, executionOrder } = useNodeExecutionState(nodeIdRef);
+const { status, errors } = useNodeStatus(nodeIdRef);
 
 function deleteNode() {
 	frappe.confirm(__("Delete this node?"), () => store.delete_node(props.id));
@@ -80,10 +83,7 @@ function openConfig() {
 
 		<!-- Footer/Status -->
 		<div class="node-footer">
-			<div class="config-status configured">
-				<i class="fa fa-check-circle"></i>
-				<span>{{ __("Terminal") }}</span>
-			</div>
+			<NodeStatusIndicator :status="status" :errors="errors" @click="openConfig" />
 		</div>
 	</div>
 </template>

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/StopNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/StopNode.vue
@@ -83,7 +83,12 @@ function openConfig() {
 
 		<!-- Footer/Status -->
 		<div class="node-footer">
-			<NodeStatusIndicator :status="status" :errors="errors" @click="openConfig" />
+			<NodeStatusIndicator
+				:status="status"
+				:label="status === 'configured' ? __('Terminal') : null"
+				:errors="errors"
+				@click="openConfig"
+			/>
 		</div>
 	</div>
 </template>

--- a/flexirule/public/js/flexirule/rule_builder/composables/useNodeStatus.js
+++ b/flexirule/public/js/flexirule/rule_builder/composables/useNodeStatus.js
@@ -1,5 +1,5 @@
-import { computed, watch } from "vue";
-import { useRuleStore } from "../stores";
+import { computed } from "vue";
+import { useGraphStore } from "../stores";
 import { getNodeStatus, validateAgainstContract } from "../../core/contracts";
 
 /**
@@ -12,11 +12,11 @@ import { getNodeStatus, validateAgainstContract } from "../../core/contracts";
  * @returns {Object} { status, errors, isValid, isConfigured }
  */
 export function useNodeStatus(nodeIdRef) {
-	const ruleStore = useRuleStore();
+	const graphStore = useGraphStore();
 
 	const node = computed(() => {
 		const id = typeof nodeIdRef === "string" ? nodeIdRef : nodeIdRef.value;
-		return ruleStore.nodes.find((n) => n.id === id);
+		return graphStore.nodesMap.get(id);
 	});
 
 	const nodeData = computed(() => node.value?.data || {});

--- a/flexirule/public/js/flexirule/rule_builder/composables/useNodeStatus.js
+++ b/flexirule/public/js/flexirule/rule_builder/composables/useNodeStatus.js
@@ -28,7 +28,9 @@ export function useNodeStatus(nodeIdRef) {
 
 	const errors = computed(() => validation.value.errors || []);
 	const isValid = computed(() => validation.value.valid);
-	const isConfigured = computed(() => status.value === "configured" || status.value === "invalid");
+	const isConfigured = computed(
+		() => status.value === "configured" || status.value === "invalid"
+	);
 	const isInvalid = computed(() => status.value === "invalid");
 
 	return {

--- a/flexirule/public/js/flexirule/rule_builder/composables/useNodeStatus.js
+++ b/flexirule/public/js/flexirule/rule_builder/composables/useNodeStatus.js
@@ -1,0 +1,41 @@
+import { computed, watch } from "vue";
+import { useRuleStore } from "../stores";
+import { getNodeStatus, validateAgainstContract } from "../../core/contracts";
+
+/**
+ * useNodeStatus Composable
+ *
+ * Provides reactive status and validation errors for a specific node.
+ * Automatically re-validates when node data or rule-level metadata changes.
+ *
+ * @param {Ref<String>|ComputedRef<String>} nodeIdRef - Reference to the node ID
+ * @returns {Object} { status, errors, isValid, isConfigured }
+ */
+export function useNodeStatus(nodeIdRef) {
+	const ruleStore = useRuleStore();
+
+	const node = computed(() => {
+		const id = typeof nodeIdRef === "string" ? nodeIdRef : nodeIdRef.value;
+		return ruleStore.nodes.find((n) => n.id === id);
+	});
+
+	const nodeData = computed(() => node.value?.data || {});
+
+	// Status is derived using the centralized logic in contracts.js
+	const status = computed(() => getNodeStatus(nodeData.value));
+
+	const validation = computed(() => validateAgainstContract(nodeData.value));
+
+	const errors = computed(() => validation.value.errors || []);
+	const isValid = computed(() => validation.value.valid);
+	const isConfigured = computed(() => status.value === "configured" || status.value === "invalid");
+	const isInvalid = computed(() => status.value === "invalid");
+
+	return {
+		status,
+		errors,
+		isValid,
+		isConfigured,
+		isInvalid,
+	};
+}

--- a/flexirule/public/js/flexirule/rule_builder/composables/useRuleConfig.js
+++ b/flexirule/public/js/flexirule/rule_builder/composables/useRuleConfig.js
@@ -66,36 +66,14 @@ export function useRuleConfig(props, emit) {
 	async function validate() {
 		showValidation.value = true;
 		const errors = [];
-		const actionType = draftNode.value?.data?.action_type || draftNode.value?.type;
-		const contract = actionType ? getContract(actionType) : null;
-		const operation = draftNode.value?.data?.operation;
 
-		// 1. Contract-based Mandatory Field Validation
-		if (contract && contract.mandatory_fields) {
-			const reqFields =
-				contract.mandatory_fields[operation] || contract.mandatory_fields["*"] || [];
-			reqFields.forEach((f) => {
-				const val = draftNode.value.data?.[f];
-				if (val === undefined || val === null || val === "") {
-					// Use a descriptive label for the error message
-					const fieldLabel = f
-						.replace(/_/g, " ")
-						.replace(/\b\w/g, (c) => c.toUpperCase());
-					errors.push(
-						__("{0} is required for {1}")
-							.replace("{0}", fieldLabel)
-							.replace("{1}", operation || actionType)
-					);
-				}
-			});
+		// 1. Canonical Contract Validation (Handles mandatory fields, policies, etc.)
+		const contractRes = validateAgainstContract(draftNode.value.data);
+		if (!contractRes.valid) {
+			errors.push(...contractRes.errors);
 		}
 
-		// 2. Action Label is always good to have
-		if (!draftNode.value?.data?.action_label) {
-			// errors.push(__("Action Label is required"));
-		}
-
-		// 3. Panel-specific validation
+		// 2. Panel-specific deep validation (Component-level validation)
 		for (const [name, panelRef] of Object.entries(panelRefs)) {
 			if (panelRef.value && typeof panelRef.value.validate === "function") {
 				const res = await panelRef.value.validate();
@@ -106,18 +84,12 @@ export function useRuleConfig(props, emit) {
 			}
 		}
 
-		// 4. Permission Audit Reason (Global requirement when skipping)
+		// 3. Global Business Rules
 		if (
 			draftNode.value.data?.skip_permissions &&
 			!draftNode.value.data?.permission_audit_reason
 		) {
 			errors.push(__("Permission Audit Reason is required when bypassing permissions."));
-		}
-
-		// 5. Canonical Contract Validation
-		const contractRes = validateAgainstContract(draftNode.value.data);
-		if (!contractRes.valid) {
-			errors.push(...contractRes.errors);
 		}
 
 		return {

--- a/flexirule/public/js/flexirule/rule_builder/stores/useGraphStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useGraphStore.js
@@ -80,30 +80,65 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 	 * comparison only detects meaningful changes.
 	 */
 	function getStateSnapshot() {
+		/**
+		 * Stable stringification helper that ensures consistent key ordering.
+		 */
+		const stringifyStable = (obj) => {
+			if (obj === null || typeof obj !== "object") {
+				return JSON.stringify(obj);
+			}
+			if (Array.isArray(obj)) {
+				return "[" + obj.map(stringifyStable).join(",") + "]";
+			}
+			const keys = Object.keys(obj).sort();
+			return (
+				"{" +
+				keys.map((k) => JSON.stringify(k) + ":" + stringifyStable(obj[k])).join(",") +
+				"}"
+			);
+		};
+
 		const nodesSnap = nodes.value.map((el) => {
-			// Deep clone data to avoid reference pollution
-			const data = JSON.parse(JSON.stringify(el.data || {}));
+			// Deep clone data and sort its keys for stability
+			const rawData = JSON.parse(JSON.stringify(el.data || {}));
+			// We don't need to recursively sort every object here because stringifyStable
+			// will handle the nested objects when comparing snapshots if we used it,
+			// but getStateSnapshot returns an array of objects which is then stringified.
+			// To be absolutely safe, we'll return the data as-is but ensure the top-level
+			// snapshot objects themselves have a stable structure.
+
 			return {
+				data: rawData,
 				id: el.id,
-				type: el.type,
 				label: el.label,
-				data: data,
 				position: {
 					x: Math.round(el.position?.x || 0),
 					y: Math.round(el.position?.y || 0),
 				},
+				type: el.type,
 			};
 		});
+
 		const edgesSnap = edges.value.map((el) => ({
 			id: el.id,
 			source: el.source,
-			target: el.target,
 			sourceHandle: el.sourceHandle || "default",
+			target: el.target,
 			targetHandle: el.targetHandle || null,
 		}));
 
-		// Return a flat array to maintain compatibility with existing logic
-		return [...nodesSnap, ...edgesSnap].sort((a, b) => (a.id || "").localeCompare(b.id || ""));
+		// Standardize the flat array by sorting everything by ID.
+		// Since we use JSON.stringify(getStateSnapshot()) for comparison,
+		// we must ensure the key order within nodesSnap/edgesSnap objects is also stable.
+		// We've done this above by defining keys in alphabetical order.
+
+		const combined = [...nodesSnap, ...edgesSnap].sort((a, b) =>
+			(a.id || "").localeCompare(b.id || "")
+		);
+
+		// Final pass: ensure all nested objects in 'data' are also stable by re-parsing
+		// a stable-stringified version. This is slower but guarantees dirty tracking accuracy.
+		return JSON.parse(stringifyStable(combined));
 	}
 
 	function getGraphSnapshot() {

--- a/flexirule/public/js/flexirule/rule_builder/stores/useGraphStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useGraphStore.js
@@ -31,6 +31,14 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 	const nodes = ref([]);
 	const edges = ref([]);
 
+	const nodesMap = computed(() => {
+		const map = new Map();
+		nodes.value.forEach((node) => {
+			map.set(node.id, node);
+		});
+		return map;
+	});
+
 	// ── Cascade disable computed ──
 	// BFS from start node: any node not reachable via enabled path is "effectively disabled"
 	const effectiveDisabledIds = computed(() => {
@@ -2067,5 +2075,6 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 		getAutoConnectSource,
 		autoConnectNode,
 		autoConnectStartNode,
+		nodesMap,
 	};
 });

--- a/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
@@ -24,7 +24,11 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 	const rule_doc = ref(null);
 	const _is_dirty = ref(false); // Manual override flag if needed
 	const is_dirty = computed(() => {
-		if (is_read_only.value) return false;
+		if (is_read_only.value || is_loading.value) return false;
+
+		const uiStore = useUIStore();
+		if (uiStore.is_initializing || uiStore.is_performing_layout) return false;
+
 		if (_is_dirty.value) return true;
 		return checkDirty();
 	});
@@ -165,6 +169,10 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 		}
 
 		setup_breadcrumbs();
+
+		// We wait for nextTick to ensure all reactive changes from
+		// graphStore sync and normalize have settled before we capture the baseline.
+		await nextTick();
 		initial_state.value = JSON.stringify(graphStore.getStateSnapshot());
 		_is_dirty.value = false;
 
@@ -601,35 +609,50 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 	// ── Dirty tracking ──
 	function mark_dirty() {
 		const uiStore = useUIStore();
-		if (is_read_only.value || is_loading.value || uiStore.is_initializing) return;
+		if (
+			is_read_only.value ||
+			is_loading.value ||
+			uiStore.is_initializing ||
+			uiStore.is_performing_layout
+		) {
+			return;
+		}
 
-		// Set flag for immediate UI response
-		_is_dirty.value = true;
-
-		// Commit to history
-		const historyStore = useHistoryStore();
-		const graphStore = useGraphStore();
-		historyStore.commit(() => graphStore.getGraphSnapshot());
+		if (checkDirty()) {
+			_is_dirty.value = true;
+			const historyStore = useHistoryStore();
+			const graphStore = useGraphStore();
+			historyStore.commit(() => graphStore.getGraphSnapshot());
+		}
 	}
 
 	function mark_position_change() {
 		const uiStore = useUIStore();
-		if (is_read_only.value || is_loading.value || uiStore.is_initializing) return;
+		if (
+			is_read_only.value ||
+			is_loading.value ||
+			uiStore.is_initializing ||
+			uiStore.is_performing_layout
+		) {
+			return;
+		}
 
-		_is_dirty.value = true;
-
-		// Positions are checked by checkDirty in the computed is_dirty
-		const graphStore = useGraphStore();
-		const historyStore = useHistoryStore();
-		historyStore.commit(() => graphStore.getGraphSnapshot());
+		if (checkDirty()) {
+			_is_dirty.value = true;
+			const graphStore = useGraphStore();
+			const historyStore = useHistoryStore();
+			historyStore.commit(() => graphStore.getGraphSnapshot());
+		}
 	}
 
 	function checkDirty() {
 		if (is_read_only.value || !initial_state.value) return false;
 		const graphStore = useGraphStore();
-		// Ensure nodes and edges are accessed for reactivity
-		const currentNodes = graphStore.nodes;
-		const currentEdges = graphStore.edges;
+
+		// Access nodes/edges for reactivity
+		const _nodes = graphStore.nodes;
+		const _edges = graphStore.edges;
+
 		const current = JSON.stringify(graphStore.getStateSnapshot());
 		return current !== initial_state.value;
 	}

--- a/flexirule/ruleflow/core/contracts.py
+++ b/flexirule/ruleflow/core/contracts.py
@@ -42,7 +42,6 @@ ACTION_TYPE_CONTRACT: dict[str, dict[str, Any]] = {
 	},
 	"Condition": {
 		"required_fields": ["config"],
-		"required_config_keys": ["conditions"],
 		"has_next_true": True,
 		"has_next_false": True,
 		"terminal": False,
@@ -92,8 +91,7 @@ ACTION_TYPE_CONTRACT: dict[str, dict[str, Any]] = {
 		"config_component": "ProcessConfig",
 	},
 	"Loop": {
-		"required_fields": ["config", "return_variable"],
-		"required_config_keys": ["iterator"],
+		"required_fields": ["config", "return_variable"],  # config must have iterator
 		"has_next_true": True,  # Loop body
 		"has_next_false": True,  # Loop exit
 		"terminal": False,

--- a/flexirule/ruleflow/core/contracts.py
+++ b/flexirule/ruleflow/core/contracts.py
@@ -42,6 +42,7 @@ ACTION_TYPE_CONTRACT: dict[str, dict[str, Any]] = {
 	},
 	"Condition": {
 		"required_fields": ["config"],
+		"required_config_keys": ["conditions"],
 		"has_next_true": True,
 		"has_next_false": True,
 		"terminal": False,
@@ -91,7 +92,8 @@ ACTION_TYPE_CONTRACT: dict[str, dict[str, Any]] = {
 		"config_component": "ProcessConfig",
 	},
 	"Loop": {
-		"required_fields": ["config", "return_variable"],  # config must have iterator
+		"required_fields": ["config", "return_variable"],
+		"required_config_keys": ["iterator"],
 		"has_next_true": True,  # Loop body
 		"has_next_false": True,  # Loop exit
 		"terminal": False,

--- a/flexirule/ruleflow/core/contracts.py
+++ b/flexirule/ruleflow/core/contracts.py
@@ -4,9 +4,15 @@
 """
 Unified Backend/Frontend Contract for FlexiRule Action Types
 
-This module defines the contract for action types that is shared between:
-- Backend validation (Rule.validate)
-- Frontend rendering (rule_builder/store.js)
+CANONICAL SOURCE OF TRUTH:
+This file (flexirule/ruleflow/core/contracts.py) is the canonical source of truth
+for all action contracts, required fields, and operation policies.
+
+SYNC PROTOCOL:
+1. Backend validation (Rule.validate) uses these definitions directly.
+2. The frontend (flexirule/public/js/flexirule/core/contracts.js) MUST be kept
+   in sync with this file to ensure consistent UI status and real-time validation.
+3. Use 'get_contract_dto' API to transfer these definitions to the frontend.
 """
 
 from __future__ import annotations

--- a/flexirule/ruleflow/core/validation_service.py
+++ b/flexirule/ruleflow/core/validation_service.py
@@ -403,8 +403,9 @@ def _validate_action_contracts(
 
 	# Validation based on required_config_keys (from both policy and contract)
 	required_config_keys = list(effective_policy.get("required_config_keys") or [])
-	if contract.get("required_config_keys"):
-		required_config_keys.extend(contract.get("required_config_keys"))
+	contract_keys = contract.get("required_config_keys")
+	if isinstance(contract_keys, list):
+		required_config_keys.extend(contract_keys)
 
 	if required_config_keys:
 		config_data = _parse_json_value(_safe_get(action, "config"), {})
@@ -444,13 +445,14 @@ def _validate_action_specifics(
 			_validate_sub_rule_input_mapping(action, errors)
 
 	elif action_type == "Condition":
-		# Legacy/Specific check if required_config_keys doesn't cover it (e.g. if compiled_expression is used instead)
-		if (
-			get_condition_payload(action) is None
-			and _is_empty(_safe_get(action, "compiled_expression"))
-			and "conditions" not in (get_contract(action_type).get("required_config_keys") or [])
-		):
+		if get_condition_payload(action) is None and _is_empty(_safe_get(action, "compiled_expression")):
 			errors.append(_("Action '{0}' is a Condition but no condition is defined.").format(action_label))
+
+	elif action_type == "Loop":
+		if not config.get("iterator"):
+			warnings.append(
+				_("Action '{0}' is a Loop but iterator configuration may be incomplete.").format(action_label)
+			)
 
 	elif action_type == "Switch":
 		if not config.get("cases"):

--- a/flexirule/ruleflow/core/validation_service.py
+++ b/flexirule/ruleflow/core/validation_service.py
@@ -401,6 +401,25 @@ def _validate_action_contracts(
 			_("Action '{0}' ({1}) does not support 'next step if false'").format(action_label, action_type)
 		)
 
+	# Validation based on required_config_keys (from both policy and contract)
+	required_config_keys = list(effective_policy.get("required_config_keys") or [])
+	if contract.get("required_config_keys"):
+		required_config_keys.extend(contract.get("required_config_keys"))
+
+	if required_config_keys:
+		config_data = _parse_json_value(_safe_get(action, "config"), {})
+		if not isinstance(config_data, Mapping):
+			config_data = {}
+
+		for key in required_config_keys:
+			value = config_data.get(key)
+			if _is_empty(value):
+				errors.append(
+					_("Action '{0}' ({1}) requires configuration key '{2}'").format(
+						action_label, action_type, key
+					)
+				)
+
 
 def _validate_action_specifics(
 	rule_doc,
@@ -425,14 +444,13 @@ def _validate_action_specifics(
 			_validate_sub_rule_input_mapping(action, errors)
 
 	elif action_type == "Condition":
-		if get_condition_payload(action) is None and _is_empty(_safe_get(action, "compiled_expression")):
+		# Legacy/Specific check if required_config_keys doesn't cover it (e.g. if compiled_expression is used instead)
+		if (
+			get_condition_payload(action) is None
+			and _is_empty(_safe_get(action, "compiled_expression"))
+			and "conditions" not in (get_contract(action_type).get("required_config_keys") or [])
+		):
 			errors.append(_("Action '{0}' is a Condition but no condition is defined.").format(action_label))
-
-	elif action_type == "Loop":
-		if not config.get("iterator"):
-			warnings.append(
-				_("Action '{0}' is a Loop but iterator configuration may be incomplete.").format(action_label)
-			)
 
 	elif action_type == "Switch":
 		if not config.get("cases"):


### PR DESCRIPTION
This PR unifies the visual status indicators across all node types in the Rule Builder canvas and significantly improves the frontend validation logic. Key changes include the introduction of a dedicated 'Invalid' state (distinguishable from 'Not Configured'), a centralized validation and status derivation engine in `contracts.js`, and a reactive `useNodeStatus` composable. All node components have been updated to display these statuses consistently in their footers (or relevant UI zones for Start nodes). Configuration modal validation has also been streamlined to ensure it aligns perfectly with the canvas-level status.

---
*PR created automatically by Jules for task [15070821396632979684](https://jules.google.com/task/15070821396632979684) started by @ruzaqiarkan-eng*