### PR TITLE
Harden Rule Builder Reactivity & Debug Simulation

### DIFF
--- a/flexirule/public/js/flexirule/rule_builder/rule_builder.js
+++ b/flexirule/public/js/flexirule/rule_builder/rule_builder.js
@@ -127,8 +127,8 @@ class RuleBuilder {
 
 		// Watch for active status changes - Unified Source of Truth
 		watch(
-			() => [this.ruleStore.is_active, this.ruleStore.rule_doc?.is_active],
-			([is_active]) => {
+			() => this.ruleStore.is_active,
+			(is_active) => {
 				this.update_status_button(is_active);
 			},
 			{ immediate: true }

--- a/flexirule/public/js/flexirule/rule_builder/rule_builder.js
+++ b/flexirule/public/js/flexirule/rule_builder/rule_builder.js
@@ -125,30 +125,17 @@ class RuleBuilder {
 			}
 		);
 
-		// Watch for active status changes
+		// Watch for active status changes - Unified Source of Truth
 		watch(
-			() => this.ruleStore.rule_doc?.is_active,
-			(is_active) => {
+			() => [this.ruleStore.is_active, this.ruleStore.rule_doc?.is_active],
+			([is_active]) => {
 				this.update_status_button(is_active);
-			}
+			},
+			{ immediate: true }
 		);
 
 		this.uiStore.$subscribe((mutation, state) => {
 			this.update_test_ui(state.test_execution_path);
-		});
-
-		// Initial status update after fetch
-		// We might need to wait for fetch, but store.$subscribe handles mutations.
-		// We can also watch rule_doc specifically if needed, but the main subscribe is usually enough for state changes.
-		// Also manual call after mount if data is already there (it fetches async)
-
-		// Use a watcher on rule_doc specifically
-		const unwatch = this.ruleStore.$onAction(({ name, after }) => {
-			if (name === "fetch") {
-				after(() => {
-					this.update_status_button(this.ruleStore.rule_doc?.is_active);
-				});
-			}
 		});
 
 		this.setup_debug_api();
@@ -167,21 +154,34 @@ class RuleBuilder {
 			if (this.ruleStore.rule_doc.is_active) {
 				await this.ruleStore.deactivate_rule();
 			} else {
-				// If there are unsaved edits, persist first, then activate.
-				if (this.ruleStore.is_dirty) {
+				// If there are semantic changes (logic, edges), persist first.
+				// We allow purely visual changes (positions) to be saved during activation
+				// if save_changes() is called, but is_semantically_dirty is the blocker.
+				if (this.ruleStore.is_semantically_dirty) {
+					const confirmed = await new Promise((resolve) => {
+						frappe.confirm(
+							__("You have unsaved semantic changes. Save and activate now?"),
+							() => resolve(true),
+							() => resolve(false)
+						);
+					});
+					if (!confirmed) return;
+
 					await this.ruleStore.save_changes();
-					if (this.ruleStore.is_dirty) {
+					if (this.ruleStore.is_semantically_dirty) {
 						// Save failed or was blocked; keep current status.
 						return;
 					}
+				} else if (this.ruleStore.is_dirty) {
+					// Purely visual changes - just save silently or continue
+					await this.ruleStore.save_changes();
 				}
+
 				await this.ruleStore.activate_rule();
 			}
 		} finally {
 			frappe.dom.unfreeze();
 		}
-
-		this.update_status_button(this.ruleStore.rule_doc?.is_active);
 	}
 
 	update_status_button(is_active) {
@@ -368,17 +368,24 @@ class RuleBuilder {
 
 				this.uiStore.clear_test_result();
 
+				const args = {
+					rule_name: this.rule,
+					doctype: values.doctype,
+					docnames: values.docnames,
+					sim_user: values.sim_user,
+					sim_role: values.sim_role,
+					dry_run: !values.save_log,
+					skip_log_enqueue: !values.save_log,
+				};
+
+				// If rule is dirty, send current draft for simulation
+				if (this.ruleStore.is_dirty) {
+					args.rule_doc_json = JSON.stringify(this.ruleStore.generateRuleDoc());
+				}
+
 				frappe.call({
 					method: "flexirule.ruleflow.api.test_rule",
-					args: {
-						rule_name: this.rule,
-						doctype: values.doctype,
-						docnames: values.docnames,
-						sim_user: values.sim_user,
-						sim_role: values.sim_role,
-						dry_run: !values.save_log,
-						skip_log_enqueue: !values.save_log,
-					},
+					args: args,
 					callback: (r) => {
 						if (r.message?.multi) {
 							// For multi-run, we might already have results from realtime.

--- a/flexirule/public/js/flexirule/rule_builder/stores/useGraphStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useGraphStore.js
@@ -100,8 +100,11 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 	 * Returns a stable, serializable representation of the graph data.
 	 * Excludes transient UI state (selection, dragging, etc.) to ensure
 	 * comparison only detects meaningful changes.
+	 *
+	 * @param {Object} options - snapshot options
+	 * @param {boolean} options.includePositions - whether to include node positions (default: true)
 	 */
-	function getStateSnapshot() {
+	function getStateSnapshot(options = { includePositions: true }) {
 		/**
 		 * Stable stringification helper that ensures consistent key ordering.
 		 */
@@ -137,16 +140,21 @@ export const useGraphStore = defineStore("rule-builder-graph", () => {
 			// To be absolutely safe, we'll return the data as-is but ensure the top-level
 			// snapshot objects themselves have a stable structure.
 
-			return {
+			const nodeSnap = {
 				data: rawData,
 				id: el.id,
 				label: el.label,
-				position: {
-					x: Math.round(el.position?.x || 0),
-					y: Math.round(el.position?.y || 0),
-				},
 				type: el.type,
 			};
+
+			if (options.includePositions) {
+				nodeSnap.position = {
+					x: Math.round(el.position?.x || 0),
+					y: Math.round(el.position?.y || 0),
+				};
+			}
+
+			return nodeSnap;
 		});
 
 		const edgesSnap = edges.value.map((el) => ({

--- a/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
@@ -9,7 +9,7 @@
  * Extracted from store.js lines: 12-14, 20-22, 153-259, 747-874, 891-1221
  */
 import { defineStore } from "pinia";
-import { ref, computed, nextTick } from "vue";
+import { ref, computed, nextTick, watch } from "vue";
 import { normalizeActionType, loadContractsFromBackend } from "../../core/contracts";
 import { getConditionPayload } from "../utils/condition_payload";
 import { deepClone } from "../utils/serialization";

--- a/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
@@ -31,7 +31,16 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 		if (uiStore.is_initializing || uiStore.is_performing_layout) return false;
 
 		if (_is_dirty.value) return true;
-		return checkDirty();
+		return checkDirty({ includePositions: true });
+	});
+
+	/**
+	 * Returns true if there are semantic changes (logic, connections, config)
+	 * ignoring pure visual layout/position changes.
+	 */
+	const is_semantically_dirty = computed(() => {
+		if (is_read_only.value || is_loading.value) return false;
+		return checkDirty({ includePositions: false });
 	});
 	const initial_state = ref(null);
 	const settings = ref(null);
@@ -189,6 +198,11 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 		// We wait for nextTick to ensure all reactive changes from
 		// graphStore sync and normalize have settled before we capture the baseline.
 		await nextTick();
+
+		// Wait slightly longer for fitView and layout animations to settle
+		// to prevent "Not Saved" appearing immediately on load.
+		await new Promise((resolve) => setTimeout(resolve, 200));
+
 		initial_state.value = JSON.stringify(graphStore.getStateSnapshot());
 		_is_dirty.value = false;
 
@@ -201,6 +215,180 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 		is_loading.value = false;
 
 		// Note: is_initializing is kept true until VueFlow reports ready in App.vue
+	}
+
+	/**
+	 * Extracts a full Rule document object from the current store state.
+	 * Can be used for saving or for simulation/debugging of unsaved changes.
+	 */
+	function generateRuleDoc(baseDoc = null) {
+		const graphStore = useGraphStore();
+		const uiStore = useUIStore();
+
+		// Use provided base, current rule_doc, or a fresh structure
+		let doc = baseDoc
+			? deepClone(baseDoc)
+			: rule_doc.value
+			? deepClone(rule_doc.value)
+			: { doctype: "Rule", name: rule_name.value };
+
+		const startNode = graphStore.nodes.find((el) => el.type === "start");
+		doc.trigger_condition = serializeField(startNode?.data?.trigger_condition);
+		doc.compiled_expression = null; // Backend will re-compile
+
+		if (startNode?.data) {
+			doc.trigger_type = startNode.data.trigger_type ?? doc.trigger_type;
+			doc.document_type = startNode.data.document_type ?? doc.document_type;
+			doc.trigger_event = startNode.data.trigger_event ?? doc.trigger_event;
+			doc.priority = startNode.data.priority ?? doc.priority;
+			doc.execution_mode = startNode.data.execution_mode ?? doc.execution_mode;
+			doc.max_execution_time =
+				startNode.data.max_execution_time !== undefined
+					? startNode.data.max_execution_time
+					: doc.max_execution_time;
+			doc.debug_mode = startNode.data.debug_mode ? 1 : 0;
+			doc.description = startNode.data.description;
+			const exposedAsSubrule = startNode.data.exposed_as_subrule ? 1 : 0;
+			doc.exposed_as_subrule = exposedAsSubrule;
+			const skip_roles = Array.isArray(startNode.data.skip_for_roles)
+				? startNode.data.skip_for_roles
+				: [];
+			doc.skip_for_roles = skip_roles.filter(Boolean).map((role) => ({ role: role }));
+			const perms = Array.isArray(startNode.data.permissions)
+				? startNode.data.permissions
+				: [];
+			doc.permissions = perms
+				.filter((row) => row && row.role)
+				.map((row) => ({
+					role: row.role,
+					can_execute: row.can_execute ? 1 : 0,
+				}));
+		}
+
+		// Topological sort for action ordering
+		const edgesList = graphStore.edges;
+		const orderedNodes = graphStore.getTopologicalSort(graphStore.nodes, edgesList);
+		const nodeIdToActionId = new Map(
+			graphStore.nodes
+				.map((node) => [node.id, getActionIdForNode(node)])
+				.filter(([nodeId, actionId]) => nodeId && actionId)
+		);
+		const resolveActionId = (nodeId) => nodeIdToActionId.get(nodeId) || nodeId || null;
+
+		doc.visual_data = JSON.stringify(
+			canonicalizeGraphData(
+				graphStore.get_visual_data_payload(
+					uiStore.layout_preference ||
+						(settings.value?.layout_direction === "Top to Bottom" ? "TB" : "LR")
+				),
+				nodeIdToActionId
+			)
+		);
+
+		doc.actions = orderedNodes.map((node, idx) => {
+			const outgoing = edgesList.filter((e) => e.source === node.id);
+			let true_edge = outgoing.find(
+				(e) => e.sourceHandle === "true" || e.sourceHandle === "default"
+			);
+			const false_edge = outgoing.find((e) => e.sourceHandle === "false");
+
+			const is_start_node = node.type === "start";
+			const action_type = is_start_node
+				? "Entry Action"
+				: normalizeActionType(node.data?.action_type || "Process");
+
+			if (is_start_node && !true_edge) {
+				const startOutgoing = edgesList.filter(
+					(e) => e.source === "start" || e.source === "root"
+				);
+				true_edge = startOutgoing.find(
+					(e) => e.sourceHandle === "true" || e.sourceHandle === "default"
+				);
+			}
+
+			let rawConfig = node.data?.config || {};
+			if (typeof rawConfig === "string") {
+				try {
+					rawConfig = JSON.parse(rawConfig);
+				} catch (e) {
+					rawConfig = {};
+				}
+			}
+			const normalizedConfig =
+				graphStore.clean_action_config(rawConfig, {
+					actionType: action_type,
+					processName: node.data?.process_name,
+					operation: node.data?.operation,
+				}) || {};
+			const conditionPayload =
+				action_type === "Condition"
+					? getConditionPayload({
+							config: node.data?.config,
+							condition_json: node.data?.condition_json,
+					  })
+					: null;
+
+			const finalInputMapping =
+				node.data?.input_mapping && node.data.input_mapping.length > 0
+					? node.data.input_mapping
+					: normalizedConfig.input_mapping;
+			if (finalInputMapping) {
+				normalizedConfig.input_mapping = finalInputMapping;
+			}
+
+			const finalOutputMapping =
+				node.data?.output_mapping && node.data.output_mapping.length > 0
+					? node.data.output_mapping
+					: normalizedConfig.output_mapping;
+			if (finalOutputMapping) {
+				normalizedConfig.output_mapping = finalOutputMapping;
+			}
+
+			if (action_type === "Sub-Rule" && node.data?.rule) {
+				normalizedConfig.sub_rule_name = node.data.rule;
+			}
+
+			const finalConfig =
+				action_type === "Condition"
+					? conditionPayload || normalizedConfig
+					: normalizedConfig;
+
+			return {
+				name: node.data?.name,
+				idx: idx + 1,
+				action_id: resolveActionId(node.id),
+				action_label: node.data?.action_label || node.label,
+				action_type: action_type,
+				is_enabled: node.data?.is_enabled !== undefined ? node.data.is_enabled : 1,
+				process_name: node.data?.process_name,
+				operation: node.data?.operation,
+				config: serializeField(finalConfig),
+				target_field: node.data?.target_field,
+				value_template: node.data?.value_template,
+				compiled_expression: node.data?.compiled_expression,
+				condition_json: action_type === "Condition" ? serializeField(finalConfig) : null,
+				on_error: node.data?.on_error || "Stop",
+				timeout: node.data?.timeout || 30,
+				priority: node.data?.priority || 0,
+				retry_count: node.data?.retry_count || 0,
+				return_variable: node.data?.return_variable,
+				rule: node.data?.rule,
+				is_async: node.data?.is_async || 0,
+				skip_conditions:
+					node.data?.skip_conditions !== undefined ? node.data.skip_conditions : 1,
+				skip_permissions: node.data?.skip_permissions || 0,
+				next_step_if_true: resolveActionId(true_edge?.target),
+				next_step_if_false: resolveActionId(false_edge?.target),
+				input_source: node.data?.input_source,
+				reference_doctype: node.data?.reference_doctype,
+				reference_docname: node.data?.reference_docname,
+				mutation_mode: node.data?.mutation_mode,
+				return_type: node.data?.return_type,
+				resolved_output_schema: serializeField(node.data?.resolved_output_schema),
+			};
+		});
+
+		return doc;
 	}
 
 	// ── Save ──
@@ -285,166 +473,10 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 
 			const currentIsActive = rule_doc.value.is_active;
 			frappe.model.sync(fresh.message);
-			let doc = frappe.get_doc("Rule", rule_name.value);
+
+			// Extract rule payload using our helper, passing the fresh doc as base
+			const doc = generateRuleDoc(frappe.get_doc("Rule", rule_name.value));
 			doc.is_active = currentIsActive;
-
-			const startNode = graphStore.nodes.find((el) => el.type === "start");
-			doc.trigger_condition = serializeField(startNode?.data?.trigger_condition);
-			doc.compiled_expression = null;
-
-			if (startNode?.data) {
-				doc.trigger_type = startNode.data.trigger_type ?? doc.trigger_type;
-				doc.document_type = startNode.data.document_type ?? doc.document_type;
-				doc.trigger_event = startNode.data.trigger_event ?? doc.trigger_event;
-				doc.priority = startNode.data.priority ?? doc.priority;
-				doc.execution_mode = startNode.data.execution_mode ?? doc.execution_mode;
-				doc.max_execution_time =
-					startNode.data.max_execution_time !== undefined
-						? startNode.data.max_execution_time
-						: doc.max_execution_time;
-				doc.debug_mode = startNode.data.debug_mode ? 1 : 0;
-				doc.description = startNode.data.description;
-				const exposedAsSubrule = startNode.data.exposed_as_subrule ? 1 : 0;
-				doc.exposed_as_subrule = exposedAsSubrule;
-				const skip_roles = Array.isArray(startNode.data.skip_for_roles)
-					? startNode.data.skip_for_roles
-					: [];
-				doc.skip_for_roles = skip_roles.filter(Boolean).map((role) => ({ role: role }));
-				const perms = Array.isArray(startNode.data.permissions)
-					? startNode.data.permissions
-					: [];
-				doc.permissions = perms
-					.filter((row) => row && row.role)
-					.map((row) => ({
-						role: row.role,
-						can_execute: row.can_execute ? 1 : 0,
-					}));
-			}
-
-			// Topological sort for action ordering
-			const edgesList = graphStore.edges;
-			const orderedNodes = graphStore.getTopologicalSort(graphStore.nodes, edgesList);
-			const nodeIdToActionId = new Map(
-				graphStore.nodes
-					.map((node) => [node.id, getActionIdForNode(node)])
-					.filter(([nodeId, actionId]) => nodeId && actionId)
-			);
-			const resolveActionId = (nodeId) => nodeIdToActionId.get(nodeId) || nodeId || null;
-
-			const uiStore = useUIStore();
-			doc.visual_data = JSON.stringify(
-				canonicalizeGraphData(
-					graphStore.get_visual_data_payload(
-						uiStore.layout_preference ||
-							(settings.value?.layout_direction === "Top to Bottom" ? "TB" : "LR")
-					),
-					nodeIdToActionId
-				)
-			);
-
-			doc.actions = orderedNodes.map((node, idx) => {
-				const outgoing = edgesList.filter((e) => e.source === node.id);
-				let true_edge = outgoing.find(
-					(e) => e.sourceHandle === "true" || e.sourceHandle === "default"
-				);
-				const false_edge = outgoing.find((e) => e.sourceHandle === "false");
-
-				const is_start_node = node.type === "start";
-				const action_type = is_start_node
-					? "Entry Action"
-					: normalizeActionType(node.data?.action_type || "Process");
-
-				if (is_start_node && !true_edge) {
-					const startOutgoing = edgesList.filter(
-						(e) => e.source === "start" || e.source === "root"
-					);
-					true_edge = startOutgoing.find(
-						(e) => e.sourceHandle === "true" || e.sourceHandle === "default"
-					);
-				}
-
-				let rawConfig = node.data?.config || {};
-				if (typeof rawConfig === "string") {
-					try {
-						rawConfig = JSON.parse(rawConfig);
-					} catch (e) {
-						rawConfig = {};
-					}
-				}
-				const normalizedConfig =
-					graphStore.clean_action_config(rawConfig, {
-						actionType: action_type,
-						processName: node.data?.process_name,
-						operation: node.data?.operation,
-					}) || {};
-				const conditionPayload =
-					action_type === "Condition"
-						? getConditionPayload({
-								config: node.data?.config,
-								condition_json: node.data?.condition_json,
-						  })
-						: null;
-
-				const finalInputMapping =
-					node.data?.input_mapping && node.data.input_mapping.length > 0
-						? node.data.input_mapping
-						: normalizedConfig.input_mapping;
-				if (finalInputMapping) {
-					normalizedConfig.input_mapping = finalInputMapping;
-				}
-
-				const finalOutputMapping =
-					node.data?.output_mapping && node.data.output_mapping.length > 0
-						? node.data.output_mapping
-						: normalizedConfig.output_mapping;
-				if (finalOutputMapping) {
-					normalizedConfig.output_mapping = finalOutputMapping;
-				}
-
-				if (action_type === "Sub-Rule" && node.data?.rule) {
-					normalizedConfig.sub_rule_name = node.data.rule;
-				}
-
-				const finalConfig =
-					action_type === "Condition"
-						? conditionPayload || normalizedConfig
-						: normalizedConfig;
-
-				return {
-					name: node.data?.name,
-					idx: idx + 1,
-					action_id: resolveActionId(node.id),
-					action_label: node.data?.action_label || node.label,
-					action_type: action_type,
-					is_enabled: node.data?.is_enabled !== undefined ? node.data.is_enabled : 1,
-					process_name: node.data?.process_name,
-					operation: node.data?.operation,
-					config: serializeField(finalConfig),
-					target_field: node.data?.target_field,
-					value_template: node.data?.value_template,
-					compiled_expression: node.data?.compiled_expression,
-					condition_json:
-						action_type === "Condition" ? serializeField(finalConfig) : null,
-					on_error: node.data?.on_error || "Stop",
-					timeout: node.data?.timeout || 30,
-					priority: node.data?.priority || 0,
-					retry_count: node.data?.retry_count || 0,
-					return_variable: node.data?.return_variable,
-					rule: node.data?.rule,
-					is_async: node.data?.is_async || 0,
-					skip_conditions:
-						node.data?.skip_conditions !== undefined ? node.data.skip_conditions : 1,
-					skip_permissions: node.data?.skip_permissions || 0,
-					next_step_if_true: resolveActionId(true_edge?.target),
-					next_step_if_false: resolveActionId(false_edge?.target),
-					input_source: node.data?.input_source,
-					reference_doctype: node.data?.reference_doctype,
-					reference_docname: node.data?.reference_docname,
-					mutation_mode: node.data?.mutation_mode,
-					return_type: node.data?.return_type,
-					resolved_output_schema: serializeField(node.data?.resolved_output_schema),
-				};
-			});
 
 			// 3. Backend validation precheck (draft mode: relaxed for building)
 			validation_errors.value = []; // Clear previous errors
@@ -661,7 +693,7 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 		}
 	}
 
-	function checkDirty() {
+	function checkDirty(options = { includePositions: true }) {
 		if (is_read_only.value || !initial_state.value) return false;
 		const graphStore = useGraphStore();
 
@@ -669,7 +701,26 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 		const _nodes = graphStore.nodes;
 		const _edges = graphStore.edges;
 
-		const current = JSON.stringify(graphStore.getStateSnapshot());
+		const current = JSON.stringify(graphStore.getStateSnapshot(options));
+
+		// For semantic-only checks, we need to compare against a semantic baseline
+		if (!options.includePositions) {
+			let initialSnapshot;
+			try {
+				initialSnapshot = JSON.parse(initial_state.value);
+			} catch (e) {
+				return false;
+			}
+			// Re-serialize the baseline WITHOUT positions for comparison
+			const semanticBaseline = JSON.stringify(
+				initialSnapshot.map((el) => {
+					const { position, ...rest } = el;
+					return rest;
+				})
+			);
+			return current !== semanticBaseline;
+		}
+
 		return current !== initial_state.value;
 	}
 
@@ -953,6 +1004,7 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 		// Computed
 		is_active,
 		is_read_only,
+		is_semantically_dirty,
 		doc_fields,
 		raw_meta,
 
@@ -989,5 +1041,7 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 		next_config_node,
 		prev_config_node,
 		apply_ruleflow_layout,
+
+		generateRuleDoc,
 	};
 });

--- a/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
@@ -40,9 +40,15 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 	 */
 	const is_semantically_dirty = computed(() => {
 		if (is_read_only.value || is_loading.value) return false;
+
+		const uiStore = useUIStore();
+		if (uiStore.is_initializing || uiStore.is_performing_layout) return false;
+
+		if (_is_dirty.value) return true;
 		return checkDirty({ includePositions: false });
 	});
 	const initial_state = ref(null);
+	const initial_semantic_state = ref(null);
 	const settings = ref(null);
 	const validation_errors = ref([]);
 	const is_loading = ref(false);
@@ -195,16 +201,33 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 
 		setup_breadcrumbs();
 
-		// We wait for nextTick to ensure all reactive changes from
-		// graphStore sync and normalize have settled before we capture the baseline.
+		// Capture the baseline after layout settling.
+		// Watchers on uiStore.is_initializing and is_performing_layout
+		// will ensure we only capture when the graph is stable.
+		const waitSettled = () => {
+			return new Promise((resolve) => {
+				const unwatch = watch(
+					() => [uiStore.is_initializing, uiStore.is_performing_layout],
+					([initializing, layouting]) => {
+						if (!initializing && !layouting) {
+							unwatch();
+							resolve();
+						}
+					},
+					{ immediate: true }
+				);
+				// Safety timeout
+				setTimeout(() => {
+					unwatch();
+					resolve();
+				}, 2000);
+			});
+		};
+
+		await waitSettled();
 		await nextTick();
 
-		// Wait slightly longer for fitView and layout animations to settle
-		// to prevent "Not Saved" appearing immediately on load.
-		await new Promise((resolve) => setTimeout(resolve, 200));
-
-		initial_state.value = JSON.stringify(graphStore.getStateSnapshot());
-		_is_dirty.value = false;
+		clear_dirty();
 
 		// Ensure App.vue bindings see the nodes/edges immediately
 		// by triggering a reactivity update if needed
@@ -233,6 +256,7 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 			: { doctype: "Rule", name: rule_name.value };
 
 		const startNode = graphStore.nodes.find((el) => el.type === "start");
+		doc.doctype = "Rule";
 		doc.trigger_condition = serializeField(startNode?.data?.trigger_condition);
 		doc.compiled_expression = null; // Backend will re-compile
 
@@ -703,22 +727,8 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 
 		const current = JSON.stringify(graphStore.getStateSnapshot(options));
 
-		// For semantic-only checks, we need to compare against a semantic baseline
 		if (!options.includePositions) {
-			let initialSnapshot;
-			try {
-				initialSnapshot = JSON.parse(initial_state.value);
-			} catch (e) {
-				return false;
-			}
-			// Re-serialize the baseline WITHOUT positions for comparison
-			const semanticBaseline = JSON.stringify(
-				initialSnapshot.map((el) => {
-					const { position, ...rest } = el;
-					return rest;
-				})
-			);
-			return current !== semanticBaseline;
+			return current !== initial_semantic_state.value;
 		}
 
 		return current !== initial_state.value;
@@ -730,7 +740,12 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 	 */
 	function clear_dirty() {
 		const graphStore = useGraphStore();
-		initial_state.value = JSON.stringify(graphStore.getStateSnapshot());
+		initial_state.value = JSON.stringify(
+			graphStore.getStateSnapshot({ includePositions: true })
+		);
+		initial_semantic_state.value = JSON.stringify(
+			graphStore.getStateSnapshot({ includePositions: false })
+		);
 		_is_dirty.value = false;
 	}
 

--- a/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
+++ b/flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js
@@ -206,19 +206,27 @@ export const useRuleStore = defineStore("rule-builder-rule", () => {
 		// will ensure we only capture when the graph is stable.
 		const waitSettled = () => {
 			return new Promise((resolve) => {
+				// 1. If already settled, resolve immediately to avoid TDZ with unwatch
+				if (!uiStore.is_initializing && !uiStore.is_performing_layout) {
+					resolve();
+					return;
+				}
+
+				// 2. Otherwise, start the watcher. We don't use immediate: true
+				// to ensure unwatch is initialized before the callback can run.
 				const unwatch = watch(
 					() => [uiStore.is_initializing, uiStore.is_performing_layout],
 					([initializing, layouting]) => {
 						if (!initializing && !layouting) {
-							unwatch();
+							if (typeof unwatch === "function") unwatch();
 							resolve();
 						}
-					},
-					{ immediate: true }
+					}
 				);
+
 				// Safety timeout
 				setTimeout(() => {
-					unwatch();
+					if (typeof unwatch === "function") unwatch();
 					resolve();
 				}, 2000);
 			});

--- a/flexirule/ruleflow/api.py
+++ b/flexirule/ruleflow/api.py
@@ -298,8 +298,12 @@ def test_rule(
 
 	if rule_doc_json:
 		rule_data = json.loads(rule_doc_json)
-		# Ensure it's a Rule doctype and has a name for logging consistency
-		rule_data.setdefault("doctype", "Rule")
+
+		# Validate that the payload represents a Rule document
+		if rule_data.get("doctype") != "Rule":
+			frappe.throw(_("Invalid simulation payload: doctype must be 'Rule'"))
+
+		# Ensure it has a name for logging consistency
 		rule_data.setdefault("name", rule_name)
 		rule = frappe.get_doc(rule_data)
 		# Compile conditions to ensure simulation uses current draft logic

--- a/flexirule/ruleflow/api.py
+++ b/flexirule/ruleflow/api.py
@@ -287,6 +287,7 @@ def test_rule(
 	docname: str | None = None,
 	docnames: list | str | None = None,
 	document_json: str | None = None,
+	rule_doc_json: str | None = None,
 	dry_run: int | bool | str = True,
 	skip_log_enqueue: int | bool | str = True,
 	save_log: int | bool | str | None = None,
@@ -295,7 +296,17 @@ def test_rule(
 ):
 	_require_api_access()
 
-	rule = frappe.get_doc("Rule", rule_name)
+	if rule_doc_json:
+		rule_data = json.loads(rule_doc_json)
+		# Ensure it's a Rule doctype and has a name for logging consistency
+		rule_data.setdefault("doctype", "Rule")
+		rule_data.setdefault("name", rule_name)
+		rule = frappe.get_doc(rule_data)
+		# Compile conditions to ensure simulation uses current draft logic
+		if hasattr(rule, "compile_conditions"):
+			rule.compile_conditions()
+	else:
+		rule = frappe.get_doc("Rule", rule_name)
 
 	# Multi-document mode
 	if docnames:

--- a/report/rule-builder-reactivity-audit.md
+++ b/report/rule-builder-reactivity-audit.md
@@ -1,0 +1,131 @@
+# Rule Builder Reactivity and State Audit Report (Refined)
+
+## 1. State Lifecycle Diagram
+
+```mermaid
+sequenceDiagram
+    participant B as Backend (API)
+    participant S as Pinia Stores (Rule/Graph/UI)
+    participant BR as RuleBuilder Bridge
+    participant V as Vue Components (App/Nodes)
+    participant P as Frappe Page (Header)
+
+    Note over B,P: LOAD PHASE
+    BR->>S: ruleStore.fetch()
+    S->>B: frappe.call("get_doc", "Rule")
+    B-->>S: Rule Document
+    S->>S: Sync Actions to Graph
+    S->>S: Capture initial_state (Baseline)
+    S-->>V: Reactive Update (Nodes/Edges)
+    S-->>BR: Watchers trigger (is_dirty, is_active)
+    BR->>P: update_status_button()
+    BR->>P: update_save_button(false)
+
+    Note over B,P: EDIT PHASE
+    V->>S: graphStore.touch_node() / position change
+    S->>S: Compute is_dirty (Current vs Baseline)
+    S-->>BR: is_dirty watcher (true)
+    BR->>P: show "Reset Changes", set "Not Saved" indicator
+
+    Note over B,P: SAVE & ACTIVATE
+    P->>BR: Click "Save Rule"
+    BR->>S: ruleStore.save_changes()
+    S->>S: Serialize Graph to Payload
+    S->>B: frappe.call("save", doc)
+    B-->>S: Success
+    S->>S: Capture new initial_state (Baseline)
+    S-->>BR: is_dirty watcher (false)
+    BR->>P: clear "Not Saved"
+
+    Note over B,P: UNLOCK FOR EDITING
+    P->>BR: Click "Unlock"
+    BR->>S: ruleStore.deactivate_rule()
+    S->>B: transition_rule(status="Draft")
+    B-->>S: Updated Doc
+    S-->>V: isReadOnly (false)
+    S-->>BR: is_active watcher (false)
+    BR->>P: update_status_button("Draft")
+```
+
+---
+
+## 2. Confirmed Root Causes with Code Evidence
+
+### 2.1 Status Toggle Jitter
+*   **File**: `flexirule/public/js/flexirule/rule_builder/rule_builder.js`
+*   **Functions**: `setup_app()`, `toggle_rule_active()`
+*   **Evidence**:
+    *   Line 129: `watch(() => this.ruleStore.rule_doc?.is_active, ...)` calls `update_status_button`.
+    *   Line 185: `toggle_rule_active()` explicitly calls `update_status_button` after API completion.
+    *   Line 146: `$onAction("fetch")` also calls `update_status_button`.
+*   **Root Cause**: Triple-path synchronization. The UI updates once reactively, once via the explicit call, and potentially a third time if a fetch is triggered.
+*   **Reproduction**: Click "Set to Active". The button label may "flicker" or show the orange "Draft" badge momentarily before settling on green "Active".
+
+### 2.2 Baseline Capture Timing (Dirty Lag)
+*   **File**: `flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js`
+*   **Function**: `fetch()`
+*   **Evidence**:
+    *   Line 191: `await nextTick(); initial_state.value = JSON.stringify(graphStore.getStateSnapshot());`
+*   **Root Cause**: Capture happens after only one `nextTick`. Auto-layout and `fitView` (lines 181-186) involve timeouts and CSS transitions that settle *after* the baseline is already set.
+*   **Reproduction**: Load a rule with auto-layout enabled. After 500ms, the rule shows "Not Saved" even though no user edits occurred.
+
+### 2.3 Unused Baseline Sync
+*   **File**: `flexirule/public/js/flexirule/rule_builder/stores/useRuleStore.js`
+*   **Function**: `sync_initial_state_positions()`
+*   **Evidence**: The function is defined (line 697) and exported, but it is **not** called by any store action after visual-only changes (like layout).
+*   **Root Cause**: Logic exists but is orphaned, leaving layout operations in a "dirty" state.
+
+---
+
+## 3. Dirty State Analysis
+
+### 3.1 Categorization
+The current implementation (`useGraphStore.js:getStateSnapshot`) treats the graph as a flat list of objects.
+
+| Change Type | Current Behavior | Target Behavior |
+| :--- | :--- | :--- |
+| **Semantic** (Add Node, Config Change) | Dirty (Detected in `data` key) | **Dirty** |
+| **Connection** (Edges) | Dirty (Detected in `source/target`) | **Dirty** |
+| **Visual** (Node Position) | Dirty (Detected in `position` key) | **Conditional Dirty** |
+
+### 3.2 Verification
+`getStateSnapshot` explicitly includes:
+```javascript
+position: {
+    x: Math.round(el.position?.x || 0),
+    y: Math.round(el.position?.y || 0),
+}
+```
+This confirms that any dragging or auto-layout results in a "Dirty" state. Since RuleFlow persists positions in `visual_data`, this is technically correct but causes UX friction when auto-layout is forced on load.
+
+---
+
+## 4. Debug Simulation Architecture
+
+### 4.1 Backend Readiness
+`RuleEngine` (in `engine.py`) already supports executing in-memory documents:
+```python
+# engine.py:127
+def __init__(self, rule_doc, execution_context=None):
+    if isinstance(rule_doc, str):
+        rule_doc = frappe.get_doc("Rule", rule_doc)
+    self.rule = rule_doc # This accepts a Doc object!
+```
+The backend `test_rule` API (api.py) currently only takes a `rule_name`.
+
+### 4.2 Payload Reusability
+The `save_changes` function in `useRuleStore.js` contains a large block (lines 271-460) that transforms the graph into a Rule-compatible JSON object. This logic should be extracted into a `generateRuleDoc()` helper.
+
+---
+
+## 5. Refined Recommendations
+
+1.  **Single Source of Truth**:
+    *   Deprecate manual button updates in `rule_builder.js`.
+    *   The `RuleBuilder` class should only initialize the app. The header buttons should be managed by standard Vue reactivity or a single, unified watcher on a `headerState` computed property.
+2.  **Snapshot Separation**:
+    *   Split `initial_state` into `initial_semantic_state` and `initial_visual_state`.
+    *   Allow "Visual-only Dirty" to be treated as a warning or a silent auto-save, while "Semantic Dirty" blocks activation.
+3.  **Simulation API**:
+    *   Modify `test_rule` to accept `rule_doc_json`.
+    *   If present, the API should do: `rule = frappe.get_doc(json.loads(rule_doc_json))` instead of database lookup.


### PR DESCRIPTION
This PR hardens the Rule Builder's reactivity and implements a highly requested feature: debugging unsaved changes.

Key changes:
1. **Unsaved Simulation**: The Debugger now detects if a rule is dirty and sends the current frontend graph state to the backend. The backend instantiates a temporary, in-memory Rule document for the simulation run.
2. **Reactivity Hardening**: Removed redundant jQuery-based status updates in favor of unified Pinia store watchers. Fixed race conditions during rule activation/deactivation.
3. **Smart Dirty Tracking**: Semantic changes (logic, nodes, edges) are now distinguished from purely visual changes (positions). Activation is only blocked by semantic changes, improving the UX for auto-layout operations.
4. **Audit Report**: A detailed analysis of the reactivity architecture is included in `report/rule-builder-reactivity-audit.md`.
5. **Bug Fixes**: Resolved the "Dirty on Load" issue caused by premature baseline capture during auto-layout.

---
*PR created automatically by Jules for task [2714860304025353940](https://jules.google.com/task/2714860304025353940) started by @ruzaqiarkan-eng*