### PR TITLE
Fix linter errors and apply formatting

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/App.vue
+++ b/flexirule/public/js/flexirule/rule_builder/App.vue
@@ -6,12 +6,11 @@
 				class="canvas-container"
 				:class="{
 					'has-execution-bottom':
-						uiStore.test_execution_steps?.length &&
-						uiStore.layout_preference === 'LR',
+						uiStore.test_execution_steps?.length && uiStore.layout_preference === 'LR',
 					'has-execution-right':
-						uiStore.test_execution_steps?.length &&
-						uiStore.layout_preference === 'TB',
-					'has-banner': uiStore.show_layout_mismatch_banner && !uiStore.dismissed_layout_banner
+						uiStore.test_execution_steps?.length && uiStore.layout_preference === 'TB',
+					'has-banner':
+						uiStore.show_layout_mismatch_banner && !uiStore.dismissed_layout_banner,
 				}"
 				ref="flowWrapper"
 				@dragover="onDragOver"
@@ -24,7 +23,9 @@
 					<div class="banner-content">
 						<i class="fa fa-info-circle banner-icon"></i>
 						<span>{{
-							__("This rule is using a different layout direction than the current RuleFlow default.")
+							__(
+								"This rule is using a different layout direction than the current RuleFlow default."
+							)
 						}}</span>
 					</div>
 					<div class="banner-actions">
@@ -34,7 +35,10 @@
 						>
 							{{ __("Apply RuleFlow Layout") }}
 						</button>
-						<button class="btn btn-xs btn-link text-muted" @click="uiStore.dismissed_layout_banner = true">
+						<button
+							class="btn btn-xs btn-link text-muted"
+							@click="uiStore.dismissed_layout_banner = true"
+						>
 							{{ __("Dismiss") }}
 						</button>
 					</div>

--- a/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
@@ -743,6 +743,7 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 	async function apply_ruleflow_layout() {
 		const { useRuleGraph } = await import("../composables/useRuleGraph");
 		const { layoutGraph } = useRuleGraph();
+		const uiStore = useUIStore();
 
 		const defaultLayout = settings.value?.layout_direction === "Top to Bottom" ? "TB" : "LR";
 		uiStore.layout_preference = defaultLayout;


### PR DESCRIPTION
This PR runs the project's pre-commit hooks and fixes the resulting linter and formatting errors. Specifically, it resolves a `no-undef` error in `useRuleStore.js` and applies standard formatting to `App.vue`.

---
*PR created automatically by Jules for task [16992800669638910290](https://jules.google.com/task/16992800669638910290) started by @ruzaqiarkan-eng*