### PR TITLE
Fix cleanup UI

### DIFF
--- a/flexirule/public/js/flexirule/core/control_registry.js
+++ b/flexirule/public/js/flexirule/core/control_registry.js
@@ -63,10 +63,19 @@ ControlRegistry.registerDefault({
 		if (df.fieldtype === "Link") {
 			doctype = df.options || df.target_doctype || null;
 		} else if (df.fieldtype === "Dynamic Link") {
-			doctype =
-				context.doc?.[df.options] ||
-				window.frappe?.query_report?.get_filter_value(df.options) ||
-				"";
+			// Resolve Dynamic Link target via context chain:
+			// 1. Doc-level (standard Frappe form)
+			// 2. Injected ControlContext (Rule Builder / Query Report adapter)
+			// 3. Fallback empty
+			doctype = context.doc?.[df.options] || "";
+			if (!doctype && context.controlContext) {
+				const ctxVal = context.controlContext.getFieldValue(df.options);
+				if (ctxVal && typeof ctxVal === "object" && ctxVal.mode === "static") {
+					doctype = String(ctxVal.value || "");
+				} else if (typeof ctxVal === "string") {
+					doctype = ctxVal;
+				}
+			}
 		}
 
 		let options = [];
@@ -211,8 +220,15 @@ ControlRegistry.registerDefault({
 		if (df.fieldtype === "MultiFieldPicker") {
 			documentType = df.target_doctype || context.engine?.rule_doc?.document_type;
 		} else if (df.options && typeof df.options === "string") {
-			// Resolve options dynamically using the scoped frappe.query_report shim if it references another filter field (like party_type)
-			const parent_val = window.frappe?.query_report?.get_filter_value(df.options);
+			// Resolve options through injected ControlContext (Rule Builder / Query Report)
+			// instead of reaching into window.frappe.query_report.
+			let parent_val = undefined;
+			if (context.controlContext) {
+				parent_val = context.controlContext.getFieldValue(df.options);
+				if (parent_val && typeof parent_val === "object" && parent_val.mode === "static") {
+					parent_val = parent_val.value || undefined;
+				}
+			}
 			if (parent_val) {
 				documentType = parent_val;
 			} else if (!df.options.includes("\n") && df.options !== df.fieldname) {

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/ConditionNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/ConditionNode.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { Handle, Position } from "@vue-flow/core";
-import { useStore } from "../../stores";
+import { useStore, useRuleStore } from "../../stores";
 import { getContract } from "../../../core/contracts";
 import { computed } from "vue";
 import { useNodeExecutionState } from "../../composables/useNodeExecutionState";
@@ -27,7 +27,8 @@ const isEffectiveDisabled = computed(() => {
 	return store.effectiveDisabledIds?.has(props.id);
 });
 
-const isReadOnly = computed(() => store.is_read_only);
+const ruleStore = useRuleStore();
+const isReadOnly = computed(() => ruleStore.is_read_only);
 
 const nodeMeta = computed(() => {
 	const actionType = props.data?.action_type || "Condition";

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/LoopNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/LoopNode.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed } from "vue";
 import { Handle, Position } from "@vue-flow/core";
-import { useStore } from "../../stores";
+import { useStore, useRuleStore } from "../../stores";
 import { useNodeExecutionState } from "../../composables/useNodeExecutionState";
 import { useNodeStatus } from "../../composables/useNodeStatus";
 import { useCanvasLayout } from "../../composables/useCanvasLayout";
@@ -29,7 +29,8 @@ const isEffectiveDisabled = computed(() => {
 	return store.effectiveDisabledIds?.has(props.id);
 });
 
-const isReadOnly = computed(() => store.is_read_only);
+const ruleStore = useRuleStore();
+const isReadOnly = computed(() => ruleStore.is_read_only);
 
 const nodeIdRef = computed(() => props.id);
 const { isExecuted, isRunning, isErrored, executionOrder } = useNodeExecutionState(nodeIdRef);

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/StartNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/StartNode.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { Handle, Position } from "@vue-flow/core";
-import { useStore } from "../../stores";
+import { useStore, useRuleStore } from "../../stores";
 import { getContract } from "../../../core/contracts";
 import { computed } from "vue";
 import { useNodeExecutionState } from "../../composables/useNodeExecutionState";
@@ -12,7 +12,8 @@ import NodeStatusIndicator from "./NodeStatusIndicator.vue";
 
 const props = defineProps(["data", "label", "id", "selected", "sourcePosition"]);
 const store = useStore();
-const isReadOnly = computed(() => store.is_read_only);
+const ruleStore = useRuleStore();
+const isReadOnly = computed(() => ruleStore.is_read_only);
 
 const { isHorizontal, sourcePosition: defaultSourcePos } = useCanvasLayout();
 const sourcePos = computed(() => props.sourcePosition || defaultSourcePos.value);

--- a/flexirule/public/js/flexirule/rule_builder/components/nodes/StopNode.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/nodes/StopNode.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed } from "vue";
 import { Handle, Position } from "@vue-flow/core";
-import { useStore } from "../../stores";
+import { useStore, useRuleStore } from "../../stores";
 import { useNodeExecutionState } from "../../composables/useNodeExecutionState";
 import { useNodeStatus } from "../../composables/useNodeStatus";
 import { useCanvasLayout } from "../../composables/useCanvasLayout";
@@ -19,7 +19,8 @@ const isEffectiveDisabled = computed(() => {
 	return store.effectiveDisabledIds?.has(props.id);
 });
 
-const isReadOnly = computed(() => store.is_read_only);
+const ruleStore = useRuleStore();
+const isReadOnly = computed(() => ruleStore.is_read_only);
 
 const nodeIdRef = computed(() => props.id);
 const { isExecuted, isRunning, isErrored, executionOrder } = useNodeExecutionState(nodeIdRef);

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/QueryRecordsConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/QueryRecordsConfig.vue
@@ -1314,11 +1314,6 @@ function sync_local_config() {
 	// Compare before sending out to avoid loops
 	const current_str = JSON.stringify(props.node?.data?.config || {});
 	const next_str = JSON.stringify(new_config || {});
-	console.log("QueryRecordsConfig sync_local_config comparison:", {
-		current_str,
-		next_str,
-		isDifferent: current_str !== next_str,
-	});
 
 	if (current_str !== next_str) {
 		is_internal_update.value = true;
@@ -1329,8 +1324,6 @@ function sync_local_config() {
 		}, 150);
 	}
 }
-
-const debounced_sync = flexirule.utils.debounce(sync_local_config, 300);
 
 async function load_report_filters(report_name) {
 	if (!report_name || mode.value !== "Query Report") {
@@ -1435,7 +1428,6 @@ async function load_report_filters(report_name) {
 }
 
 function update_report_filter(fieldname, value) {
-	console.log("QueryRecordsConfig update_report_filter called:", { fieldname, value });
 	report_filter_values[fieldname] = value;
 	if (report_filter_types) {
 		report_filter_types[fieldname] = parse_value_type(value);
@@ -1556,7 +1548,7 @@ watch(
 	() => [order_by_rows.value, config, report_filter_values, mode.value, reference_doctype.value],
 	() => {
 		if (!is_internal_update.value) {
-			debounced_sync();
+			sync_local_config();
 			update_resolved_schema_local();
 			debounced_schema_update();
 		}

--- a/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/QueryRecordsConfig.vue
+++ b/flexirule/public/js/flexirule/rule_builder/components/rule_config/types/QueryRecordsConfig.vue
@@ -530,6 +530,7 @@ import MultiSelectList from "../../../controls/MultiSelectList.vue";
 import FlexValueControl from "../../../controls/FlexValueControl.vue";
 import { useNodeConfigPolicy } from "../../../composables/useNodeConfigPolicy";
 import { useUIStore } from "../../../stores/useUIStore";
+import { provideControlContext } from "../../../composables/useControlContext";
 
 const props = defineProps({
 	node: Object,
@@ -804,6 +805,14 @@ const query_report_adapter = {
 		add_inner_button: () => {},
 	},
 };
+
+// ── Provide ControlContext for child controls ──
+// This replaces the need for child controls to access window.frappe.query_report directly.
+// Controls can now inject this context and call getFieldValue(fieldname) to resolve
+// sibling/parent filter values within the local report adapter scope.
+provideControlContext({
+	getFieldValue: (name) => get_resolved_filter_value(name),
+});
 
 onMounted(() => {
 	window.frappe.query_report = query_report_adapter;

--- a/flexirule/public/js/flexirule/rule_builder/composables/useControlContext.js
+++ b/flexirule/public/js/flexirule/rule_builder/composables/useControlContext.js
@@ -1,0 +1,189 @@
+/**
+ * useControlContext — Dependency injection layer for FlexiRule controls.
+ *
+ * ## Purpose
+ * Replaces all direct `window.frappe.query_report` lookups inside controls
+ * with a clean, injectable context. Parent components (QueryRecordsConfig,
+ * FilterGroup, etc.) call `provideControlContext()` to expose a local value
+ * resolver that child controls can consume without knowing where they are
+ * rendered.
+ *
+ * ## Architecture
+ * - Provider:  `provideControlContext(resolver)` — called by parent
+ * - Consumer:  `useControlContext()` — called by any control
+ *
+ * The resolver is a plain function: `(fieldname) => value`
+ * It answers the question: "Given a field name that this control's `df.options`
+ * points to, what is its current value?"
+ *
+ * For example, when a Dynamic Link's `df.options = "party_type"`, the control
+ * calls `resolver("party_type")` and gets back "Customer" (or whatever the
+ * parent filter/form currently has).
+ *
+ * ## Fallback
+ * If no provider exists in the component tree, `useControlContext()` returns
+ * a context that falls back to `window.frappe.query_report.get_filter_value()`
+ * for backward compatibility with controls rendered outside the Rule Builder
+ * (e.g., in native Frappe forms or standalone dialogs).
+ */
+import { provide, inject, computed, unref } from "vue";
+
+const CONTROL_CONTEXT_KEY = Symbol("fxr-control-context");
+
+/**
+ * @typedef {Object} ControlContext
+ * @property {(fieldname: string) => any} getFieldValue
+ *   Resolve the current value of a sibling/parent field by fieldname.
+ * @property {boolean} isProvided
+ *   `true` when a parent explicitly provided a context (i.e., we are inside
+ *   the Rule Builder). `false` means we are using the global Frappe fallback.
+ */
+
+/**
+ * Provide a control context to all child components.
+ *
+ * Call this in a parent component that owns the "form" or "filter set"
+ * that controls need to read sibling values from.
+ *
+ * @param {Object} options
+ * @param {Function} options.getFieldValue - `(fieldname: string) => any`
+ *   Returns the current value for the given field name. The returned value
+ *   should be the *resolved* primitive (e.g., "Customer"), not a structured
+ *   `{ mode, value }` wrapper.
+ */
+export function provideControlContext({ getFieldValue }) {
+	const ctx = {
+		getFieldValue: getFieldValue || (() => undefined),
+		isProvided: true,
+	};
+	provide(CONTROL_CONTEXT_KEY, ctx);
+	return ctx;
+}
+
+/**
+ * Inject the control context from the nearest provider.
+ *
+ * If no provider exists, returns a fallback context that delegates to
+ * `window.frappe.query_report.get_filter_value()` for backward compatibility.
+ *
+ * @returns {ControlContext}
+ */
+export function useControlContext() {
+	const ctx = inject(CONTROL_CONTEXT_KEY, null);
+	if (ctx) return ctx;
+
+	// Fallback: global Frappe query_report API (for controls outside Rule Builder)
+	return {
+		getFieldValue(fieldname) {
+			if (
+				window.frappe &&
+				window.frappe.query_report &&
+				typeof window.frappe.query_report.get_filter_value === "function"
+			) {
+				return window.frappe.query_report.get_filter_value(fieldname);
+			}
+			return undefined;
+		},
+		isProvided: false,
+	};
+}
+
+/**
+ * Resolve the target DocType for a Dynamic Link field.
+ *
+ * Handles the standard Frappe pattern where `df.options` contains the
+ * fieldname of the "parent" field whose value is the target DocType.
+ *
+ * @param {Object} df - Field definition
+ * @param {ControlContext} ctx - The injected control context
+ * @param {Object} [doc] - Optional document object (for form-level resolution)
+ * @returns {string} The resolved DocType name, or empty string
+ */
+export function resolveDynamicLinkDoctype(df, ctx, doc = null) {
+	if (!df || !df.options) return "";
+
+	// 1. Try document-level resolution first (standard Frappe form pattern)
+	if (doc && doc[df.options]) {
+		return String(doc[df.options]);
+	}
+
+	// 2. Use the injected context
+	const contextVal = ctx.getFieldValue(df.options);
+	if (contextVal !== undefined && contextVal !== null && contextVal !== "") {
+		// Handle structured values from FlexValueControl
+		if (typeof contextVal === "object" && contextVal.mode === "static") {
+			return String(contextVal.value || "");
+		}
+		if (typeof contextVal === "string") {
+			return contextVal;
+		}
+	}
+
+	return "";
+}
+
+/**
+ * Resolve the target DocType for Link-like fields (Link, Dynamic Link,
+ * MultiSelectList).
+ *
+ * Consolidates the duplicated resolution logic that was previously spread
+ * across FlexValueControl, MultiSelectList, ComboBoxControl, and
+ * ControlRegistry.
+ *
+ * @param {Object} df - Field definition
+ * @param {ControlContext} ctx - The injected control context
+ * @param {Object} [opts] - Additional options
+ * @param {Object} [opts.doc] - Document object
+ * @param {string} [opts.explicitDoctype] - Explicitly provided doctype prop
+ * @returns {string} The resolved DocType name
+ */
+export function resolveTargetDoctype(df, ctx, opts = {}) {
+	if (!df) return opts.explicitDoctype || "";
+
+	// Explicit doctype prop always wins
+	if (opts.explicitDoctype) return opts.explicitDoctype;
+
+	const ft = df.fieldtype;
+
+	// Standard Link: df.options IS the DocType
+	if (ft === "Link") {
+		return df.options || "";
+	}
+
+	// Dynamic Link: df.options is a fieldname pointing to the DocType
+	if (ft === "Dynamic Link") {
+		return resolveDynamicLinkDoctype(df, ctx, opts.doc);
+	}
+
+	// MultiSelectList / MultiSelect: df.options may be a DocType name or
+	// a fieldname referencing a parent filter
+	if (["MultiSelectList", "MultiSelect", "MultiCheck"].includes(ft)) {
+		const optsStr = df.options;
+		if (!optsStr || typeof optsStr !== "string") return "";
+
+		// If contains delimiters, it's static options, not a DocType
+		if (optsStr.includes("\n") || optsStr.includes(",") || optsStr.includes(";")) {
+			return "";
+		}
+
+		// Try resolving as a parent field reference first
+		const parentVal = ctx.getFieldValue(optsStr);
+		if (parentVal) {
+			if (typeof parentVal === "object" && parentVal.mode === "static") {
+				return String(parentVal.value || "");
+			}
+			if (typeof parentVal === "string") {
+				return parentVal;
+			}
+		}
+
+		// If it's not a self-reference, treat as a DocType name
+		if (optsStr !== df.fieldname) {
+			return optsStr;
+		}
+
+		return "";
+	}
+
+	return df.options || "";
+}

--- a/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/FlexValueControl.vue
@@ -28,6 +28,8 @@
 					:modelValue="staticValue"
 					:documentType="isLinkType ? referenceDoctype : undefined"
 					:options="isLinkType ? undefined : fieldOptions"
+					:filters="context?.filters || {}"
+					:get_data="context?.df?.get_data || undefined"
 					displayMode="badges"
 					:badgeCollapseAfter="2"
 					:allowWrap="false"
@@ -41,6 +43,7 @@
 					:modelValue="staticValue"
 					:doc="doc"
 					:engine="engine"
+					:context="context"
 					:options="isLinkType ? undefined : fieldOptions"
 					:hideLabel="true"
 					class="flex-1 min-w-0 w-100 static-control-factory"
@@ -388,7 +391,8 @@ const TEXT_FIELDTYPES = new Set([
 ]);
 const isMultiSelect = computed(() => {
 	const ft = fieldType.value;
-	if (["MultiSelect", "MultiSelectList", "Table MultiSelect"].includes(ft)) {
+	// Native multi-select fieldtypes are always rendered as MultiSelectList
+	if (["MultiSelect", "MultiSelectList", "Table MultiSelect", "MultiCheck"].includes(ft)) {
 		return true;
 	}
 
@@ -439,7 +443,23 @@ const referenceDoctype = computed(() => {
 	if (fieldType.value === "Link" && fieldOptions.value) {
 		return fieldOptions.value;
 	}
-	return props.context?.referenceDoctype || fieldOptions.value || "";
+
+	const opts = fieldOptions.value;
+
+	// For MultiSelectList / Dynamic Link, df.options may reference a sibling filter field
+	if (opts && typeof opts === "string" && props.context?.filters) {
+		const filterVal = props.context.filters[opts];
+		if (filterVal !== undefined && filterVal !== null) {
+			if (typeof filterVal === "object" && filterVal.mode === "static") {
+				return String(filterVal.value || "");
+			}
+			if (typeof filterVal === "string") {
+				return filterVal;
+			}
+		}
+	}
+
+	return props.context?.referenceDoctype || opts || "";
 });
 
 const triggerDoctype = computed(() => {
@@ -1102,13 +1122,7 @@ function deserialize(val) {
 function emitChanges() {
 	const output = coerceStructuredValue(serialize());
 	const json = JSON.stringify(output);
-	console.log("FlexValueControl emitChanges:", {
-		fieldname: props.fieldname || props.context?.df?.fieldname,
-		output,
-		json,
-		lastEmittedJSON,
-		isSame: json === lastEmittedJSON,
-	});
+
 	if (json === lastEmittedJSON) return; // idempotency guard: prevent feedback loops
 	lastEmittedJSON = json;
 	emit("update:modelValue", output);
@@ -1169,12 +1183,6 @@ function onStaticKeydown(e) {
 }
 
 function updateStaticValue(val) {
-	console.log(
-		"FlexValueControl updateStaticValue called with:",
-		val,
-		"for field:",
-		props.fieldname || props.context?.df?.fieldname
-	);
 	if (isVariableSyntax(val)) {
 		const path = val.startsWith("@") ? val.substring(1) : val;
 		isDynamicMode.value = true;

--- a/flexirule/public/js/flexirule/rule_builder/controls/MultiSelectList.vue
+++ b/flexirule/public/js/flexirule/rule_builder/controls/MultiSelectList.vue
@@ -291,12 +291,6 @@ function validate() {
 defineExpose({ validate });
 
 function emitValue(nextValues) {
-	console.log("MultiSelectList emitValue:", {
-		fieldname: props.fieldname || props.df?.fieldname,
-		nextValues,
-		isRemote: isRemote.value,
-		get_data: !!props.get_data,
-	});
 	emit("update:modelValue", nextValues);
 	emit("change", nextValues);
 }


### PR DESCRIPTION
I have completed the deep architectural audit of the UI control system. The findings, root causes, responsibility map, divergence from native Frappe, proposed refactoring plan, and regression matrix have been documented in the implementation_plan.md artifact for your review.

, I have focused on identifying the underlying architectural issues rather than superficial bug fixes. The most critical issue discovered is the tight coupling of individual controls (like MultiSelectList) to global Frappe state (window.frappe.query_report), which breaks completely when they are rendered inside the isolated environment of the Rule Builder's QueryRecordsConfig adapter. This, along with fragmented dependency resolution and isolated caching, is the root cause of the inconsistent behavior you've observed.