### PR TITLE
Fix JSONDecodeError in link filters

### DIFF
--- a/flexirule/public/js/flexirule/core/control_registry.js
+++ b/flexirule/public/js/flexirule/core/control_registry.js
@@ -128,6 +128,7 @@ ControlRegistry.registerDefault({
 				filters = JSON.parse(filters);
 			} catch (e) {
 				console.warn("FlexiRule: Failed to parse link_filters for", df.fieldname, e);
+				filters = {};
 			}
 		}
 

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/ActionSettings.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/ActionSettings.vue
@@ -262,10 +262,11 @@ function getDoctypeForLink(df) {
 function getLinkFilters(df) {
 	if (!df.link_filters) return {};
 	try {
-		if (typeof df.link_filters === "string") {
-			return JSON.parse(df.link_filters);
+		let filters = df.link_filters;
+		if (typeof filters === "string") {
+			filters = JSON.parse(filters);
 		}
-		return df.link_filters;
+		return filters && typeof filters === "object" ? filters : {};
 	} catch (e) {
 		console.warn("FlexiRule: Failed to parse link_filters for", df.fieldname, e);
 		return {};

--- a/flexirule/public/js/flexirule/rule_builder/stores/useMetaStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useMetaStore.js
@@ -227,12 +227,14 @@ export const useMetaStore = defineStore("rule-builder-meta", () => {
 			return link_options_cache[key];
 		}
 
+		const sanitizedFilters = filters && typeof filters === "object" ? filters : {};
+
 		const response = await frappe.call({
 			method: "frappe.desk.search.search_link",
 			args: {
 				doctype,
 				txt,
-				filters: filters || {},
+				filters: sanitizedFilters,
 				start,
 				page_length,
 			},

--- a/flexirule/ruleflow/core/contracts.py
+++ b/flexirule/ruleflow/core/contracts.py
@@ -512,7 +512,7 @@ OPERATION_CONTRACTS: dict[str, dict[str, Any]] = {
 				"fieldname": "rule",
 				"reqd": 1,
 				"options": "Rule",
-				"link_filters": "[['Rule','trigger_type','=','Callable Event'],['Rule','exposed_as_subrule','=',1],['Rule','is_active','=',1]]",
+				"link_filters": '[["Rule","trigger_type","=","Callable Event"],["Rule","exposed_as_subrule","=",1],["Rule","is_active","=",1]]',
 			},
 			{
 				"fieldname": "skip_conditions",
@@ -618,7 +618,7 @@ OPERATION_CONTRACTS: dict[str, dict[str, Any]] = {
 			{
 				"fieldname": "reference_doctype",
 				"reqd": 1,
-				"link_filters": "[['DocType','issingle','=',0],['DocType','istable','=',0]]",
+				"link_filters": '[["DocType","issingle","=",0],["DocType","istable","=",0]]',
 			},
 			{
 				"fieldname": "config",
@@ -662,7 +662,7 @@ OPERATION_CONTRACTS: dict[str, dict[str, Any]] = {
 			{
 				"fieldname": "reference_doctype",
 				"reqd": 0,
-				"link_filters": "[['DocType','istable','=',0]]",
+				"link_filters": '[["DocType","istable","=",0]]',
 			},
 			{"fieldname": "config", "depends_on": "eval:doc.reference_doctype", "reqd": 1},
 			{
@@ -686,7 +686,7 @@ OPERATION_CONTRACTS: dict[str, dict[str, Any]] = {
 			{
 				"fieldname": "reference_doctype",
 				"reqd": 1,
-				"link_filters": "[['DocType','issingle','=',0],['DocType','istable','=',0]]",
+				"link_filters": '[["DocType","issingle","=",0],["DocType","istable","=",0]]',
 			},
 			{"fieldname": "config", "depends_on": "eval:doc.reference_doctype", "reqd": 1},
 			{"fieldname": "return_type", "default": "Yes / No", "read_only": 1},
@@ -706,7 +706,7 @@ OPERATION_CONTRACTS: dict[str, dict[str, Any]] = {
 			{
 				"fieldname": "reference_doctype",
 				"reqd": 1,
-				"link_filters": "[['DocType','issingle','=',0],['DocType','istable','=',0]]",
+				"link_filters": '[["DocType","issingle","=",0],["DocType","istable","=",0]]',
 			},
 			{"fieldname": "config", "depends_on": "eval:doc.reference_doctype", "reqd": 1},
 			{"fieldname": "return_type", "default": "List of Records", "read_only": 1},
@@ -728,7 +728,7 @@ OPERATION_CONTRACTS: dict[str, dict[str, Any]] = {
 			{
 				"fieldname": "reference_doctype",
 				"reqd": 1,
-				"link_filters": "[['DocType','issingle','=',0],['DocType','istable','=',0]]",
+				"link_filters": '[["DocType","issingle","=",0],["DocType","istable","=",0]]',
 			},
 			{"fieldname": "config", "depends_on": "eval:doc.reference_doctype", "reqd": 1},
 			{"fieldname": "return_type", "default": "List of Values", "read_only": 1},
@@ -747,7 +747,7 @@ OPERATION_CONTRACTS: dict[str, dict[str, Any]] = {
 			{
 				"fieldname": "reference_doctype",
 				"reqd": 1,
-				"link_filters": "[['DocType','issingle','=',0],['DocType','istable','=',0]]",
+				"link_filters": '[["DocType","issingle","=",0],["DocType","istable","=",0]]',
 			},
 			{"fieldname": "config", "depends_on": "eval:doc.reference_doctype", "reqd": 1},
 			{"fieldname": "return_type", "default": "List of Values", "read_only": 1},
@@ -766,7 +766,7 @@ OPERATION_CONTRACTS: dict[str, dict[str, Any]] = {
 			{
 				"fieldname": "reference_doctype",
 				"reqd": 1,
-				"link_filters": "[['DocType','issingle','=',0],['DocType','istable','=',0]]",
+				"link_filters": '[["DocType","issingle","=",0],["DocType","istable","=",0]]',
 			},
 			{"fieldname": "config", "depends_on": "eval:doc.reference_doctype", "reqd": 1},
 			{"fieldname": "return_type", "default": "List of Values", "read_only": 1},
@@ -785,7 +785,7 @@ OPERATION_CONTRACTS: dict[str, dict[str, Any]] = {
 			{
 				"fieldname": "reference_doctype",
 				"reqd": 1,
-				"link_filters": "[['DocType','issingle','=',0],['DocType','istable','=',0]]",
+				"link_filters": '[["DocType","issingle","=",0],["DocType","istable","=",0]]',
 			},
 			{"fieldname": "config", "depends_on": "eval:doc.reference_doctype", "reqd": 1},
 			{"fieldname": "return_type", "default": "List of Values", "read_only": 1},
@@ -804,7 +804,7 @@ OPERATION_CONTRACTS: dict[str, dict[str, Any]] = {
 			{
 				"fieldname": "reference_doctype",
 				"reqd": 1,
-				"link_filters": "[['DocType','issingle','=',0],['DocType','istable','=',0]]",
+				"link_filters": '[["DocType","issingle","=",0],["DocType","istable","=",0]]',
 			},
 			{"fieldname": "config", "depends_on": "eval:doc.reference_doctype", "reqd": 1},
 			{"fieldname": "return_type", "default": "List of Values", "read_only": 1},
@@ -823,7 +823,7 @@ OPERATION_CONTRACTS: dict[str, dict[str, Any]] = {
 			{
 				"fieldname": "reference_doctype",
 				"reqd": 1,
-				"link_filters": "[['DocType','issingle','=',0],['DocType','istable','=',0]]",
+				"link_filters": '[["DocType","issingle","=",0],["DocType","istable","=",0]]',
 			},
 			{"fieldname": "config", "depends_on": "eval:doc.reference_doctype", "reqd": 1},
 			{"fieldname": "return_type", "default": "List of Records", "read_only": 1},
@@ -848,7 +848,7 @@ OPERATION_CONTRACTS: dict[str, dict[str, Any]] = {
 			{
 				"fieldname": "reference_doctype",
 				"reqd": 1,
-				"link_filters": "[['DocType','issingle','=',0],['DocType','istable','=',0]]",
+				"link_filters": '[["DocType","issingle","=",0],["DocType","istable","=",0]]',
 			},
 			{
 				"fieldname": "config",
@@ -884,7 +884,7 @@ OPERATION_CONTRACTS: dict[str, dict[str, Any]] = {
 			{
 				"fieldname": "reference_doctype",
 				"reqd": 1,
-				"link_filters": "[['DocType','issingle','=',0],['DocType','istable','=',0]]",
+				"link_filters": '[["DocType","issingle","=",0],["DocType","istable","=",0]]',
 			},
 			{"fieldname": "reference_docname", "depends_on": "eval:doc.reference_doctype", "reqd": 1},
 			{
@@ -911,7 +911,7 @@ OPERATION_CONTRACTS: dict[str, dict[str, Any]] = {
 			{
 				"fieldname": "reference_doctype",
 				"reqd": 1,
-				"link_filters": "[['DocType','issingle','=',0],['DocType','istable','=',0]]",
+				"link_filters": '[["DocType","issingle","=",0],["DocType","istable","=",0]]',
 			},
 			{"fieldname": "reference_docname", "depends_on": "eval:doc.reference_doctype", "reqd": 1},
 			{"fieldname": "return_type", "default": "Yes / No", "read_only": 1},
@@ -930,7 +930,7 @@ OPERATION_CONTRACTS: dict[str, dict[str, Any]] = {
 			{
 				"fieldname": "reference_doctype",
 				"reqd": 1,
-				"link_filters": "[['DocType','issingle','=',0],['DocType','istable','=',0]]",
+				"link_filters": '[["DocType","issingle","=",0],["DocType","istable","=",0]]',
 			},
 			{
 				"fieldname": "config",
@@ -959,7 +959,7 @@ OPERATION_CONTRACTS: dict[str, dict[str, Any]] = {
 			{
 				"fieldname": "reference_doctype",
 				"reqd": 1,
-				"link_filters": "[['DocType','issingle','=',0],['DocType','istable','=',0]]",
+				"link_filters": '[["DocType","issingle","=",0],["DocType","istable","=",0]]',
 			},
 			{"fieldname": "reference_docname", "depends_on": "eval:doc.reference_doctype", "reqd": 1},
 			{


### PR DESCRIPTION
This PR fixes a `JSONDecodeError` that occurred in the backend when processing `link_filters`. The root cause was the use of single quotes in JSON strings within the `contracts.py` file, which is invalid according to JSON standards.

Key changes:
1.  **Data Correction:** Converted all single-quoted `link_filters` in `flexirule/ruleflow/core/contracts.py` to use escaped double quotes.
2.  **Frontend Robustness:**
    *   Updated `flexirule/public/js/flexirule/core/control_registry.js` to fallback to an empty object if `JSON.parse` fails.
    *   Updated `flexirule/public/js/flexirule/rule_builder/components/rule_config/ActionSettings.vue` to sanitize `link_filters` before returning them.
    *   Updated `flexirule/public/js/flexirule/rule_builder/stores/useMetaStore.js` to sanitize filters before making the `frappe.desk.search.search_link` call.
3.  **Linting:** Ran `pre-commit run --all` to ensure code quality and consistency.

---
*PR created automatically by Jules for task [17439329735015731471](https://jules.google.com/task/17439329735015731471) started by @ruzaqiarkan-eng*