### PR TITLE
Fix action insertion ordering in Rule Configuration Modal

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/RuleConfigModal.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/RuleConfigModal.vue
@@ -801,10 +801,10 @@ const actionPresentation = computed(() => {
 	return getActionPresentation(type);
 });
 
-const totalNodes = computed(() => graphStore.nodes.length);
+const totalNodes = computed(() => graphStore.orderedConfigurableNodes.length);
 const currentNodeIndex = computed(() => {
 	if (!uiStore.selected_id) return -1;
-	return graphStore.nodes.findIndex((n) => n.id === uiStore.selected_id);
+	return graphStore.orderedConfigurableNodes.findIndex((n) => n.id === uiStore.selected_id);
 });
 
 const transitionName = ref("slide-right");

--- a/flexirule/public/js/flexirule/rule_builder/stores/useGraphStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useGraphStore.js
@@ -40,6 +40,22 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 		return map;
 	});
 
+	/**
+	 * Returns nodes in their logical execution order (topological sort).
+	 * Filtered to include only configurable nodes (Start + Actions),
+	 * excluding placeholders (selector) and terminal nodes (stop) as per UX preference.
+	 */
+	const orderedConfigurableNodes = computed(() => {
+		const sorted = getTopologicalSort();
+		return sorted.filter((n) => {
+			if (n.type === "selector") return false;
+			// Stop nodes are terminals with minimal config; we exclude them from step navigation
+			// but keep them as valid graph elements.
+			if (n.type === "stop" || n.data?.action_type === "Stop") return false;
+			return true;
+		});
+	});
+
 	// ── Cascade disable computed ──
 	// BFS from start node: any node not reachable via enabled path is "effectively disabled"
 	const effectiveDisabledIds = computed(() => {
@@ -2134,6 +2150,7 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 		autoConnectNode,
 		autoConnectStartNode,
 		nodesMap,
+		orderedConfigurableNodes,
 		reconnect_node_edge,
 	};
 });

--- a/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
@@ -734,14 +734,14 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 		const uiStore = useUIStore();
 		const graphStore = useGraphStore();
 		uiStore.config_modal_mode = "setup";
-		uiStore.navigate_node(graphStore.nodes, 1);
+		uiStore.navigate_node(graphStore.orderedConfigurableNodes, 1);
 	}
 
 	function prev_config_node() {
 		const uiStore = useUIStore();
 		const graphStore = useGraphStore();
 		uiStore.config_modal_mode = "setup";
-		uiStore.navigate_node(graphStore.nodes, -1);
+		uiStore.navigate_node(graphStore.orderedConfigurableNodes, -1);
 	}
 
 	async function apply_ruleflow_layout() {


### PR DESCRIPTION
The `RuleConfigurationModal` was displaying actions in the order they were inserted into the `rule.actions` array, which caused newly inserted actions between existing nodes to appear at the end of the step list.

This fix shifts the source of truth for step-by-step navigation to the graph topology. By using a topological sort starting from the Trigger/Start node, the modal now correctly reflects the logical execution flow. Additionally, non-configurable elements like 'Stop' nodes are excluded from the step count to provide a cleaner UX for action configuration.

---
*PR created automatically by Jules for task [11410765573290751728](https://jules.google.com/task/11410765573290751728) started by @ruzaqiarkan-eng*