### PR TITLE
Remove Canvas Layout Toggle and Synchronize With RuleFlow Settings

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/App.vue
+++ b/flexirule/public/js/flexirule/rule_builder/App.vue
@@ -7,15 +7,38 @@
 				:class="{
 					'has-execution-bottom':
 						uiStore.test_execution_steps?.length &&
-						ruleStore.settings?.layout_direction !== 'Top to Bottom',
+						uiStore.layout_preference === 'LR',
 					'has-execution-right':
 						uiStore.test_execution_steps?.length &&
-						ruleStore.settings?.layout_direction === 'Top to Bottom',
+						uiStore.layout_preference === 'TB',
+					'has-banner': uiStore.show_layout_mismatch_banner && !uiStore.dismissed_layout_banner
 				}"
 				ref="flowWrapper"
 				@dragover="onDragOver"
 				@drop="onDrop"
 			>
+				<div
+					v-if="uiStore.show_layout_mismatch_banner && !uiStore.dismissed_layout_banner"
+					class="layout-mismatch-banner"
+				>
+					<div class="banner-content">
+						<i class="fa fa-info-circle banner-icon"></i>
+						<span>{{
+							__("This rule is using a different layout direction than the current RuleFlow default.")
+						}}</span>
+					</div>
+					<div class="banner-actions">
+						<button
+							class="btn btn-xs btn-primary-light"
+							@click="ruleStore.apply_ruleflow_layout()"
+						>
+							{{ __("Apply RuleFlow Layout") }}
+						</button>
+						<button class="btn btn-xs btn-link text-muted" @click="uiStore.dismissed_layout_banner = true">
+							{{ __("Dismiss") }}
+						</button>
+					</div>
+				</div>
 				<VueFlow
 					:dir="isRTL ? 'rtl' : 'ltr'"
 					:edges-editable="false"
@@ -126,24 +149,6 @@
 
 						<div class="divider-vertical"></div>
 
-						<div class="btn-group controls-row">
-							<button
-								class="btn btn-sm btn-default d-inline-flex align-items-center gap-2"
-								@click="toggleLayout"
-								:title="__('Switch Layout Orientation')"
-							>
-								<i
-									class="fa"
-									:class="isHorizontal ? 'fa-columns' : 'fa-align-justify'"
-								></i>
-								<span class="small font-weight-bold">{{
-									isHorizontal ? __("Vertical") : __("Horizontal")
-								}}</span>
-							</button>
-						</div>
-
-						<div class="divider-vertical"></div>
-
 						<div v-if="isReadOnly" class="read-only-badge mr-2">
 							<i class="fa fa-lock"></i> {{ __("Read Only") }}
 						</div>
@@ -180,7 +185,7 @@
 				</VueFlow>
 				<DebuggerPath
 					v-if="uiStore.test_execution_steps?.length"
-					:layout="ruleStore.settings?.layout_direction === 'Top to Bottom' ? 'TB' : 'LR'"
+					:layout="uiStore.layout_preference"
 				/>
 			</div>
 			<div
@@ -280,7 +285,6 @@ const metaStore = useMetaStore();
 
 const { zoomIn, zoomOut, removeEdges, fitView } = useVueFlow();
 const { layoutGraph } = useRuleGraph();
-const { isHorizontal, toggleLayout } = useCanvasLayout();
 const { copySelectedToClipboard, pasteFromClipboard } = useClipboard();
 const { registerShortcut, pushContext, popContext } = useKeyboardRegistry();
 const showQuickActions = ref(false);
@@ -443,8 +447,7 @@ function handleQuickActionsKeydown(e) {
 }
 
 function runAutoLayout() {
-	const dir = ruleStore.settings?.layout_direction === "Top to Bottom" ? "TB" : "LR";
-	layoutGraph(dir);
+	layoutGraph(uiStore.layout_preference);
 	showQuickActions.value = false;
 }
 
@@ -731,8 +734,7 @@ function insertNodeOnEdge(payload) {
 				clipboard.edges
 			);
 			if (newNodeId) {
-				const dir = ruleStore.settings?.layout_direction === "Left to Right" ? "LR" : "TB";
-				setTimeout(() => layoutGraph(dir), 50);
+				setTimeout(() => layoutGraph(uiStore.layout_preference), 50);
 				frappe.show_alert({ message: __("Nodes pasted on edge"), indicator: "green" }, 2);
 			}
 		}
@@ -745,9 +747,8 @@ function insertNodeOnEdge(payload) {
 		payload
 	);
 	if (newNodeId) {
-		const dir = ruleStore.settings?.layout_direction === "Top to Bottom" ? "TB" : "LR";
 		setTimeout(() => {
-			layoutGraph(dir);
+			layoutGraph(uiStore.layout_preference);
 			// Auto-open config for nodes that require immediate configuration
 			const NEEDS_CONFIG_NOW = ["Condition", "Loop", "Switch"];
 			const insertedNode = graphStore.nodes.find((n) => n.id === newNodeId);
@@ -1054,6 +1055,57 @@ function onEdgeClick({ edge, event }) {
 
 :deep(.executed .execution-badge) {
 	background: var(--green-600, #16a34a) !important;
+}
+.layout-mismatch-banner {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 8px 16px;
+	background-color: var(--fxr-info-soft, #e0f2fe);
+	border-bottom: 1px solid var(--fxr-info-border, #bae6fd);
+	border-radius: var(--fxr-radius-lg) var(--fxr-radius-lg) 0 0;
+	z-index: 20;
+}
+
+.banner-content {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	color: var(--fxr-info-text, #0369a1);
+	font-size: 13px;
+	font-weight: 500;
+}
+
+.banner-icon {
+	font-size: 14px;
+	opacity: 0.9;
+}
+
+.banner-actions {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+}
+
+.btn-primary-light {
+	background-color: var(--fxr-info-text, #0369a1);
+	color: white;
+	border: none;
+	font-weight: 600;
+}
+
+.btn-primary-light:hover {
+	background-color: #025a87;
+	color: white;
+}
+
+.canvas-container.has-banner {
+	display: flex;
+	flex-direction: column;
+}
+
+.canvas-container.has-banner :deep(.vue-flow) {
+	flex: 1;
 }
 .toolbar-center {
 	display: flex;

--- a/flexirule/public/js/flexirule/rule_builder/App.vue
+++ b/flexirule/public/js/flexirule/rule_builder/App.vue
@@ -6,12 +6,11 @@
 				class="canvas-container"
 				:class="{
 					'has-execution-bottom':
-						uiStore.test_execution_steps?.length &&
-						uiStore.layout_preference === 'LR',
+						uiStore.test_execution_steps?.length && uiStore.layout_preference === 'LR',
 					'has-execution-right':
-						uiStore.test_execution_steps?.length &&
-						uiStore.layout_preference === 'TB',
-					'has-banner': uiStore.show_layout_mismatch_banner && !uiStore.dismissed_layout_banner
+						uiStore.test_execution_steps?.length && uiStore.layout_preference === 'TB',
+					'has-banner':
+						uiStore.show_layout_mismatch_banner && !uiStore.dismissed_layout_banner,
 				}"
 				ref="flowWrapper"
 				@dragover="onDragOver"
@@ -24,7 +23,9 @@
 					<div class="banner-content">
 						<i class="fa fa-info-circle banner-icon"></i>
 						<span>{{
-							__("This rule is using a different layout direction than the current RuleFlow default.")
+							__(
+								"This rule is using a different layout direction than the current RuleFlow default."
+							)
 						}}</span>
 					</div>
 					<div class="banner-actions">
@@ -34,7 +35,10 @@
 						>
 							{{ __("Apply RuleFlow Layout") }}
 						</button>
-						<button class="btn btn-xs btn-link text-muted" @click="uiStore.dismissed_layout_banner = true">
+						<button
+							class="btn btn-xs btn-link text-muted"
+							@click="uiStore.dismissed_layout_banner = true"
+						>
 							{{ __("Dismiss") }}
 						</button>
 					</div>

--- a/flexirule/public/js/flexirule/rule_builder/composables/useCanvasLayout.js
+++ b/flexirule/public/js/flexirule/rule_builder/composables/useCanvasLayout.js
@@ -23,19 +23,10 @@ export function useCanvasLayout() {
 	const sourcePosition = computed(() => (isHorizontal.value ? Position.Right : Position.Bottom));
 	const targetPosition = computed(() => (isHorizontal.value ? Position.Left : Position.Top));
 
-	function toggleLayout() {
-		const newDir = layoutOrientation.value === "LR" ? "TB" : "LR";
-		layoutOrientation.value = newDir;
-
-		// Trigger re-layout with animation
-		layoutGraph(newDir);
-	}
-
 	return {
 		layoutOrientation,
 		isHorizontal,
 		sourcePosition,
 		targetPosition,
-		toggleLayout,
 	};
 }

--- a/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
@@ -138,17 +138,28 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 		// Build graph from actions (mirrors workflow_builder: get_workflow_elements)
 		graphStore.sync_actions_to_graph(rule_doc.value);
 
+		const defaultLayout = settings.value?.layout_direction === "Top to Bottom" ? "TB" : "LR";
 		let needs_auto_layout = false;
+		uiStore.show_layout_mismatch_banner = false;
+		uiStore.dismissed_layout_banner = false;
+
 		if (visual_data && visual_data.length > 0) {
 			graphStore.merge_visual_layout(visual_data);
 
-			// Smart layout detection: if stored layout differs from UI preference, re-layout
-			const storedPref = visual_data.find((el) => el.type === "ui_preferences")?.layout;
-			if (storedPref && storedPref !== uiStore.layout_preference) {
+			const storedLayout = visual_data.find((el) => el.type === "ui_preferences")?.layout;
+			if (storedLayout) {
+				uiStore.layout_preference = storedLayout;
+				if (storedLayout !== defaultLayout) {
+					uiStore.show_layout_mismatch_banner = true;
+				}
+			} else {
+				// No stored layout, use default
+				uiStore.layout_preference = defaultLayout;
 				needs_auto_layout = true;
 			}
 		} else {
 			// Brand new rule or missing visual data
+			uiStore.layout_preference = defaultLayout;
 			needs_auto_layout = true;
 		}
 
@@ -729,6 +740,21 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 		uiStore.navigate_node(graphStore.nodes, -1);
 	}
 
+	async function apply_ruleflow_layout() {
+		const { useRuleGraph } = await import("../composables/useRuleGraph");
+		const { layoutGraph } = useRuleGraph();
+
+		const defaultLayout = settings.value?.layout_direction === "Top to Bottom" ? "TB" : "LR";
+		uiStore.layout_preference = defaultLayout;
+
+		// Recompute node positions and entire canvas
+		layoutGraph(defaultLayout);
+		uiStore.show_layout_mismatch_banner = false;
+
+		// Mark as modified if required
+		mark_dirty();
+	}
+
 	// ── Undo/Redo coordination ──
 	function undo() {
 		if (is_read_only.value) return;
@@ -957,5 +983,6 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 		open_config,
 		next_config_node,
 		prev_config_node,
+		apply_ruleflow_layout,
 	};
 });

--- a/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
@@ -743,6 +743,7 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 	async function apply_ruleflow_layout() {
 		const { useRuleGraph } = await import("../composables/useRuleGraph");
 		const { layoutGraph } = useRuleGraph();
+		const uiStore = useUIStore();
 
 		const defaultLayout = settings.value?.layout_direction === "Top to Bottom" ? "TB" : "LR";
 		uiStore.layout_preference = defaultLayout;

--- a/flexirule/public/js/flexirule/rule_builder/stores/useUIStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useUIStore.js
@@ -17,22 +17,13 @@ export const useUIStore = defineStore("rule-builder-ui", () => {
 	const is_initializing = ref(false);
 	const is_performing_layout = ref(false);
 	const layout_preference = ref("LR"); // "LR" | "TB"
+	const show_layout_mismatch_banner = ref(false);
+	const dismissed_layout_banner = ref(false);
 
 	// ── Developer / Debug ──
 	const is_field_reveal_active = ref(false);
 	const is_developer_mode = computed(() => {
 		return !!(window.frappe && frappe.boot && frappe.boot.developer_mode);
-	});
-
-	// Keep preference in sync with localStorage for session persistence
-	// but the primary persistence is in Rule visual_data
-	const saved_pref = localStorage.getItem("flexirule_layout_preference");
-	if (saved_pref) {
-		layout_preference.value = saved_pref;
-	}
-
-	watch(layout_preference, (val) => {
-		localStorage.setItem("flexirule_layout_preference", val);
 	});
 
 	// ── Config Modal ──
@@ -206,6 +197,8 @@ export const useUIStore = defineStore("rule-builder-ui", () => {
 		test_multi_results,
 		test_current_multi_index,
 		is_initializing,
+		show_layout_mismatch_banner,
+		dismissed_layout_banner,
 
 		// Computed
 		has_selection,


### PR DESCRIPTION
Simplified layout management by making RuleFlow Settings the authoritative source for the preferred layout direction and removing the layout orientation toggle from the canvas toolbar.

Key changes:
1. Updated `useUIStore.js` to manage layout mismatch banner state and removed obsolete localStorage persistence.
2. Enhanced `useRuleStore.js` to detect layout mismatches during rule fetch and provide a synchronization action (`apply_ruleflow_layout`).
3. Modified `App.vue` to remove the toolbar toggle and display the non-blocking informational banner when a mismatch exists.
4. Refactored `useCanvasLayout.js` to remove manual toggle logic while maintaining reactive orientation properties for node handles.
5. Ensured new rules inherit the global RuleFlow default layout.

---
*PR created automatically by Jules for task [13659391480003462251](https://jules.google.com/task/13659391480003462251) started by @ruzaqiarkan-eng*