### PR TITLE
Enable Navigation for Stop and Entry Actions

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/stores/useGraphStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useGraphStore.js
@@ -49,9 +49,6 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 		const sorted = getTopologicalSort();
 		return sorted.filter((n) => {
 			if (n.type === "selector") return false;
-			// Stop nodes are terminals with minimal config; we exclude them from step navigation
-			// but keep them as valid graph elements.
-			if (n.type === "stop" || n.data?.action_type === "Stop") return false;
 			return true;
 		});
 	});

--- a/flexirule/ruleflow/core/action_handlers/simple_actions.py
+++ b/flexirule/ruleflow/core/action_handlers/simple_actions.py
@@ -41,7 +41,7 @@ class StopHandler(ActionHandler):
 			produces_result=False,
 			node_type="stop",
 			category="Control Flow",
-			configurable=False,
+			configurable=True,
 		)
 
 	@classmethod
@@ -563,7 +563,7 @@ class EntryActionHandler(ActionHandler):
 			produces_result=False,
 			node_type="start",
 			category="Control Flow",
-			configurable=False,
+			configurable=True,
 		)
 
 	@classmethod


### PR DESCRIPTION
Fixed a bug where "Stop" actions were invisible to the Rule Configuration modal's "Next/Previous" navigation flow. This was caused by an explicit filter in the frontend store and a `configurable=False` metadata flag in the backend contract. Both have been updated to allow full navigation and configuration of terminal and start nodes.

---
*PR created automatically by Jules for task [2387878612830452710](https://jules.google.com/task/2387878612830452710) started by @ruzaqiarkan-eng*