### PR TITLE
Fix Semgrep relaxed-permissions findings in Action Type and Data Review Task

### DIFF
--- a/flexirule/ruleflow/doctype/action_type/action_type.json
+++ b/flexirule/ruleflow/doctype/action_type/action_type.json
@@ -74,7 +74,7 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "All",
+   "role": "Rule Manager",
    "select": 1,
    "share": 1
   }

--- a/flexirule/ruleflow/doctype/data_review_task/data_review_task.json
+++ b/flexirule/ruleflow/doctype/data_review_task/data_review_task.json
@@ -186,7 +186,7 @@
 			"print": 1,
 			"read": 1,
 			"report": 1,
-			"role": "All",
+			"role": "Rule Manager",
 			"write": 1
 		}
 	],


### PR DESCRIPTION
This PR addresses two Semgrep security findings (relaxed-permissions) in the FlexiRule application. The "All" role was used in the permission settings for `Action Type` and `Data Review Task` DocTypes, which could allow unauthorized access by website users. These have been updated to use the more appropriate "Rule Manager" role.

Verification:
- Backend tests passed using `bench --site test_site run-tests --app flexirule`.
- All pre-commit hooks passed.
- Code review confirmed the fix is correct and follows Frappe best practices.

---
*PR created automatically by Jules for task [9749309351573209817](https://jules.google.com/task/9749309351573209817) started by @ruzaqiarkan-eng*